### PR TITLE
Support null variables, bind functions that react compiler uses to raw targets, and publish v0.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,7 +5372,7 @@
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.1.11",
+            "version": "0.1.21",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -5388,18 +5388,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.1.11",
+            "version": "0.1.21",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.1.11",
+                "@retreejs/core": "0.1.21",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.1.11",
+                "@retreejs/core": "0.1.21",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -5409,7 +5409,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.1.11"
+                "@retreejs/core": "0.1.21"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -5862,8 +5862,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.11",
-                "@retreejs/react": "0.1.11",
+                "@retreejs/core": "0.1.21",
+                "@retreejs/react": "0.1.21",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -5883,8 +5883,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.11",
-                "@retreejs/react": "0.1.11",
+                "@retreejs/core": "0.1.21",
+                "@retreejs/react": "0.1.21",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.1.11",
+    "version": "0.1.21",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -51,7 +51,10 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 typeof prop === "string" &&
                 proxyHandler[proxiedChildrenKey][prop]
             ) {
-                return proxyHandler[proxiedChildrenKey][prop];
+                const value = proxyHandler[proxiedChildrenKey][prop];
+                if (typeof value !== "function") {
+                    return value;
+                }
             }
             const baseProxy = getBaseProxy(receiver);
             const value = Reflect.get(target, prop, receiver);

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -154,6 +154,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             return returnValue;
         },
     };
+    if (object === null || object === undefined) return object;
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
     Object.entries(object).forEach(([prop, value]) => {
         if (typeof value === "object") {

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -162,6 +162,11 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 proxyNode: proxy,
                 propName: prop,
             });
+            const baseValue = proxyHandler[proxiedChildrenKey][prop];
+            if (baseValue === null || baseValue === undefined) {
+                proxyHandler[proxiedChildrenKey][prop] = value;
+                return;
+            }
             proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
         }
     });

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -72,7 +72,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     // If `receiver` has a value, we are replacing it with a new one
                     nodeRemoved = handleNodeRemoved(baseProxy, prop);
                 }
-                if (typeof newValue === "object") {
+                if (newValue !== null && typeof newValue === "object") {
                     if (prop === "constructor")
                         return Reflect.set(target, prop, newValue, receiver);
 
@@ -154,9 +154,10 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             return returnValue;
         },
     };
+    if (object === null) return object;
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
     Object.entries(object).forEach(([prop, value]) => {
-        if (typeof value === "object") {
+        if (value !== null && typeof value === "object") {
             const cProxy = buildProxy(value, emitter, {
                 proxyNode: proxy,
                 propName: prop,
@@ -227,7 +228,7 @@ function handleNodeRemoved(
     prop: string | symbol
 ): object | undefined {
     const nodeRemoved = (node as any)?.[prop];
-    if (typeof nodeRemoved === "object") {
+    if (nodeRemoved !== null && typeof nodeRemoved === "object") {
         // Remove parent reference
         const oldHandler = getCustomProxyHandler(nodeRemoved);
         if (oldHandler) {

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -19,6 +19,12 @@ import {
 import { getReproxyNodeForUnproxiedNode, updateReproxyNode } from "./reproxy";
 import { Transactions } from "./transactions";
 
+export const FUNCTION_NAMES_BIND_TO_RAW: (string | symbol)[] = [
+    "valueOf",
+    "toISOString",
+    "toJSON",
+];
+
 /**
  * @internal
  * Builds a proxied object that emits changes when any value changes.
@@ -58,7 +64,13 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             }
             const baseProxy = getBaseProxy(receiver);
             const value = Reflect.get(target, prop, receiver);
-            return typeof value === "function" ? value.bind(baseProxy) : value;
+            if (typeof value === "function") {
+                if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
+                    return value.bind(target);
+                }
+                return value.bind(baseProxy);
+            }
+            return value;
         },
         set(target, prop, newValue, receiver) {
             const prev = (target as any)[prop];

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -157,7 +157,9 @@ export function buildProxy<T extends TreeNode = TreeNode>(
     if (object === null) return object;
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
     Object.entries(object).forEach(([prop, value]) => {
-        if (value !== null && typeof value === "object") {
+        if (value === null) {
+            proxyHandler[proxiedChildrenKey][prop] = value;
+        } else if (typeof value === "object") {
             const cProxy = buildProxy(value, emitter, {
                 proxyNode: proxy,
                 propName: prop,

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -165,9 +165,9 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             const baseValue = proxyHandler[proxiedChildrenKey][prop];
             if (baseValue === null || baseValue === undefined) {
                 proxyHandler[proxiedChildrenKey][prop] = value;
-                return;
+            } else {
+                proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
             }
-            proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
         }
     });
     updateReproxyNode(proxy);

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -154,7 +154,6 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             return returnValue;
         },
     };
-    if (object === null || object === undefined) return object;
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
     Object.entries(object).forEach(([prop, value]) => {
         if (typeof value === "object") {
@@ -162,12 +161,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 proxyNode: proxy,
                 propName: prop,
             });
-            const baseValue = proxyHandler[proxiedChildrenKey][prop];
-            if (baseValue === null || baseValue === undefined) {
-                proxyHandler[proxiedChildrenKey][prop] = value;
-            } else {
-                proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
-            }
+            proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
         }
     });
     updateReproxyNode(proxy);

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -70,6 +70,9 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 handler[proxiedChildrenKey][prop]
             ) {
                 const childProxy = handler[proxiedChildrenKey][prop];
+                if (childProxy === null || childProxy === undefined) {
+                    return childProxy;
+                }
                 const reproxy = getReproxyNode(childProxy);
                 return reproxy ?? childProxy;
             }

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -4,7 +4,7 @@
  */
 
 import { TreeNode } from "../types";
-import { getCustomProxyHandler, getBaseProxy, getUnproxiedNode } from "./proxy";
+import { getCustomProxyHandler, getBaseProxy, getUnproxiedNode, FUNCTION_NAMES_BIND_TO_RAW } from "./proxy";
 import {
     ICustomProxyHandler,
     proxiedChildrenKey,
@@ -79,7 +79,13 @@ function buildReproxy<T extends TreeNode = TreeNode>(
             const reproxy = getReproxyNode(baseProxy);
             const rawNode = getUnproxiedNode(baseProxy);
             const value = Reflect.get(rawNode ?? target, prop, receiver);
-            return typeof value === "function" ? value.bind(reproxy) : value;
+            if (typeof value === "function") {
+                if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
+                    return value.bind(rawNode);
+                }
+                return value.bind(reproxy);
+            }
+            return value;
         },
         set(target, prop, newValue, receiver) {
             return Reflect.set(target, prop, newValue, receiver);

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -70,8 +70,10 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 handler[proxiedChildrenKey][prop]
             ) {
                 const childProxy = handler[proxiedChildrenKey][prop];
-                const reproxy = getReproxyNode(childProxy);
-                return reproxy ?? childProxy;
+                if (typeof childProxy !== "function") {
+                    const reproxy = getReproxyNode(childProxy);
+                    return reproxy ?? childProxy;
+                }
             }
             const baseProxy: TCustomProxy<T> = getBaseProxy(receiver);
             const reproxy = getReproxyNode(baseProxy);

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -70,9 +70,6 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 handler[proxiedChildrenKey][prop]
             ) {
                 const childProxy = handler[proxiedChildrenKey][prop];
-                if (childProxy === null || childProxy === undefined) {
-                    return childProxy;
-                }
                 const reproxy = getReproxyNode(childProxy);
                 return reproxy ?? childProxy;
             }

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.1.11",
+    "version": "0.1.21",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.1.11",
+        "@retreejs/core": "0.1.21",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.1.11",
+        "@retreejs/core": "0.1.21",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "eslint src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.11"
+        "@retreejs/core": "0.1.21"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "@retreejs/core": "0.1.11",
-    "@retreejs/react": "0.1.11"
+    "@retreejs/core": "0.1.21",
+    "@retreejs/react": "0.1.21"
   },
   "devDependencies": {
     "@types/react": "^19.2.3",

--- a/samples/02.react-example/src/App.tsx
+++ b/samples/02.react-example/src/App.tsx
@@ -6,12 +6,12 @@ import "./App.css";
 
 class CatFacts {
     public loading = false;
-    public error: string | undefined = undefined;
+    public error: string | null = null;
     public fact: string | undefined;
 
     public async randomize() {
         this.loading = true;
-        if (this.error) this.error = undefined;
+        if (this.error) this.error = null;
         try {
             const data = await fetch("https://meowfacts.herokuapp.com/");
             const json = await data.json();

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "@retreejs/core": "0.1.11",
-    "@retreejs/react": "0.1.11",
+    "@retreejs/core": "0.1.21",
+    "@retreejs/react": "0.1.21",
     "uuid": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Support null variables (apparently null is considered `typeof null === 'object`)
- Bind functions that react compiler uses to raw targets so they can do type assertions, stringify, etc.
- Publish version 0.1.20