### PR TITLE
Release v0.1.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It's extremely easy to get started with Retree. There are two React hooks: `useN
 
 If you adopt the `useNode` pattern, your apps will automatically inherit performant re-renders, since only the components that depend on each node in your object tree will re-render on changes. For this to work, you need to do the following:
 
-1. Pass some object into `Retree.use`, e.g., `const root = Retree.use({ foo: "bar", list: [] })`
+1. Pass some object into `Retree.root`, e.g., `const root = Retree.root({ foo: "bar", list: [] })`
 2. Make the response stateful using `useNode`, e.g., `const rootState = useNode(root)`
 3. Render values from the object in your component, e.g., `<h1>{fooState.foo}</h1>`
 4. Set values like you normally would in JS/TS, e.g., `fooState.foo = "moo"`
@@ -81,7 +81,7 @@ class TodoList {
 }
 
 // Create your root TreeNode instance with any object
-const root = Retree.use(new TodoList());
+const root = Retree.root(new TodoList());
 
 // Render app
 function App() {
@@ -106,7 +106,7 @@ import React from "react";
 import { Retree } from "@retreejs/core";
 import { useNode } from "@retreejs/react";
 
-const whiteboardRoot = Retree.use({
+const whiteboardRoot = Retree.root({
     selectedColor: "red",
     visible: false,
     canvasSize: { width: "0px", height: "0px" },
@@ -164,7 +164,7 @@ import React from "react";
 import { Retree } from "@retreejs/core";
 import { useNode, useTree } from "@retreejs/react";
 
-const table = Retree.use({
+const table = Retree.root({
     headers: [{ title: "label" }, { title: "count" }, { title: "actions" }],
     rows: [
         { label: "count 1", count: 0 },
@@ -232,7 +232,7 @@ export default App;
 `useTree` is very powerful and makes things incredibly simple. The following scenarios should help clarify the behavior of `useTree`:
 
 ```ts
-const root = Retree.use({
+const root = Retree.root({
     great_grandparent_1: {
         name: "Bob Sr",
         grandparent_1: {
@@ -317,7 +317,7 @@ class Node extends ReactiveNode {
     }
 }
 // Create root `ReactiveNode` instance and listen for changes in `useNode`
-const node = Retree.use(new Node());
+const node = Retree.root(new Node());
 const nodeState = useNode(node);
 
 // ✅ Will re-render
@@ -333,7 +333,7 @@ node.list.push(99);
 If you are making multiple changes to one or many nodes at once, you can use `Retree.runTransaction` function to only set to React state once per instance of `useNode` or `useTree`. Here is an example:
 
 ```ts
-const _counter = Retree.use({ count: 0 });
+const _counter = Retree.root({ count: 0 });
 const counter = useNode(_counter);
 // Will only emit "valueChanged" once
 Retree.runTransaction(() => {
@@ -347,7 +347,7 @@ Retree.runTransaction(() => {
 If you want to skip re-rendering on a change, you can use the `Retree.runSilent` function. Here is an example:
 
 ```ts
-const counter = Retree.use({ count: 0, multiplier: 1 });
+const counter = Retree.root({ count: 0, multiplier: 1 });
 const counterState = useNode(counter);
 // Skip re-render on setting the multiplier
 function onClickIncrementMultipler() {
@@ -414,7 +414,7 @@ class TodoList {
     }
 }
 
-const tree = Retree.use(new TodoList());
+const tree = Retree.root(new TodoList());
 
 // Listen for changes to the todo list (e.g., todo created)
 const unsubscribe = Retree.on(tree.todos, "treeChanged", (todos) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,7 +8374,7 @@
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.1.33",
+            "version": "0.1.34",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -8390,18 +8390,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.1.33",
+            "version": "0.1.34",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.1.33",
+                "@retreejs/core": "0.1.34",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.1.33",
+                "@retreejs/core": "0.1.34",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -8411,7 +8411,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.1.33"
+                "@retreejs/core": "0.1.34"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -8846,8 +8846,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.33",
-                "@retreejs/react": "0.1.33",
+                "@retreejs/core": "0.1.34",
+                "@retreejs/react": "0.1.34",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -8867,8 +8867,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.33",
-                "@retreejs/react": "0.1.33",
+                "@retreejs/core": "0.1.34",
+                "@retreejs/react": "0.1.34",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -49,7 +49,7 @@ class TodoList {
     }
 }
 
-const tree = Retree.use(new TodoList());
+const tree = Retree.root(new TodoList());
 
 // Listen for changes to the todo list (e.g., todo created)
 const unsubscribe = Retree.on(tree.todos, "treeChanged", (todos) => {

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.1.33",
+    "version": "0.1.34",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/src/Map.spec.ts
+++ b/packages/retree-core/src/Map.spec.ts
@@ -1,0 +1,366 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Retree } from "./Retree";
+import { Transactions } from "./internals/transactions";
+
+const rootsToCleanup: object[] = [];
+
+function trackRoot<T extends object>(root: T): T {
+    rootsToCleanup.push(root);
+    return root;
+}
+
+afterEach(() => {
+    for (const root of rootsToCleanup.splice(0)) {
+        clearListenersRecursively(root);
+    }
+    Transactions.skipEmit = false;
+    Transactions.skipReproxy = false;
+    Transactions.runningTransaction = false;
+    Transactions.runPendingTransactions();
+});
+
+function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
+    if (!node || typeof node !== "object" || seen.has(node)) {
+        return;
+    }
+    seen.add(node);
+    Retree.clearListeners(node as never);
+    if (node instanceof Map) {
+        for (const value of node.values()) {
+            clearListenersRecursively(value, seen);
+        }
+        return;
+    }
+    if (node instanceof Set) {
+        for (const value of node.values()) {
+            clearListenersRecursively(value, seen);
+        }
+        return;
+    }
+    for (const child of Object.values(node)) {
+        clearListenersRecursively(child, seen);
+    }
+}
+
+describe("Map within Retree proxy", () => {
+    describe("as a child of the root", () => {
+        it("supports set/get/has/size on a Map child", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+
+            root.map.set("a", 1);
+            root.map.set("b", 2);
+
+            expect(root.map.get("a")).toBe(1);
+            expect(root.map.get("b")).toBe(2);
+            expect(root.map.has("a")).toBe(true);
+            expect(root.map.has("missing")).toBe(false);
+            expect(root.map.size).toBe(2);
+        });
+
+        it("supports delete and clear on a Map child", () => {
+            const root = trackRoot(
+                Retree.root({
+                    map: new Map<string, number>([
+                        ["a", 1],
+                        ["b", 2],
+                    ]),
+                })
+            );
+
+            expect(root.map.delete("a")).toBe(true);
+            expect(root.map.has("a")).toBe(false);
+            expect(root.map.size).toBe(1);
+
+            root.map.clear();
+            expect(root.map.size).toBe(0);
+        });
+
+        it("supports iteration on a Map child", () => {
+            const root = trackRoot(
+                Retree.root({
+                    map: new Map<string, number>([
+                        ["a", 1],
+                        ["b", 2],
+                    ]),
+                })
+            );
+
+            const entries = Array.from(root.map.entries());
+            expect(entries).toEqual([
+                ["a", 1],
+                ["b", 2],
+            ]);
+            const keys = Array.from(root.map.keys());
+            expect(keys).toEqual(["a", "b"]);
+            const values = Array.from(root.map.values());
+            expect(values).toEqual([1, 2]);
+
+            const forEachKeys: string[] = [];
+            root.map.forEach((_value, key) => forEachKeys.push(key));
+            expect(forEachKeys).toEqual(["a", "b"]);
+
+            const spreadKeys = [...root.map].map(([key]) => key);
+            expect(spreadKeys).toEqual(["a", "b"]);
+        });
+    });
+
+    describe("listener emission", () => {
+        it("emits nodeChanged when a Map child is mutated via set", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+            const nodeChanged = vi.fn();
+            Retree.on(root.map, "nodeChanged", nodeChanged);
+
+            root.map.set("a", 1);
+
+            expect(nodeChanged).toHaveBeenCalledTimes(1);
+            const reproxy = nodeChanged.mock.calls[0]?.[0] as Map<
+                string,
+                number
+            >;
+            expect(reproxy.get("a")).toBe(1);
+        });
+
+        it("emits nodeChanged when a Map child is mutated via delete", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>([["a", 1]]) })
+            );
+            const nodeChanged = vi.fn();
+            Retree.on(root.map, "nodeChanged", nodeChanged);
+
+            root.map.delete("a");
+
+            expect(nodeChanged).toHaveBeenCalledTimes(1);
+            expect(root.map.has("a")).toBe(false);
+        });
+
+        it("emits nodeChanged when a Map child is cleared", () => {
+            const root = trackRoot(
+                Retree.root({
+                    map: new Map<string, number>([
+                        ["a", 1],
+                        ["b", 2],
+                    ]),
+                })
+            );
+            const nodeChanged = vi.fn();
+            Retree.on(root.map, "nodeChanged", nodeChanged);
+
+            root.map.clear();
+
+            expect(nodeChanged).toHaveBeenCalledTimes(1);
+            expect(root.map.size).toBe(0);
+        });
+
+        it("emits treeChanged on the parent when a Map child is mutated", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+            const treeChanged = vi.fn();
+            Retree.on(root, "treeChanged", treeChanged);
+
+            root.map.set("a", 1);
+
+            expect(treeChanged).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("object values", () => {
+        it("proxies object values stored in a Map", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, { count: number }>() })
+            );
+            const inner = { count: 0 };
+            root.map.set("a", inner);
+
+            const stored = root.map.get("a")!;
+            // Parent of an object value should be the map it was set into.
+            expect(Retree.parent(stored)).toBe(root.map);
+        });
+
+        it("emits treeChanged on the parent when a Map's object value mutates", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, { count: number }>() })
+            );
+            root.map.set("a", { count: 0 });
+
+            const treeChanged = vi.fn();
+            Retree.on(root, "treeChanged", treeChanged);
+
+            const inner = root.map.get("a")!;
+            inner.count = 1;
+
+            expect(treeChanged).toHaveBeenCalledTimes(1);
+        });
+
+        it("proxies object values that were already in the Map at root time", () => {
+            const inner = { count: 0 };
+            const root = trackRoot(
+                Retree.root({
+                    map: new Map<string, { count: number }>([["a", inner]]),
+                })
+            );
+
+            const stored = root.map.get("a")!;
+            expect(Retree.parent(stored)).toBe(root.map);
+
+            const treeChanged = vi.fn();
+            Retree.on(root, "treeChanged", treeChanged);
+            stored.count = 1;
+            expect(treeChanged).toHaveBeenCalledTimes(1);
+        });
+
+        it("emits nodeRemoved when an object value is replaced via set", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, { count: number }>() })
+            );
+            root.map.set("a", { count: 0 });
+            const original = root.map.get("a")!;
+
+            const removed = vi.fn();
+            Retree.on(original, "nodeRemoved", removed);
+
+            root.map.set("a", { count: 5 });
+            expect(removed).toHaveBeenCalledTimes(1);
+        });
+
+        it("emits nodeRemoved when an object value is removed via delete", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, { count: number }>() })
+            );
+            root.map.set("a", { count: 0 });
+            const original = root.map.get("a")!;
+
+            const removed = vi.fn();
+            Retree.on(original, "nodeRemoved", removed);
+
+            root.map.delete("a");
+            expect(removed).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns the same proxy reference for repeated reads", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, { count: number }>() })
+            );
+            root.map.set("a", { count: 0 });
+
+            const first = root.map.get("a");
+            const second = root.map.get("a");
+            expect(first).toBe(second);
+        });
+    });
+
+    describe("chaining and identity", () => {
+        it("supports chaining Map.set calls", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+
+            root.map.set("a", 1).set("b", 2).set("c", 3);
+            expect(root.map.size).toBe(3);
+            expect(root.map.get("c")).toBe(3);
+        });
+
+        it("does not emit when delete is called on a missing key", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+            const nodeChanged = vi.fn();
+            Retree.on(root.map, "nodeChanged", nodeChanged);
+
+            const result = root.map.delete("missing");
+            expect(result).toBe(false);
+            expect(nodeChanged).not.toHaveBeenCalled();
+        });
+
+        it("does not emit when clear is called on an empty Map", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+            const nodeChanged = vi.fn();
+            Retree.on(root.map, "nodeChanged", nodeChanged);
+
+            root.map.clear();
+            expect(nodeChanged).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("transactions and root usage", () => {
+        it("batches multiple Map mutations in a transaction", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+            const nodeChanged = vi.fn();
+            Retree.on(root.map, "nodeChanged", nodeChanged);
+
+            Retree.runTransaction(() => {
+                root.map.set("a", 1);
+                root.map.set("b", 2);
+                root.map.set("c", 3);
+            });
+
+            expect(nodeChanged).toHaveBeenCalledTimes(1);
+            expect(root.map.size).toBe(3);
+        });
+
+        it("works when a Map is the root node", () => {
+            const root = trackRoot(Retree.root(new Map<string, number>()));
+            const nodeChanged = vi.fn();
+            Retree.on(root, "nodeChanged", nodeChanged);
+
+            root.set("a", 1);
+            expect(nodeChanged).toHaveBeenCalledTimes(1);
+            expect(root.get("a")).toBe(1);
+        });
+
+        it("allows mutating the Map via the reproxy passed to listeners", () => {
+            const root = trackRoot(
+                Retree.root({ map: new Map<string, number>() })
+            );
+            let lastReproxy: Map<string, number> | undefined;
+            Retree.on(root.map, "nodeChanged", (reproxy) => {
+                lastReproxy = reproxy as Map<string, number>;
+            });
+
+            root.map.set("a", 1);
+            expect(lastReproxy).toBeDefined();
+            // Calling a Map method on the reproxy should not throw.
+            expect(lastReproxy!.get("a")).toBe(1);
+        });
+    });
+
+    describe("Set within Retree proxy", () => {
+        it("supports add/has/delete/clear on a Set child", () => {
+            const root = trackRoot(Retree.root({ set: new Set<number>() }));
+
+            root.set.add(1);
+            root.set.add(2);
+            expect(root.set.has(1)).toBe(true);
+            expect(root.set.size).toBe(2);
+
+            expect(root.set.delete(1)).toBe(true);
+            expect(root.set.has(1)).toBe(false);
+
+            root.set.clear();
+            expect(root.set.size).toBe(0);
+        });
+
+        it("emits nodeChanged on Set add/delete/clear", () => {
+            const root = trackRoot(Retree.root({ set: new Set<number>() }));
+            const nodeChanged = vi.fn();
+            Retree.on(root.set, "nodeChanged", nodeChanged);
+
+            root.set.add(1);
+            root.set.add(1); // duplicate, no emit
+            root.set.delete(1);
+            root.set.delete(1); // missing, no emit
+            root.set.add(2);
+            root.set.clear();
+
+            expect(nodeChanged).toHaveBeenCalledTimes(4);
+        });
+    });
+});

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -55,7 +55,7 @@ class DynamicComparisonNode extends ReactiveNode {
 
 describe("ReactiveNode", () => {
     it("emits only when comparison values change", () => {
-        const root = trackRoot(Retree.use(new EvenNumberNode()));
+        const root = trackRoot(Retree.root(new EvenNumberNode()));
         const nodeChanged = vi.fn();
 
         Retree.on(root, "nodeChanged", nodeChanged);
@@ -68,7 +68,7 @@ describe("ReactiveNode", () => {
     });
 
     it("throws when dependency list length changes while subscribed", () => {
-        const root = trackRoot(Retree.use(new DynamicDependencyNode()));
+        const root = trackRoot(Retree.root(new DynamicDependencyNode()));
         Retree.on(root, "nodeChanged", vi.fn());
 
         expect(() => {
@@ -77,7 +77,7 @@ describe("ReactiveNode", () => {
     });
 
     it("throws when comparison list length changes for a dependency", () => {
-        const root = trackRoot(Retree.use(new DynamicComparisonNode()));
+        const root = trackRoot(Retree.root(new DynamicComparisonNode()));
         Retree.on(root, "nodeChanged", vi.fn());
 
         expect(() => {

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -49,7 +49,7 @@ export const COLLECTED_KEYS_SYMBOL = "RETREE_COLLECTED_KEYS_SYMBOL";
     }
  }
  // Create root ReactiveNode instance and listen for changes
- const node = Retree.use(new Node());
+ const node = Retree.root(new Node());
  Retree.on(node, "nodeChanged", () => {
     console.log(node.evenNumberCount);
  });

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -35,7 +35,7 @@ function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
 describe("Retree", () => {
     it("tracks parent relationships for nested objects and array items", () => {
         const root = trackRoot(
-            Retree.use({
+            Retree.root({
                 child: { grandchild: { value: 1 } },
                 list: [{ value: 2 }],
             })
@@ -50,7 +50,7 @@ describe("Retree", () => {
 
     it("distinguishes nodeChanged and treeChanged notifications", () => {
         const root = trackRoot(
-            Retree.use({ child: { value: 1 }, sibling: { value: 2 } })
+            Retree.root({ child: { value: 1 }, sibling: { value: 2 } })
         );
         const rootNodeChanged = vi.fn();
         const rootTreeChanged = vi.fn();
@@ -72,7 +72,7 @@ describe("Retree", () => {
     });
 
     it("emits nodeRemoved for replaced object nodes", () => {
-        const root = trackRoot(Retree.use({ child: { value: 1 } }));
+        const root = trackRoot(Retree.root({ child: { value: 1 } }));
         const childRemoved = vi.fn();
 
         Retree.on(root.child, "nodeRemoved", childRemoved);
@@ -82,9 +82,9 @@ describe("Retree", () => {
     });
 
     it("enforces the single-parent rule for proxied children", () => {
-        const root1 = trackRoot(Retree.use({ child: { value: 1 } }));
+        const root1 = trackRoot(Retree.root({ child: { value: 1 } }));
         const root2 = trackRoot(
-            Retree.use({ other: null as null | { value: number } })
+            Retree.root({ other: null as null | { value: number } })
         );
 
         expect(() => {
@@ -93,7 +93,7 @@ describe("Retree", () => {
     });
 
     it("batches transaction notifications per node", () => {
-        const root = trackRoot(Retree.use({ count: 0, child: { value: 1 } }));
+        const root = trackRoot(Retree.root({ count: 0, child: { value: 1 } }));
         const rootNodeChanged = vi.fn();
         const rootTreeChanged = vi.fn();
         const childNodeChanged = vi.fn();
@@ -115,7 +115,7 @@ describe("Retree", () => {
     });
 
     it("suppresses listener emission during silent updates and can preserve reproxy identity", () => {
-        const root = trackRoot(Retree.use({ count: 0 }));
+        const root = trackRoot(Retree.root({ count: 0 }));
         const nodeChanged = vi.fn();
         Retree.on(root, "nodeChanged", nodeChanged);
 
@@ -139,7 +139,7 @@ describe("Retree", () => {
     });
 
     it("restores transaction state when a transaction callback throws", () => {
-        const root = trackRoot(Retree.use({ count: 0 }));
+        const root = trackRoot(Retree.root({ count: 0 }));
         const nodeChanged = vi.fn();
         const error = new Error("boom");
         Retree.on(root, "nodeChanged", nodeChanged);
@@ -157,7 +157,7 @@ describe("Retree", () => {
 
     it("restores transaction state when a queued listener throws", () => {
         // Regression coverage: listener failures during the post-transaction flush should not poison global state.
-        const root = trackRoot(Retree.use({ count: 0 }));
+        const root = trackRoot(Retree.root({ count: 0 }));
         const nodeChanged = vi.fn(() => {
             throw new Error("listener failed");
         });
@@ -176,7 +176,7 @@ describe("Retree", () => {
     });
 
     it("restores silent flags when a silent callback throws", () => {
-        const root = trackRoot(Retree.use({ count: 0 }));
+        const root = trackRoot(Retree.root({ count: 0 }));
         const nodeChanged = vi.fn();
         const error = new Error("boom");
         Retree.on(root, "nodeChanged", nodeChanged);

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -102,7 +102,7 @@ export class Retree {
      * @example
      ```ts
      // Create the root node
-     const counter = Retree.use({ count: 0 });
+     const counter = Retree.root({ count: 0 });
      // Listen for changes to values of the node
      const unsubscribe = Retree.on(counter, "valueChanged", (reproxy) => {
         console.log(reproxy !== counter); // output: false
@@ -131,7 +131,7 @@ export class Retree {
         const unproxiedNode = getUnproxiedNode(node);
         if (!unproxiedNode) {
             throw new Error(
-                "Retree.on: must use an object that is a proxied node. Pass object to Retree.use first, or get value from another child object."
+                "Retree.on: must use an object that is a proxied node. Pass object to Retree.root first, or get value from another child object."
             );
         }
         const relevantListenerMap =
@@ -169,7 +169,7 @@ export class Retree {
      * 
      * @example
      ```js
-     const tree = Retree.use({
+     const tree = Retree.root({
         count: 0,
         child: {
             count: 0,
@@ -227,7 +227,7 @@ export class Retree {
      * 
      * @example
      ```ts
-     const counter = Retree.use({ count: 0 });
+     const counter = Retree.root({ count: 0 });
      Retree.on(counter, "valueChanged", () => console.log(counter.count));
      // Will only emit "valueChanged" once
      Retree.runTransaction(() => {

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -61,7 +61,15 @@ export class Retree {
     private static nodeChangeEmitter = new TreeChangeEmitter();
 
     /**
-     * Builds a Retree compatible node for the root object of your tree.
+     * @deprecated
+     * Use {@link root} instead.
+     */
+    static use<T extends TreeNode = TreeNode>(object: T): T {
+        return this.root(object);
+    }
+
+    /**
+     * Builds a Retree compatible root node for the root object of your tree.
      * @remarks
      * Use this function only for a root object.
      * This will make the object compatible with {@link Retree.on}, {@link Retree.parent}, etc.
@@ -71,11 +79,11 @@ export class Retree {
      * @returns a Retree compatible object of type T
      * 
      * @example
-     const counter = Retree.use({ count: 0 });
+     const counter = Retree.root({ count: 0 });
      Retree.on(counter, "valueChanged", () => console.log(counter.count));
      counter.count = counter.count + 1;
      */
-    static use<T extends TreeNode = TreeNode>(object: T): T {
+    static root<T extends TreeNode = TreeNode>(object: T): T {
         return buildProxy<T>(object, this.nodeChangeEmitter);
     }
 

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 
 describe("retreeIgnore", () => {
     it("skips Retree listener emission for ignored nested objects", () => {
-        root = Retree.use(new IgnoredNode());
+        root = Retree.root(new IgnoredNode());
         const nodeChanged = vi.fn();
         Retree.on(root, "nodeChanged", nodeChanged);
 

--- a/packages/retree-core/src/internals/proxy.spec.ts
+++ b/packages/retree-core/src/internals/proxy.spec.ts
@@ -4,7 +4,7 @@ import { getBaseProxy, getCustomProxyHandler, getUnproxiedNode } from "./proxy";
 
 describe("proxy internals", () => {
     it("exposes proxy metadata for managed nodes", () => {
-        const root = Retree.use({ child: { value: 1 } });
+        const root = Retree.root({ child: { value: 1 } });
         const handler = getCustomProxyHandler(root.child);
 
         expect(handler).toBeDefined();

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -26,6 +26,20 @@ export const FUNCTION_NAMES_BIND_TO_RAW: (string | symbol)[] = [
     "toJSON",
 ];
 
+const MAP_MUTATING_METHODS = new Set(["set", "delete", "clear"]);
+const SET_MUTATING_METHODS = new Set(["add", "delete", "clear"]);
+
+/**
+ * Built-ins like {@link Map} and {@link Set} rely on internal slots, so calling their methods
+ * with a Proxy as the `this` value throws "incompatible receiver". For those instances we bind
+ * methods to the raw target and wrap mutating methods so they still emit change events.
+ */
+function isInternalSlotInstance(
+    target: any
+): target is Map<any, any> | Set<any> {
+    return target instanceof Map || target instanceof Set;
+}
+
 /**
  * @internal
  * Builds a proxied object that emits changes when any value changes.
@@ -74,6 +88,39 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 }
             }
             const baseProxy = getBaseProxy(receiver);
+            if (isInternalSlotInstance(target)) {
+                // Methods on Map/Set must run with the raw target as `this` because they read
+                // internal slots that the proxy does not expose.
+                const value = Reflect.get(target, prop, target);
+                if (typeof value === "function") {
+                    if (
+                        target instanceof Map &&
+                        typeof prop === "string" &&
+                        MAP_MUTATING_METHODS.has(prop)
+                    ) {
+                        return wrapMapMutation(
+                            prop,
+                            target,
+                            baseProxy,
+                            emitter
+                        );
+                    }
+                    if (
+                        target instanceof Set &&
+                        typeof prop === "string" &&
+                        SET_MUTATING_METHODS.has(prop)
+                    ) {
+                        return wrapSetMutation(
+                            prop,
+                            target,
+                            baseProxy,
+                            emitter
+                        );
+                    }
+                    return value.bind(target);
+                }
+                return value;
+            }
             const value = Reflect.get(target, prop, receiver);
             if (typeof value === "function") {
                 if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
@@ -210,25 +257,185 @@ export function buildProxy<T extends TreeNode = TreeNode>(
     if (object === null) return object;
     if (isCustomProxy(object)) return getBaseProxy(object);
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
-    Object.entries(object).forEach(([prop, value]) => {
-        const propString = String(prop);
-        if (
-            value === null ||
-            (object instanceof ReactiveNode &&
-                (propString === COLLECTED_KEYS_SYMBOL ||
-                    object[COLLECTED_KEYS_SYMBOL].has(propString)))
-        ) {
-            proxyHandler[proxiedChildrenKey][prop] = value;
-        } else if (typeof value === "object") {
-            const cProxy = buildProxy(value, emitter, {
-                proxyNode: proxy,
-                propName: prop,
-            });
-            proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
+    if (object instanceof Map) {
+        // Replace each existing object value with a proxied/parented version so reads
+        // through the proxy yield reactive children with correct parent links.
+        const entries = Array.from(object.entries());
+        for (const [key, value] of entries) {
+            if (value !== null && typeof value === "object") {
+                const parentToSet: IProxyParent<any> = {
+                    proxyNode: proxy,
+                    propName: mapKeyAsPropName(key),
+                };
+                const childProxy = isCustomProxy(value)
+                    ? reparentProxy(value, parentToSet)
+                    : buildProxy(value, emitter, parentToSet);
+                Map.prototype.set.call(object, key, childProxy);
+            }
         }
-    });
+    } else {
+        Object.entries(object).forEach(([prop, value]) => {
+            const propString = String(prop);
+            if (
+                value === null ||
+                (object instanceof ReactiveNode &&
+                    (propString === COLLECTED_KEYS_SYMBOL ||
+                        object[COLLECTED_KEYS_SYMBOL].has(propString)))
+            ) {
+                proxyHandler[proxiedChildrenKey][prop] = value;
+            } else if (typeof value === "object") {
+                const cProxy = buildProxy(value, emitter, {
+                    proxyNode: proxy,
+                    propName: prop,
+                });
+                proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
+            }
+        });
+    }
     updateReproxyNode(proxy);
     return proxy;
+}
+
+function mapKeyAsPropName(key: unknown): string | symbol | null {
+    if (typeof key === "string" || typeof key === "symbol") return key;
+    return null;
+}
+
+function wrapMapMutation(
+    prop: string,
+    target: Map<any, any>,
+    baseProxy: TCustomProxy<any>,
+    emitter: TreeChangeEmitter
+) {
+    if (prop === "set") {
+        return function setWrapper(key: any, value: any) {
+            const previous = target.get(key);
+            const removedNodes: object[] = [];
+            // If we are replacing an existing object child of this map, detach it.
+            if (
+                previous !== value &&
+                previous !== null &&
+                typeof previous === "object"
+            ) {
+                const removed = detachCollectionChild(previous, baseProxy);
+                if (removed) removedNodes.push(removed);
+            }
+            let valueToStore: any = value;
+            if (value !== null && typeof value === "object") {
+                const parentToSet: IProxyParent<any> = {
+                    proxyNode: baseProxy,
+                    propName: mapKeyAsPropName(key),
+                };
+                valueToStore = isCustomProxy(value)
+                    ? reparentProxy(value, parentToSet)
+                    : buildProxy(value, emitter, parentToSet);
+            }
+            Map.prototype.set.call(target, key, valueToStore);
+            emitCollectionChange(target, baseProxy, emitter, removedNodes);
+            // Map.prototype.set returns the map itself; return the proxy so chaining stays reactive.
+            return baseProxy;
+        };
+    }
+    if (prop === "delete") {
+        return function deleteWrapper(key: any) {
+            const previous = target.get(key);
+            const removedNodes: object[] = [];
+            if (
+                previous !== null &&
+                previous !== undefined &&
+                typeof previous === "object"
+            ) {
+                const removed = detachCollectionChild(previous, baseProxy);
+                if (removed) removedNodes.push(removed);
+            }
+            const result = Map.prototype.delete.call(target, key);
+            if (result) {
+                emitCollectionChange(target, baseProxy, emitter, removedNodes);
+            }
+            return result;
+        };
+    }
+    if (prop === "clear") {
+        return function clearWrapper() {
+            if (target.size === 0) return;
+            const removedNodes: object[] = [];
+            target.forEach((value) => {
+                if (value !== null && typeof value === "object") {
+                    const removed = detachCollectionChild(value, baseProxy);
+                    if (removed) removedNodes.push(removed);
+                }
+            });
+            Map.prototype.clear.call(target);
+            emitCollectionChange(target, baseProxy, emitter, removedNodes);
+        };
+    }
+    throw new Error(`Unsupported Map mutation: ${prop}`);
+}
+
+function wrapSetMutation(
+    prop: string,
+    target: Set<any>,
+    baseProxy: TCustomProxy<any>,
+    emitter: TreeChangeEmitter
+) {
+    if (prop === "add") {
+        return function addWrapper(value: any) {
+            const hadValue = target.has(value);
+            Set.prototype.add.call(target, value);
+            if (!hadValue) {
+                emitCollectionChange(target, baseProxy, emitter, []);
+            }
+            return baseProxy;
+        };
+    }
+    if (prop === "delete") {
+        return function deleteWrapper(value: any) {
+            const result = Set.prototype.delete.call(target, value);
+            if (result) {
+                emitCollectionChange(target, baseProxy, emitter, []);
+            }
+            return result;
+        };
+    }
+    if (prop === "clear") {
+        return function clearWrapper() {
+            if (target.size === 0) return;
+            Set.prototype.clear.call(target);
+            emitCollectionChange(target, baseProxy, emitter, []);
+        };
+    }
+    throw new Error(`Unsupported Set mutation: ${prop}`);
+}
+
+function detachCollectionChild(
+    child: object,
+    parentBaseProxy: TCustomProxy<any>
+): object | undefined {
+    const handler = getCustomProxyHandler(child);
+    if (!handler) return undefined;
+    const oldParent = handler[proxiedParentKey];
+    if (!oldParent || oldParent.proxyNode !== parentBaseProxy) {
+        return undefined;
+    }
+    oldParent.propName = null;
+    oldParent.proxyNode = null;
+    return child;
+}
+
+function emitCollectionChange(
+    target: object,
+    baseProxy: TCustomProxy<any>,
+    emitter: TreeChangeEmitter,
+    removedNodes: object[]
+) {
+    if (Transactions.skipReproxy) return;
+    const reproxy = updateReproxyNode(baseProxy);
+    emitter.emit("nodeChanged", target, baseProxy, reproxy);
+    if (removedNodes.length === 0 || Transactions.skipEmit) return;
+    for (const removed of removedNodes) {
+        const removedUnproxied = getUnproxiedNode(removed);
+        emitter.emit("nodeRemoved", removedUnproxied ?? removed, removed);
+    }
 }
 
 /**

--- a/packages/retree-core/src/internals/reproxy.spec.ts
+++ b/packages/retree-core/src/internals/reproxy.spec.ts
@@ -5,7 +5,7 @@ import { getReproxyNode, updateReproxyNode } from "./reproxy";
 
 describe("reproxy internals", () => {
     it("creates a fresh snapshot and preserves access to the base proxy", () => {
-        const root = Retree.use({ child: { value: 1 } });
+        const root = Retree.root({ child: { value: 1 } });
         const original = getReproxyNode(root.child);
 
         root.child.value = 2;

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -91,8 +91,13 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 }
             }
             const baseProxy: TCustomProxy<T> = getBaseProxy(receiver);
-            const reproxy = getReproxyNode(baseProxy);
             const rawNode = getUnproxiedNode(baseProxy);
+            // Map/Set methods need internal slots on `this`. Delegate property access to the
+            // base proxy so the bind/wrap logic in buildProxy is reused (and mutations emit).
+            if (rawNode instanceof Map || rawNode instanceof Set) {
+                return Reflect.get(baseProxy, prop, baseProxy);
+            }
+            const reproxy = getReproxyNode(baseProxy);
             const value = Reflect.get(rawNode ?? target, prop, receiver);
             if (typeof value === "function") {
                 if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {

--- a/packages/retree-react/README.md
+++ b/packages/retree-react/README.md
@@ -26,7 +26,7 @@ It's extremely easy to get started with Retree. There are two React hooks: `useN
 
 If you adopt the `useNode` pattern, your apps will automatically inherit performant re-renders, since only the components that depend on each node in your object tree will re-render on changes. For this to work, you need to do the following:
 
-1. Pass some object into `Retree.use`, e.g., `const root = Retree.use({ foo: "bar", list: [] })`
+1. Pass some object into `Retree.root`, e.g., `const root = Retree.root({ foo: "bar", list: [] })`
 2. Make the response stateful using `useNode`, e.g., `const rootState = useNode(root)`
 3. Render values from the object in your component, e.g., `<h1>{fooState.foo}</h1>`
 4. Set values like you normally would in JS/TS, e.g., `fooState.foo = "moo"`
@@ -79,7 +79,7 @@ class TodoList {
 }
 
 // Create your root TreeNode instance with any object
-const root = Retree.use(new TodoList());
+const root = Retree.root(new TodoList());
 
 // Render app
 function App() {
@@ -104,7 +104,7 @@ import React from "react";
 import { Retree } from "@retreejs/core";
 import { useNode } from "@retreejs/react";
 
-const whiteboardRoot = Retree.use({
+const whiteboardRoot = Retree.root({
     selectedColor: "red",
     visible: false,
     canvasSize: { width: "0px", height: "0px" },
@@ -162,7 +162,7 @@ import React from "react";
 import { Retree } from "@retreejs/core";
 import { useNode, useTree } from "@retreejs/react";
 
-const table = Retree.use({
+const table = Retree.root({
     headers: [{ title: "label" }, { title: "count" }, { title: "actions" }],
     rows: [
         { label: "count 1", count: 0 },
@@ -230,7 +230,7 @@ export default App;
 `useTree` is very powerful and makes things incredibly simple. The following scenarios should help clarify the behavior of `useTree`:
 
 ```ts
-const root = Retree.use({
+const root = Retree.root({
     great_grandparent_1: {
         name: "Bob Sr",
         grandparent_1: {
@@ -315,7 +315,7 @@ class Node extends ReactiveNode {
     }
 }
 // Create root `ReactiveNode` instance and listen for changes in `useNode`
-const node = Retree.use(new Node());
+const node = Retree.root(new Node());
 const nodeState = useNode(node);
 
 // ✅ Will re-render
@@ -331,7 +331,7 @@ node.list.push(99);
 If you are making multiple changes to one or many nodes at once, you can use `Retree.runTransaction` function to only set to React state once per instance of `useNode` or `useTree`. Here is an example:
 
 ```ts
-const _counter = Retree.use({ count: 0 });
+const _counter = Retree.root({ count: 0 });
 const counter = useNode(_counter);
 // Will only emit "valueChanged" once
 Retree.runTransaction(() => {
@@ -345,7 +345,7 @@ Retree.runTransaction(() => {
 If you want to skip re-rendering on a change, you can use the `Retree.runSilent` function. Here is an example:
 
 ```ts
-const counter = Retree.use({ count: 0, multiplier: 1 });
+const counter = Retree.root({ count: 0, multiplier: 1 });
 const counterState = useNode(counter);
 // Skip re-render on setting the multiplier
 function onClickIncrementMultipler() {

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.1.33",
+    "version": "0.1.34",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.1.33",
+        "@retreejs/core": "0.1.34",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.1.33",
+        "@retreejs/core": "0.1.34",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/src/ReactiveNode.integration.spec.tsx
+++ b/packages/retree-react/src/ReactiveNode.integration.spec.tsx
@@ -42,7 +42,7 @@ class EvenNumberNode extends ReactiveNode {
 
 describe("ReactiveNode integration", () => {
     it("rerenders only when reactive comparison values change", () => {
-        const root = trackRoot(Retree.use(new EvenNumberNode()));
+        const root = trackRoot(Retree.root(new EvenNumberNode()));
         let renderCount = 0;
 
         function Probe() {

--- a/packages/retree-react/src/transactions.spec.tsx
+++ b/packages/retree-react/src/transactions.spec.tsx
@@ -31,7 +31,7 @@ function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
 
 describe("React transaction behavior", () => {
     it("collapses multiple useNode updates inside a transaction to one rerender", () => {
-        const root = trackRoot(Retree.use({ count: 0 }));
+        const root = trackRoot(Retree.root({ count: 0 }));
         let renderCount = 0;
 
         function Probe() {
@@ -54,7 +54,7 @@ describe("React transaction behavior", () => {
     });
 
     it("suppresses useNode rerenders during silent updates until a visible change occurs", () => {
-        const root = trackRoot(Retree.use({ count: 1, multiplier: 1 }));
+        const root = trackRoot(Retree.root({ count: 1, multiplier: 1 }));
         let renderCount = 0;
 
         function Probe() {
@@ -89,7 +89,7 @@ describe("React transaction behavior", () => {
     });
 
     it("collapses descendant useTree updates inside a transaction to one rerender", () => {
-        const root = trackRoot(Retree.use({ child: { value: 0 } }));
+        const root = trackRoot(Retree.root({ child: { value: 0 } }));
         let renderCount = 0;
 
         function Probe() {

--- a/packages/retree-react/src/useNode.spec.tsx
+++ b/packages/retree-react/src/useNode.spec.tsx
@@ -30,7 +30,7 @@ function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
 
 describe("useNode", () => {
     it("rerenders for direct primitive updates", () => {
-        const root = trackRoot(Retree.use({ count: 0 }));
+        const root = trackRoot(Retree.root({ count: 0 }));
         let renderCount = 0;
 
         function Probe() {
@@ -51,7 +51,7 @@ describe("useNode", () => {
     });
 
     it("does not rerender for deep descendant leaf updates", () => {
-        const root = trackRoot(Retree.use({ child: { value: 1 } }));
+        const root = trackRoot(Retree.root({ child: { value: 1 } }));
         let renderCount = 0;
 
         function Probe() {
@@ -73,7 +73,7 @@ describe("useNode", () => {
 
     it("supports the node factory form and switches immediately when the node prop changes", () => {
         const root = trackRoot(
-            Retree.use({ first: { value: 1 }, second: { value: 2 } })
+            Retree.root({ first: { value: 1 }, second: { value: 2 } })
         );
 
         function DirectProbe({ node }: { node: { value: number } }) {

--- a/packages/retree-react/src/useNode.ts
+++ b/packages/retree-react/src/useNode.ts
@@ -64,7 +64,7 @@ class TodoList {
 }
 
 // Create your root TreeNode instance with any object
-const root = Retree.use(new TodoList());
+const root = Retree.root(new TodoList());
 
 // Render app
 function App() {

--- a/packages/retree-react/src/useRoot.ts
+++ b/packages/retree-react/src/useRoot.ts
@@ -11,12 +11,12 @@ import { useRef } from "react";
 /**
  * Create a Retree-managed root that survives React Strict Mode's
  * double-invocation of `useState`/`useMemo` initializers.
- * Use this in place of `useState(() => Retree.use(new Foo()))`.
+ * Use this in place of `useState(() => Retree.root(new Foo()))`.
  * Then pass into `useNode` or `useTree`.
  *
  * @remarks
  * Why: under Strict Mode, React invokes a `useState` lazy initializer twice
- * to detect impurity. `Retree.use(...)` mutates module-global state
+ * to detect impurity. `Retree.root(...)` mutates module-global state
  * (`reproxyMap`) keyed by raw object identity. When the constructor wraps
  * the same shared raw inputs (e.g., props passed from a parent) twice, the
  * second call overwrites entries the first instance depends on — and any
@@ -26,13 +26,13 @@ import { useRef } from "react";
  * across the function body's StrictMode re-renders within a single mount,
  * so a `useRef + null check` guard ensures the factory runs exactly once.
  *
- * @param factory function that returns a node wrapped in `Retree.use`.
+ * @param factory function that returns a node wrapped in `Retree.root`.
  * @returns a root proxied node.
  */
 export function useRoot<T extends TreeNode>(factory: () => T): T {
     const ref = useRef<T | null>(null);
     if (ref.current === null) {
-        ref.current = Retree.use(factory());
+        ref.current = Retree.root(factory());
     }
     return ref.current;
 }

--- a/packages/retree-react/src/useTree.spec.tsx
+++ b/packages/retree-react/src/useTree.spec.tsx
@@ -31,7 +31,7 @@ function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
 describe("useTree", () => {
     it("rerenders for deep descendant changes in the observed subtree", () => {
         const root = trackRoot(
-            Retree.use({ child: { value: 1 }, sibling: { value: 2 } })
+            Retree.root({ child: { value: 1 }, sibling: { value: 2 } })
         );
         let renderCount = 0;
 
@@ -53,7 +53,7 @@ describe("useTree", () => {
 
     it("does not rerender for changes outside the observed subtree", () => {
         const root = trackRoot(
-            Retree.use({ child: { value: 1 }, sibling: { value: 2 } })
+            Retree.root({ child: { value: 1 }, sibling: { value: 2 } })
         );
         let renderCount = 0;
 
@@ -74,7 +74,7 @@ describe("useTree", () => {
     });
 
     it("supports the node factory form", () => {
-        const root = trackRoot(Retree.use({ child: { value: 1 } }));
+        const root = trackRoot(Retree.root({ child: { value: 1 } }));
 
         function Probe() {
             const state = useTree(() => root.child);

--- a/packages/retree-react/src/useTree.ts
+++ b/packages/retree-react/src/useTree.ts
@@ -15,7 +15,7 @@ const LISTENER_TYPE = "treeChanged";
  *
  * @remarks
  * Only use in cases where re-rendering of a parent component will not cause expensive re-renders of child components.
- * The root of the node provided must have been first passed to {@link Retree.use}.
+ * The root of the node provided must have been first passed to {@link Retree.root}.
  *
  * @param node object to make stateful
  * @returns a stateful version of the node provided
@@ -26,7 +26,7 @@ import React from "react";
 import { Retree } from "@retreejs/core";
 import { useNode, useTree } from "@retreejs/react";
 
-const table = Retree.use({
+const table = Retree.root({
     headers: [{ title: "label" }, { title: "count" }, { title: "actions" }],
     rows: [
         { label: "count 1", count: 0 },

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.33"
+        "@retreejs/core": "0.1.34"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/01.core-example/src/app.ts
+++ b/samples/01.core-example/src/app.ts
@@ -32,7 +32,7 @@ async function start() {
 
     const schema = new Schema(0, "", new Node("initial"), []);
 
-    const root = Retree.use(schema);
+    const root = Retree.root(schema);
     const unsubscribe = Retree.on(root, "nodeChanged", (reproxy) => {
         console.log("nodeChanged root:", root, reproxy === root);
         if (reproxy.count === 1) {

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.1.33",
-        "@retreejs/react": "0.1.33"
+        "@retreejs/core": "0.1.34",
+        "@retreejs/react": "0.1.34"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/02.react-example/src/App.tsx
+++ b/samples/02.react-example/src/App.tsx
@@ -50,7 +50,7 @@ class AppTree {
     public facts: CatFacts = new CatFacts();
 }
 // Setup Retree root
-const appTree = Retree.use(new AppTree());
+const appTree = Retree.root(new AppTree());
 
 const App: FC = () => {
     const root = useTree(appTree);

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.33",
-        "@retreejs/react": "0.1.33",
+        "@retreejs/core": "0.1.34",
+        "@retreejs/react": "0.1.34",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/src/NodeExample.tsx
+++ b/samples/03.react-recursion/src/NodeExample.tsx
@@ -70,7 +70,7 @@ const _ViewCard: FC<{
 const ViewCard = memo(_ViewCard);
 
 // Setup Retree with our root node
-const appTree = Retree.use(new Tree("useNode (optimal performance)"));
+const appTree = Retree.root(new Tree("useNode (optimal performance)"));
 
 const _NodeExample: FC = () => {
     const root = useNode(appTree);

--- a/samples/03.react-recursion/src/TreeExample.tsx
+++ b/samples/03.react-recursion/src/TreeExample.tsx
@@ -68,7 +68,7 @@ const _ViewCard: FC<{
 const ViewCard = memo(_ViewCard);
 
 // Setup Retree with our root node
-const appTree = Retree.use(new Tree("useTree (ease of use)"));
+const appTree = Retree.root(new Tree("useTree (ease of use)"));
 
 const _TreeExample: FC = () => {
     const root = useTree(appTree);

--- a/samples/03.react-recursion/src/global-state.ts
+++ b/samples/03.react-recursion/src/global-state.ts
@@ -4,4 +4,4 @@ export class GlobalState {
     memoize = true;
     silentSkipReproxy = true;
 }
-export const globalState = Retree.use(new GlobalState());
+export const globalState = Retree.root(new GlobalState());


### PR DESCRIPTION
- deprecate Retree.use, replace with Retree.root
- fix bugs with `Map` and `Set`
- Update & release 0.1.34