### PR TITLE
react disable memo & release 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,7 +5372,7 @@
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.1.10",
+            "version": "0.1.11",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -5388,18 +5388,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.1.10",
+            "version": "0.1.11",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.1.10",
+                "@retreejs/core": "0.1.11",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.1.10",
+                "@retreejs/core": "0.1.11",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -5409,7 +5409,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.1.10"
+                "@retreejs/core": "0.1.11"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -5862,8 +5862,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.10",
-                "@retreejs/react": "0.1.10",
+                "@retreejs/core": "0.1.11",
+                "@retreejs/react": "0.1.11",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -5883,8 +5883,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.10",
-                "@retreejs/react": "0.1.10",
+                "@retreejs/core": "0.1.11",
+                "@retreejs/react": "0.1.11",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.1.10",
+        "@retreejs/core": "0.1.11",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.1.10",
+        "@retreejs/core": "0.1.11",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/src/internals/useNodeInternal.ts
+++ b/packages/retree-react/src/internals/useNodeInternal.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Ryan Bliss. All rights reserved.
  * Licensed under the MIT License.
  */
+"use no memo";
 
 import { Retree, TreeNode } from "@retreejs/core";
 import { getReproxyNode, getBaseProxy } from "@retreejs/core/internal";

--- a/packages/retree-react/src/useNode.ts
+++ b/packages/retree-react/src/useNode.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Ryan Bliss. All rights reserved.
  * Licensed under the MIT License.
  */
+"use no memo";
 
 import { TreeNode } from "@retreejs/core";
 import { useNodeInternal } from "./internals/useNodeInternal";

--- a/packages/retree-react/src/useTree.ts
+++ b/packages/retree-react/src/useTree.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Ryan Bliss. All rights reserved.
  * Licensed under the MIT License.
  */
+"use no memo";
 
 import { Retree, TreeNode } from "@retreejs/core";
 import { useNodeInternal } from "./internals/useNodeInternal";

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "eslint src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.10"
+        "@retreejs/core": "0.1.11"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "@retreejs/core": "0.1.10",
-    "@retreejs/react": "0.1.10"
+    "@retreejs/core": "0.1.11",
+    "@retreejs/react": "0.1.11"
   },
   "devDependencies": {
     "@types/react": "^19.2.3",

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "@retreejs/core": "0.1.10",
-    "@retreejs/react": "0.1.10",
+    "@retreejs/core": "0.1.11",
+    "@retreejs/react": "0.1.11",
     "uuid": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Disabled react compiler memo for react hooks (not needed)
- Release v0.1.11