### PR TITLE
react use node builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,7 +5372,7 @@
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.1.22",
+            "version": "0.1.23",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -5388,18 +5388,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.1.22",
+            "version": "0.1.23",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.1.22",
+                "@retreejs/core": "0.1.23",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.1.22",
+                "@retreejs/core": "0.1.23",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -5409,7 +5409,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.1.22"
+                "@retreejs/core": "0.1.23"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -5862,8 +5862,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.22",
-                "@retreejs/react": "0.1.22",
+                "@retreejs/core": "0.1.23",
+                "@retreejs/react": "0.1.23",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -5883,8 +5883,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.22",
-                "@retreejs/react": "0.1.22",
+                "@retreejs/core": "0.1.23",
+                "@retreejs/react": "0.1.23",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.1.22",
+    "version": "0.1.23",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.1.22",
+    "version": "0.1.23",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.1.22",
+        "@retreejs/core": "0.1.23",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.1.22",
+        "@retreejs/core": "0.1.23",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/src/internals/useNodeInternal.ts
+++ b/packages/retree-react/src/internals/useNodeInternal.ts
@@ -6,22 +6,35 @@
 
 import { Retree, TreeNode } from "@retreejs/core";
 import { getReproxyNode, getBaseProxy } from "@retreejs/core/internal";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+function getNode<T extends TreeNode = TreeNode>(node: T | (() => T)) {
+    if (typeof node === "function") {
+        return node();
+    }
+    return node;
+}
 
 /**
  * Stateful version of an object and its leafs.
  */
 export function useNodeInternal<T extends TreeNode = TreeNode>(
-    node: T,
+    node: T | (() => T),
     listenerType: "nodeChanged" | "treeChanged"
 ): T {
-    const [nodeState, setNodeState] = useState<{ node: T }>({
-        node: getReproxyNode<T>(node),
+    const [nodeState, setNodeState] = useState<{ node: T }>(() => {
+        return {
+            node: getReproxyNode(getNode(node)),
+        };
     });
+
+    const memoNode = useMemo(() => {
+        return getNode(node);
+    }, [node])
 
     // We can listen to a reproxied or base proxy node, but base proxies change less frequently.
     // Listen to the baseProxy changes. This is cheap so it's okay to do it unmemoized.
-    const baseProxy = getBaseProxy<T>(node);
+    const baseProxy = getBaseProxy<T>(memoNode);
     useEffect(() => {
         // Listen to changes to the node
         const unsubscribe = Retree.on<T>(baseProxy, listenerType, (proxy) => {

--- a/packages/retree-react/src/useNode.ts
+++ b/packages/retree-react/src/useNode.ts
@@ -80,6 +80,6 @@ function App() {
 }
 export default App;
  */
-export function useNode<T extends TreeNode = TreeNode>(node: T): T {
+export function useNode<T extends TreeNode = TreeNode>(node: T | (() => T)): T {
     return useNodeInternal(node, LISTENER_TYPE);
 }

--- a/packages/retree-react/src/useTree.ts
+++ b/packages/retree-react/src/useTree.ts
@@ -90,6 +90,6 @@ function App() {
 export default App;
  * ```
  */
-export function useTree<T extends TreeNode = TreeNode>(node: T): T {
+export function useTree<T extends TreeNode = TreeNode>(node: T | (() => T)): T {
     return useNodeInternal(node, LISTENER_TYPE);
 }

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "eslint src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.22"
+        "@retreejs/core": "0.1.23"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "@retreejs/core": "0.1.22",
-    "@retreejs/react": "0.1.22"
+    "@retreejs/core": "0.1.23",
+    "@retreejs/react": "0.1.23"
   },
   "devDependencies": {
     "@types/react": "^19.2.3",

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "@retreejs/core": "0.1.22",
-    "@retreejs/react": "0.1.22",
+    "@retreejs/core": "0.1.23",
+    "@retreejs/react": "0.1.23",
     "uuid": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- support factory function for `useNodeInternal`
- new `useRoot` hook for one-time `Retree.use` for root nodes in react
- Release up to 0.1.30