### PR TITLE
@memo, rename @retreeIgnore to @ignore, and 0.2.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+<!-- BEGIN:typescript-preferences -->
+
+Always use the type system to your advantage. Do not force cast, preferring type guards, generics with inferred typing, etc.
+Throw errors that give helpful information. Errors should be a single failure condition (e.g., `||` conditions when throwing should instead be separate `if` statements, each with their own unique error message). If a user were to send the developer a screenshot of the error, the developer should be able to pinpoint it to an exact line of code and know exactly what the failure was, without reproducing the error to see which `||` triggered that error to be thrown.
+Do not go crazy with inline ternaries. Only one ternary per variable is acceptable.
+
+<!-- END:typescript-preferences -->
+
+<!-- BEGIN:verification-and-debugging-rules -->
+
+Always test your changes (`npm run test`). If a test is failing, do not ignore it or assume it was pre-existing. Fix it.
+Always run `npm run doctor` when you're finished with changes.
+
+<!-- END:verification-and-debugging-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -328,6 +328,106 @@ node.list.push(3);
 node.list.push(99);
 ```
 
+#### Memoize computed getters
+
+`ReactiveNode` provides `memo` to cache the result of a getter, similar in spirit to React's `useMemo`. Use it to skip expensive recomputation when the values it depends on haven't changed.
+
+There are three ways to memoize: a keyless `this.memo(fn, deps?)` form (cleanest, when you want one cache per getter), an explicit-key `this.memo(key, fn, deps?)` form (for stacking multiple memos in one getter or memoizing inside a method), and a `@memo` decorator form.
+
+##### `this.memo(fn, deps?)` (keyless, inside a getter)
+
+The cache key is derived from the active getter's name automatically. Throws if called outside a getter, or more than once in the same getter without an explicit key.
+
+```ts
+import { Retree, ReactiveNode } from "@retreejs/core";
+
+interface Card {
+    text: string;
+}
+
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    get filteredList(): Card[] {
+        return this.memo(
+            () => this.list.filter((c) => c.text === this.searchText),
+            [this.list, this.searchText]
+        );
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+##### `@memo` decorator (one memo per getter, no body wrapping)
+
+The cache key is the getter's property name. Pass a function that returns the comparisons array — it's invoked with the current instance on every read, so the values are always live.
+
+```ts
+import { Retree, ReactiveNode } from "@retreejs/core";
+import { memo } from "@retreejs/core";
+
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    @memo((self: ListFilter) => [self.list, self.searchText])
+    get filteredList(): Card[] {
+        return this.list.filter((c) => c.text === this.searchText);
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+##### `this.memo(key, fn, deps?)` (explicit key)
+
+Use this when you need multiple memo cells in the same getter, or when caching a result inside a method.
+
+```ts
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    get pair(): { filtered: Card[]; count: number } {
+        const filtered = this.memo(
+            "filtered",
+            () => this.list.filter((c) => c.text === this.searchText),
+            [this.list, this.searchText]
+        );
+        const count = this.memo(
+            "count",
+            () => filtered.length,
+            [filtered]
+        );
+        return { filtered, count };
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+##### Cache semantics
+
+The same `deps` rules apply to all three forms:
+
+| `deps` argument | Behavior                                                                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `undefined`     | Recompute whenever the `ReactiveNode` reproxies (a property was set on it or one of its dependencies changed). Useful as a "compute once per render." |
+| `[]`            | Compute once and cache forever for that instance.                                                                                                     |
+| `[a, b, ...]`   | Recompute when any cell shallow-changes (compared with `Object.is`).                                                                                  |
+
+**Tree-node cells in `deps` are compared by their latest reproxy identity, not by the stable buildProxy reference.** That's why `[this.list, this.searchText]` correctly invalidates when `list` mutates — without this, `this.list` would always look unchanged because Retree returns the same buildProxy for the lifetime of the tree.
+
+The cache is per-instance and stored in a `WeakMap` keyed by the unproxied `ReactiveNode`, so it follows the instance's lifetime and is naturally garbage-collected when the node is dropped.
+
 #### Transactions
 
 If you are making multiple changes to one or many nodes at once, you can use `Retree.runTransaction` function to only set to React state once per instance of `useNode` or `useTree`. Here is an example:

--- a/README.md
+++ b/README.md
@@ -428,9 +428,9 @@ The cache is per-instance and stored in a `WeakMap` keyed by the unproxied `Reac
 
 `@ignore` is a class-field decorator that excludes a property of a `ReactiveNode` from Retree's reactivity system. Reads and writes to the field still work normally — what's skipped is **listener emission**:
 
-- Nested mutations like `this.cache.foo = 1` do **not** fire `nodeChanged` / `treeChanged` on the `ReactiveNode` or its ancestors.
-- Replacing the field at the top level (`this.cache = {...}`) likewise skips emission.
-- The proxy will not wrap the field's value or build child proxies underneath it.
+-   Nested mutations like `this.cache.foo = 1` do **not** fire `nodeChanged` / `treeChanged` on the `ReactiveNode` or its ancestors.
+-   Replacing the field at the top level (`this.cache = {...}`) likewise skips emission.
+-   The proxy will not wrap the field's value or build child proxies underneath it.
 
 Use it for state that lives on a `ReactiveNode` but shouldn't participate in the tree — caches, scratch buffers, framework handles, references to objects already managed elsewhere, etc.
 

--- a/README.md
+++ b/README.md
@@ -400,11 +400,7 @@ class ListFilter extends ReactiveNode {
             () => this.list.filter((c) => c.text === this.searchText),
             [this.list, this.searchText]
         );
-        const count = this.memo(
-            "count",
-            () => filtered.length,
-            [filtered]
-        );
+        const count = this.memo("count", () => filtered.length, [filtered]);
         return { filtered, count };
     }
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,43 @@ The same `deps` rules apply to all three forms:
 
 The cache is per-instance and stored in a `WeakMap` keyed by the unproxied `ReactiveNode`, so it follows the instance's lifetime and is naturally garbage-collected when the node is dropped.
 
+#### Opt fields out of reactivity with `@ignore`
+
+`@ignore` is a class-field decorator that excludes a property of a `ReactiveNode` from Retree's reactivity system. Reads and writes to the field still work normally — what's skipped is **listener emission**:
+
+- Nested mutations like `this.cache.foo = 1` do **not** fire `nodeChanged` / `treeChanged` on the `ReactiveNode` or its ancestors.
+- Replacing the field at the top level (`this.cache = {...}`) likewise skips emission.
+- The proxy will not wrap the field's value or build child proxies underneath it.
+
+Use it for state that lives on a `ReactiveNode` but shouldn't participate in the tree — caches, scratch buffers, framework handles, references to objects already managed elsewhere, etc.
+
+```ts
+import { Retree, ReactiveNode, ignore } from "@retreejs/core";
+import { useNode } from "@retreejs/react";
+
+class Counter extends ReactiveNode {
+    public count = 0;
+    // Mutations under `cache` do not trigger Retree listeners or re-renders.
+    @ignore public cache: Record<string, unknown> = {};
+
+    get dependencies() {
+        return [];
+    }
+}
+
+const node = Retree.root(new Counter());
+const state = useNode(node);
+
+// ❌ no re-render
+node.cache.something = 1;
+// ❌ no re-render — replacing the field also skips emission
+node.cache = { other: 2 };
+// ✅ re-renders
+node.count += 1;
+```
+
+**Caveat:** because the proxy doesn't wrap an `@ignore`-d field's value, you also lose `Retree.parent(...)` for objects stored under it, and they won't appear in `treeChanged` notifications. Treat ignored fields as opaque from Retree's perspective.
+
 #### Transactions
 
 If you are making multiple changes to one or many nodes at once, you can use `Retree.runTransaction` function to only set to React state once per instance of `useNode` or `useTree`. Here is an example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,7 +8374,7 @@
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.1.34",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -8390,18 +8390,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.1.34",
+            "version": "0.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.1.34",
+                "@retreejs/core": "0.2.0",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.1.34",
+                "@retreejs/core": "0.2.0",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -8411,7 +8411,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.1.34"
+                "@retreejs/core": "0.2.0"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -8846,8 +8846,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.34",
-                "@retreejs/react": "0.1.34",
+                "@retreejs/core": "0.2.0",
+                "@retreejs/react": "0.2.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -8867,8 +8867,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.1.34",
-                "@retreejs/react": "0.1.34",
+                "@retreejs/core": "0.2.0",
+                "@retreejs/react": "0.2.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,7 +8374,7 @@
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -8390,18 +8390,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.2.0",
+                "@retreejs/core": "0.2.1",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.2.0",
+                "@retreejs/core": "0.2.1",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -8411,7 +8411,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.2.0"
+                "@retreejs/core": "0.2.1"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -8846,8 +8846,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.2.0",
-                "@retreejs/react": "0.2.0",
+                "@retreejs/core": "0.2.1",
+                "@retreejs/react": "0.2.1",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -8867,8 +8867,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.2.0",
-                "@retreejs/react": "0.2.0",
+                "@retreejs/core": "0.2.1",
+                "@retreejs/react": "0.2.1",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -117,6 +117,32 @@ class ListFilter extends ReactiveNode {
 
 The cache is per-instance (a `WeakMap` keyed by the unproxied `ReactiveNode`) and is GC'd with the node.
 
+## Opt fields out of reactivity with `@ignore`
+
+`@ignore` is a class-field decorator that excludes a property of a `ReactiveNode` from Retree's reactivity system. Reads and writes still work normally — what's skipped is listener emission. Nested mutations (`this.cache.foo = 1`) and top-level replacement (`this.cache = {...}`) both bypass `nodeChanged` / `treeChanged`, and the proxy will not wrap the field's value or build child proxies underneath it.
+
+Use it for state that lives on a `ReactiveNode` but shouldn't participate in the tree — caches, scratch buffers, framework handles, references to objects already managed elsewhere, etc.
+
+```ts
+import { Retree, ReactiveNode, ignore } from "@retreejs/core";
+
+class Counter extends ReactiveNode {
+    public count = 0;
+    @ignore public cache: Record<string, unknown> = {};
+
+    get dependencies() {
+        return [];
+    }
+}
+
+const node = Retree.root(new Counter());
+Retree.on(node, "nodeChanged", () => console.log("changed"));
+node.cache.something = 1; // ❌ no log
+node.count = 1; //            ✅ logs "changed"
+```
+
+**Caveat:** because the field's value isn't wrapped, you also lose `Retree.parent(...)` for objects stored under it, and they won't appear in `treeChanged` notifications. Treat ignored fields as opaque from Retree's perspective.
+
 ## Core samples
 
 See the [useNode React hook](./packages/retree-react/src/useNode.ts) or [example 01 project](./samples/01.core-example/) for more example usages.

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -111,9 +111,9 @@ class ListFilter extends ReactiveNode {
 
 `deps` semantics (same for all three forms):
 
-- `undefined` → recompute whenever the `ReactiveNode` reproxies (any dependency changes or a property is set).
-- `[]` → compute once and cache forever for that instance.
-- `[a, b, ...]` → recompute when any cell shallow-changes (compared with `Object.is`). Tree-node cells are compared by their latest reproxy identity, so passing `this.list` correctly invalidates when `list` mutates.
+-   `undefined` → recompute whenever the `ReactiveNode` reproxies (any dependency changes or a property is set).
+-   `[]` → compute once and cache forever for that instance.
+-   `[a, b, ...]` → recompute when any cell shallow-changes (compared with `Object.is`). Tree-node cells are compared by their latest reproxy identity, so passing `this.list` correctly invalidates when `list` mutates.
 
 The cache is per-instance (a `WeakMap` keyed by the unproxied `ReactiveNode`) and is GC'd with the node.
 

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -61,6 +61,62 @@ tree.todos[0].delete();
 unsubscribe();
 ```
 
+## Memoize computed getters
+
+`ReactiveNode` exposes a `memo` helper for caching the result of a computed getter, similar in spirit to React's `useMemo`. Three forms are supported:
+
+```ts
+import { Retree, ReactiveNode, memo } from "@retreejs/core";
+
+interface Card {
+    text: string;
+}
+
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    // 1) Keyless method form — cache key is the getter's name.
+    get filteredList(): Card[] {
+        return this.memo(
+            () => this.list.filter((c) => c.text === this.searchText),
+            [this.list, this.searchText]
+        );
+    }
+
+    // 2) Decorator form — same cache-key behavior; pass a function that
+    //    returns deps so they're read live on every access.
+    @memo((self: ListFilter) => [self.list, self.searchText])
+    get filteredListDecorated(): Card[] {
+        return this.list.filter((c) => c.text === this.searchText);
+    }
+
+    // 3) Explicit-key method form — required for multiple memos in one
+    //    getter, or memoizing inside a method.
+    get pair() {
+        const filtered = this.memo(
+            "filtered",
+            () => this.list.filter((c) => c.text === this.searchText),
+            [this.list, this.searchText]
+        );
+        const count = this.memo("count", () => filtered.length, [filtered]);
+        return { filtered, count };
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+`deps` semantics (same for all three forms):
+
+- `undefined` → recompute whenever the `ReactiveNode` reproxies (any dependency changes or a property is set).
+- `[]` → compute once and cache forever for that instance.
+- `[a, b, ...]` → recompute when any cell shallow-changes (compared with `Object.is`). Tree-node cells are compared by their latest reproxy identity, so passing `this.list` correctly invalidates when `list` mutates.
+
+The cache is per-instance (a `WeakMap` keyed by the unproxied `ReactiveNode`) and is GC'd with the node.
+
 ## Core samples
 
 See the [useNode React hook](./packages/retree-react/src/useNode.ts) or [example 01 project](./samples/01.core-example/) for more example usages.

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.1.34",
+    "version": "0.2.0",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -1,4 +1,4 @@
-import { runMemo } from "./internals/memo";
+import { consumeCurrentMemoGetter, runMemo } from "./internals/memo";
 import { OptionalNode, TreeNode } from "./types";
 
 /**
@@ -86,39 +86,63 @@ export abstract class ReactiveNode {
     /**
      * Memoize the result of `fn`, scoped to this {@link ReactiveNode} instance.
      * @remarks
-     * Use this from inside a getter (or any method) to cache an expensive computation
-     * across reads. Each {@link memo} call must use a unique `key` per instance — if you
-     * want a "one cache per getter" form, use the {@link memo | `@memo`} decorator instead,
-     * which derives the key from the property name automatically.
+     * Two forms:
+     * - **Keyless (inside a getter):** `this.memo(fn, deps?)` — derives the cache key
+     *   from the active getter's property name. Throws if called outside a getter or
+     *   more than once in the same getter.
+     * - **Explicit key:** `this.memo(key, fn, deps?)` — works anywhere; required when
+     *   stacking multiple memo cells in one getter, or memoizing inside a method.
      *
      * Cache semantics for `comparisons`:
      * - `undefined`: recompute whenever this {@link ReactiveNode} reproxies (a dependency
      *   changed or a property was set on it). Useful as a "compute once per render" cache.
      * - `[]`: compute once and cache forever for this instance.
      * - `[a, b, ...]`: recompute when any cell shallow-changes (compared with {@link Object.is}).
-     *
-     * @param key unique cache key within this ReactiveNode instance.
-     * @param fn computation to run on cache miss.
-     * @param comparisons optional comparisons array; see semantics above.
-     * @returns cached or freshly-computed value.
+     *   Tree-node cells are compared by their latest reproxy identity, so passing
+     *   `this.list` correctly invalidates when `list` mutates.
      *
      * @example
      ```ts
      class ListFilter extends ReactiveNode {
         list: Card[] = [];
         searchText = "";
+        // Keyless form
         get filteredList() {
             return this.memo(
-                "filteredList",
                 () => this.list.filter((c) => c.text === this.searchText),
                 [this.list, this.searchText]
             );
+        }
+        // Explicit-key form (e.g. when stacking two memos in one getter)
+        get pair() {
+            const a = this.memo("a", () => expensiveA(), [this.list]);
+            const b = this.memo("b", () => expensiveB(), [this.searchText]);
+            return { a, b };
         }
         get dependencies() { return [this.dependency(this.list)]; }
      }
      ```
      */
-    protected memo<T>(key: string, fn: () => T, comparisons?: unknown[]): T {
+    protected memo<T>(fn: () => T, comparisons?: unknown[]): T;
+    protected memo<T>(key: string, fn: () => T, comparisons?: unknown[]): T;
+    protected memo<T>(
+        ...args:
+            | [fn: () => T, comparisons?: unknown[]]
+            | [key: string, fn: () => T, comparisons?: unknown[]]
+    ): T {
+        let key: string | symbol;
+        let fn: () => T;
+        let comparisons: unknown[] | undefined;
+        if (typeof args[0] === "function") {
+            // Keyless: derive the key from the active getter on the stack.
+            key = consumeCurrentMemoGetter(this);
+            fn = args[0];
+            comparisons = args[1] as unknown[] | undefined;
+        } else {
+            key = args[0];
+            fn = args[1] as () => T;
+            comparisons = args[2];
+        }
         return runMemo(this, key, fn, comparisons);
     }
     /**

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -1,3 +1,4 @@
+import { runMemo } from "./internals/memo";
 import { OptionalNode, TreeNode } from "./types";
 
 /**
@@ -81,6 +82,44 @@ export abstract class ReactiveNode {
             node,
             comparisons,
         };
+    }
+    /**
+     * Memoize the result of `fn`, scoped to this {@link ReactiveNode} instance.
+     * @remarks
+     * Use this from inside a getter (or any method) to cache an expensive computation
+     * across reads. Each {@link memo} call must use a unique `key` per instance — if you
+     * want a "one cache per getter" form, use the {@link memo | `@memo`} decorator instead,
+     * which derives the key from the property name automatically.
+     *
+     * Cache semantics for `comparisons`:
+     * - `undefined`: recompute whenever this {@link ReactiveNode} reproxies (a dependency
+     *   changed or a property was set on it). Useful as a "compute once per render" cache.
+     * - `[]`: compute once and cache forever for this instance.
+     * - `[a, b, ...]`: recompute when any cell shallow-changes (compared with {@link Object.is}).
+     *
+     * @param key unique cache key within this ReactiveNode instance.
+     * @param fn computation to run on cache miss.
+     * @param comparisons optional comparisons array; see semantics above.
+     * @returns cached or freshly-computed value.
+     *
+     * @example
+     ```ts
+     class ListFilter extends ReactiveNode {
+        list: Card[] = [];
+        searchText = "";
+        get filteredList() {
+            return this.memo(
+                "filteredList",
+                () => this.list.filter((c) => c.text === this.searchText),
+                [this.list, this.searchText]
+            );
+        }
+        get dependencies() { return [this.dependency(this.list)]; }
+     }
+     ```
+     */
+    protected memo<T>(key: string, fn: () => T, comparisons?: unknown[]): T {
+        return runMemo(this, key, fn, comparisons);
     }
     /**
      * @hidden

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
-import { retreeIgnore } from "./decorators";
+import { ignore } from "./decorators";
 import { Transactions } from "./internals/transactions";
 
 class IgnoredNode extends ReactiveNode {
-    @retreeIgnore
+    @ignore
     public ignored = { count: 0 };
     public count = 0;
 
@@ -27,7 +27,7 @@ afterEach(() => {
     Transactions.runPendingTransactions();
 });
 
-describe("retreeIgnore", () => {
+describe("ignore", () => {
     it("skips Retree listener emission for ignored nested objects", () => {
         root = Retree.root(new IgnoredNode());
         const nodeChanged = vi.fn();

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -1,7 +1,40 @@
 import { COLLECTED_KEYS_SYMBOL, ReactiveNode } from "./ReactiveNode";
 import { runMemo } from "./internals/memo";
 
-export function retreeIgnore(
+/**
+ * Field decorator that excludes a property of a {@link ReactiveNode} from Retree's
+ * reactivity system.
+ * @remarks
+ * Reads and writes to the ignored field still work normally, but:
+ * - The proxy will not wrap the field's value or build child proxies underneath it,
+ *   so nested mutations (e.g. `this.ignored.count = 1`) do **not** emit
+ *   `nodeChanged` / `treeChanged` listeners on the parent.
+ * - Replacing the field at the top level (e.g. `this.ignored = {...}`) likewise
+ *   skips listener emission.
+ *
+ * Use this for state that lives on a `ReactiveNode` but should not participate in
+ * the tree — caches, scratch buffers, framework handles, references to objects
+ * already managed elsewhere, etc.
+ *
+ * @example
+ ```ts
+ import { Retree, ReactiveNode, ignore } from "@retreejs/core";
+
+ class Counter extends ReactiveNode {
+    public count = 0;
+    // Mutations to `cache` do not trigger Retree listeners.
+    @ignore public cache: Record<string, unknown> = {};
+
+    get dependencies() { return []; }
+ }
+
+ const node = Retree.root(new Counter());
+ Retree.on(node, "nodeChanged", () => console.log("changed"));
+ node.cache.something = 1; // ❌ no log
+ node.count = 1;            // ✅ logs "changed"
+ ```
+ */
+export function ignore(
     _value: undefined,
     context: ClassFieldDecoratorContext
 ): void | ((this: ReactiveNode, value: any) => any) {

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -1,4 +1,5 @@
 import { COLLECTED_KEYS_SYMBOL, ReactiveNode } from "./ReactiveNode";
+import { runMemo } from "./internals/memo";
 
 export function retreeIgnore(
     _value: undefined,
@@ -9,4 +10,58 @@ export function retreeIgnore(
         this[COLLECTED_KEYS_SYMBOL].add(context.name);
     });
     return;
+}
+
+/**
+ * Decorator that memoizes a getter on a {@link ReactiveNode}.
+ * @remarks
+ * Pass a function that returns the comparisons array — the function captures `this`
+ * lazily, so the values are read fresh each time the getter is accessed.
+ *
+ * Cache semantics (matches {@link ReactiveNode.memo}):
+ * - No argument or returns `undefined`: recompute on every reproxy of the ReactiveNode.
+ * - Returns `[]`: compute once, cache forever for this instance.
+ * - Returns `[a, b, ...]`: recompute on shallow-change.
+ *
+ * The cache key is the getter's property name, so each `@memo`-decorated getter has
+ * its own cell automatically.
+ *
+ * @example
+ ```ts
+ class ListFilter extends ReactiveNode {
+    list: Card[] = [];
+    searchText = "";
+
+    @memo((self: ListFilter) => [self.list, self.searchText])
+    get filteredList() {
+        return this.list.filter((c) => c.text === this.searchText);
+    }
+
+    get dependencies() { return [this.dependency(this.list)]; }
+ }
+ ```
+ */
+export function memo<This extends ReactiveNode, Value>(
+    getComparisons?: (self: This) => unknown[] | undefined
+) {
+    return function (
+        target: (this: This) => Value,
+        context: ClassGetterDecoratorContext<This, Value>
+    ): (this: This) => Value {
+        if (context.kind !== "getter") {
+            throw new Error(
+                "@memo can only be applied to a getter on a ReactiveNode subclass."
+            );
+        }
+        const cacheKey = context.name;
+        return function memoizedGetter(this: This): Value {
+            const comparisons = getComparisons?.(this);
+            return runMemo(
+                this,
+                cacheKey,
+                () => target.call(this),
+                comparisons
+            );
+        };
+    };
 }

--- a/packages/retree-core/src/internals/memo.ts
+++ b/packages/retree-core/src/internals/memo.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ReactiveNode } from "../ReactiveNode";
+import { TreeNode } from "../types";
+import { getUnproxiedNode } from "./proxy";
+import { getReproxyNodeForUnproxiedNode } from "./reproxy";
+
+/**
+ * @internal
+ * One memoized result for a {@link ReactiveNode}, keyed by getter name (decorator form)
+ * or explicit string key (method form).
+ */
+interface IMemoCacheEntry {
+    value: unknown;
+    /**
+     * Comparisons array captured the last time the memo computed.
+     * `undefined` means "no comparisons; invalidate when the ReactiveNode reproxies."
+     */
+    comparisons: unknown[] | undefined;
+    /**
+     * Reproxy reference at the time of caching. Used to detect "the ReactiveNode
+     * has reproxied since this entry was made" for the `undefined` comparisons case.
+     */
+    reproxy: TreeNode | undefined;
+}
+
+const memoCacheMap = new WeakMap<
+    ReactiveNode,
+    Map<string | symbol, IMemoCacheEntry>
+>();
+
+function getOrCreateMemoCache(
+    unproxied: ReactiveNode
+): Map<string | symbol, IMemoCacheEntry> {
+    let cache = memoCacheMap.get(unproxied);
+    if (!cache) {
+        cache = new Map();
+        memoCacheMap.set(unproxied, cache);
+    }
+    return cache;
+}
+
+function shallowEqualArrays(a: unknown[], b: unknown[]): boolean {
+    if (a === b) return true;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+        if (!Object.is(a[i], b[i])) return false;
+    }
+    return true;
+}
+
+/**
+ * @internal
+ * Shared memo runner used by both `ReactiveNode.memo(...)` (method form) and the
+ * `@memo` decorator. Keys are unique per ReactiveNode instance.
+ *
+ * Cache semantics:
+ * - `comparisons === undefined`: hit when the current reproxy of the instance is the same
+ *   object as the one captured at compute time. (Recompute once per reproxy.)
+ * - `comparisons === []`: hit always (two empty arrays are shallow-equal).
+ * - `comparisons` populated: hit when shallow-equal to the stored array.
+ */
+export function runMemo<T>(
+    instance: ReactiveNode,
+    key: string | symbol,
+    fn: () => T,
+    comparisons: unknown[] | undefined
+): T {
+    // Cache by the unproxied instance so reproxy churn doesn't lose entries.
+    const unproxied = getUnproxiedNode(instance) as ReactiveNode | undefined;
+    if (!unproxied) {
+        // Defensive: ReactiveNode without a stable identity can't be cached safely.
+        return fn();
+    }
+    const cache = getOrCreateMemoCache(unproxied);
+    const currentReproxy = getReproxyNodeForUnproxiedNode(unproxied);
+    // Tree nodes are compared by their latest reproxy identity. The buildProxy a user
+    // gets via `this.list` is stable across the lifetime of the tree, so it would never
+    // appear "changed". The reproxy ref is what bumps on every mutation.
+    const normalized =
+        comparisons === undefined
+            ? undefined
+            : normalizeComparisons(comparisons);
+    const prev = cache.get(key);
+    if (prev) {
+        if (normalized === undefined) {
+            if (
+                prev.comparisons === undefined &&
+                prev.reproxy === currentReproxy
+            ) {
+                return prev.value as T;
+            }
+        } else if (
+            prev.comparisons !== undefined &&
+            shallowEqualArrays(prev.comparisons, normalized)
+        ) {
+            return prev.value as T;
+        }
+    }
+    const value = fn();
+    // Capture the reproxy AFTER fn so any mutations the computation performed on
+    // `this` (e.g. an internal counter) are folded into the cached snapshot. Otherwise
+    // the very first read would reproxy mid-compute and every subsequent read would
+    // be a cache miss.
+    cache.set(key, {
+        value,
+        comparisons: normalized,
+        reproxy: getReproxyNodeForUnproxiedNode(unproxied) ?? currentReproxy,
+    });
+    return value;
+}
+
+/**
+ * Replace each tree-node cell with its latest reproxy reference. This makes shallow
+ * comparison detect mutations: the stable "base proxy" returned by `this.list` would
+ * never change identity, but the reproxy bumps every time the node mutates.
+ */
+function normalizeComparisons(comparisons: unknown[]): unknown[] {
+    const out = new Array(comparisons.length);
+    for (let i = 0; i < comparisons.length; i++) {
+        const cell = comparisons[i];
+        if (cell !== null && typeof cell === "object") {
+            const unproxy = getUnproxiedNode(cell as TreeNode);
+            if (unproxy) {
+                const reproxy = getReproxyNodeForUnproxiedNode(unproxy);
+                if (reproxy) {
+                    out[i] = reproxy;
+                    continue;
+                }
+            }
+        }
+        out[i] = cell;
+    }
+    return out;
+}

--- a/packages/retree-core/src/internals/memo.ts
+++ b/packages/retree-core/src/internals/memo.ts
@@ -136,3 +136,109 @@ function normalizeComparisons(comparisons: unknown[]): unknown[] {
     }
     return out;
 }
+
+/**
+ * @internal
+ * One frame of the "currently-evaluating getter" stack used by the keyless
+ * `this.memo(fn, deps)` form to derive the cache key from the active getter.
+ */
+interface IMemoGetterFrame {
+    getterName: string | symbol;
+    memoCalled: boolean;
+}
+
+const memoGetterStackMap = new WeakMap<ReactiveNode, IMemoGetterFrame[]>();
+
+function resolveStackOwner(target: object): ReactiveNode {
+    // The stack must always be keyed by the unproxied instance so that pushes from
+    // proxy.ts (which sees the raw target) and reads from `this.memo(...)` (which
+    // sees a proxy) end up at the same map entry.
+    const unproxied = getUnproxiedNode(target as TreeNode) as
+        | ReactiveNode
+        | undefined;
+    return unproxied ?? (target as ReactiveNode);
+}
+
+/**
+ * @internal
+ * Push a frame onto the memo-getter stack. Called by `proxy.ts` / `reproxy.ts`
+ * immediately before invoking a `ReactiveNode` getter via `Reflect.get`.
+ */
+export function pushMemoGetter(
+    target: ReactiveNode,
+    getterName: string | symbol
+): void {
+    const owner = resolveStackOwner(target);
+    let stack = memoGetterStackMap.get(owner);
+    if (!stack) {
+        stack = [];
+        memoGetterStackMap.set(owner, stack);
+    }
+    stack.push({ getterName, memoCalled: false });
+}
+
+/**
+ * @internal
+ * Pop the most recent frame; paired with {@link pushMemoGetter} in a try/finally.
+ */
+export function popMemoGetter(target: ReactiveNode): void {
+    const owner = resolveStackOwner(target);
+    const stack = memoGetterStackMap.get(owner);
+    if (stack) stack.pop();
+}
+
+/**
+ * @internal
+ * Read the active getter name for a keyless `this.memo(fn, deps)` call and mark
+ * the frame as having consumed its memo cell. Throws if invoked outside a getter,
+ * or more than once within the same getter invocation (which would silently
+ * collide on the same cache cell).
+ */
+export function consumeCurrentMemoGetter(
+    instance: ReactiveNode
+): string | symbol {
+    const owner = resolveStackOwner(instance);
+    const stack = memoGetterStackMap.get(owner);
+    const top = stack && stack.length > 0 ? stack[stack.length - 1] : undefined;
+    if (!top) {
+        throw new Error(
+            "memo() was called without a key outside of a ReactiveNode getter. " +
+                "Either call memo from a getter, or pass an explicit key as the first " +
+                "argument: `this.memo('myKey', fn, deps)`."
+        );
+    }
+    if (top.memoCalled) {
+        throw new Error(
+            `memo() was called more than once in getter '${String(
+                top.getterName
+            )}' without an explicit key. Pass a unique string key as the first ` +
+                "argument: `this.memo('myKey', fn, deps)`."
+        );
+    }
+    top.memoCalled = true;
+    return top.getterName;
+}
+
+/**
+ * @internal
+ * Walk the prototype chain looking for `prop`. Returns the getter function if the
+ * first descriptor found is an accessor with a `get`; returns `undefined`
+ * otherwise (data prop, method, or missing). Used to decide whether a `Reflect.get`
+ * call needs to be wrapped with push/pop for memo-getter tracking.
+ */
+export function getReactiveNodeGetter(
+    target: object,
+    prop: string | symbol
+): (() => unknown) | undefined {
+    let current: object | null = target;
+    while (current && current !== Object.prototype) {
+        const descriptor = Object.getOwnPropertyDescriptor(current, prop);
+        if (descriptor) {
+            // Own descriptors shadow prototype descriptors. If the first one we find
+            // isn't a getter (e.g. it's a data property), there's nothing to wrap.
+            return descriptor.get;
+        }
+        current = Object.getPrototypeOf(current);
+    }
+    return undefined;
+}

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -17,6 +17,7 @@ import {
     TCustomProxy,
     unproxiedBaseNodeKey,
 } from "./proxy-types";
+import { getReactiveNodeGetter, popMemoGetter, pushMemoGetter } from "./memo";
 import { getReproxyNodeForUnproxiedNode, updateReproxyNode } from "./reproxy";
 import { Transactions } from "./transactions";
 
@@ -121,7 +122,23 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 }
                 return value;
             }
-            const value = Reflect.get(target, prop, receiver);
+            let value: any;
+            if (
+                target instanceof ReactiveNode &&
+                getReactiveNodeGetter(target, prop)
+            ) {
+                // For ReactiveNode getters, push the getter name onto the memo-getter
+                // stack so a keyless `this.memo(fn, deps)` inside the getter can derive
+                // its cache key from `prop`. Pop in `finally` so a throwing getter
+                pushMemoGetter(target, prop);
+                try {
+                    value = Reflect.get(target, prop, receiver);
+                } finally {
+                    popMemoGetter(target);
+                }
+            } else {
+                value = Reflect.get(target, prop, receiver);
+            }
             if (typeof value === "function") {
                 if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
                     return value.bind(target);

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -11,6 +11,7 @@ import {
     getUnproxiedNode,
     FUNCTION_NAMES_BIND_TO_RAW,
 } from "./proxy";
+import { getReactiveNodeGetter, popMemoGetter, pushMemoGetter } from "./memo";
 import {
     ICustomProxyHandler,
     proxiedChildrenKey,
@@ -98,7 +99,24 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 return Reflect.get(baseProxy, prop, baseProxy);
             }
             const reproxy = getReproxyNode(baseProxy);
-            const value = Reflect.get(rawNode ?? target, prop, receiver);
+            const evalTarget = rawNode ?? target;
+
+            let value: any;
+            if (
+                evalTarget instanceof ReactiveNode &&
+                getReactiveNodeGetter(evalTarget, prop)
+            ) {
+                // Mirror proxy.ts: track the active getter for keyless `this.memo(...)`.
+                pushMemoGetter(evalTarget, prop);
+                try {
+                    value = Reflect.get(evalTarget, prop, receiver);
+                } finally {
+                    popMemoGetter(evalTarget);
+                }
+            } else {
+                value = Reflect.get(evalTarget, prop, receiver);
+            }
+
             if (typeof value === "function") {
                 if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
                     return value.bind(rawNode);

--- a/packages/retree-core/src/memo.spec.ts
+++ b/packages/retree-core/src/memo.spec.ts
@@ -415,6 +415,48 @@ describe("@memo decorator", () => {
         expect(b.computeCount).toBe(1);
     });
 
+    it("can co-exist with a keyless this.memo() call in the same class", () => {
+        // Sanity check that the @memo decorator and a keyless this.memo() in a
+        // separate getter on the same class don't interfere with each other.
+        class Mixed extends ReactiveNode {
+            public x = 1;
+            public y = 1;
+            public xCount = 0;
+            public yCount = 0;
+
+            @memo((self: Mixed) => [self.x])
+            get viaDecorator(): number {
+                this.xCount += 1;
+                return this.x * 2;
+            }
+
+            get viaMethod(): number {
+                return this.memo(() => {
+                    this.yCount += 1;
+                    return this.y * 3;
+                }, [this.y]);
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Mixed()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        root.viaDecorator;
+        root.viaMethod;
+        expect(root.xCount).toBe(1);
+        expect(root.yCount).toBe(1);
+
+        root.x = 2;
+        root.viaDecorator;
+        root.viaMethod;
+        expect(root.xCount).toBe(2);
+        expect(root.yCount).toBe(1);
+    });
+
     it("works with subclassing — derived getter @memo cell is independent of base", () => {
         class Base extends ReactiveNode {
             public x = 1;
@@ -451,5 +493,237 @@ describe("@memo decorator", () => {
         root.other;
         expect(root.baseCount).toBe(2);
         expect(root.derivedCount).toBe(1); // y didn't change
+    });
+});
+
+describe("memo (keyless method form)", () => {
+    it("derives the cache key from the active getter's name", () => {
+        class Keyless extends ReactiveNode {
+            public list: Card[] = [];
+            public searchText: string = "";
+            public computeCount = 0;
+
+            get filtered(): Card[] {
+                return this.memo(() => {
+                    this.computeCount += 1;
+                    return this.list.filter((c) => c.text === this.searchText);
+                }, [this.list, this.searchText]);
+            }
+
+            get dependencies() {
+                return [this.dependency(this.list)];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Keyless()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.filtered).toEqual([]);
+        expect(root.computeCount).toBe(1);
+
+        // Repeated reads with no change reuse the cache.
+        root.filtered;
+        root.filtered;
+        expect(root.computeCount).toBe(1);
+
+        // Change a comparison, then mutate the list — both should invalidate.
+        root.searchText = "match";
+        root.filtered;
+        root.list.push({ text: "match" });
+        expect(root.filtered).toEqual([{ text: "match" }]);
+        expect(root.computeCount).toBe(3);
+    });
+
+    it("supports the undefined-deps form (recompute once per reproxy)", () => {
+        class Undef extends ReactiveNode {
+            public counter = 0;
+            public computeCount = 0;
+
+            get cached(): number {
+                return this.memo(() => {
+                    this.computeCount += 1;
+                    return this.counter;
+                });
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Undef()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        root.cached;
+        root.cached;
+        root.cached;
+        expect(root.computeCount).toBe(1);
+
+        root.counter = 1;
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("supports the empty-deps form (cache forever)", () => {
+        class Once extends ReactiveNode {
+            public counter = 0;
+            public computeCount = 0;
+
+            get cached(): number {
+                return this.memo(() => {
+                    this.computeCount += 1;
+                    return this.counter;
+                }, []);
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Once()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.cached).toBe(0);
+        root.counter = 99;
+        expect(root.cached).toBe(0);
+        expect(root.computeCount).toBe(1);
+    });
+
+    it("uses a separate cache cell for each getter (keyless cells don't collide across getters)", () => {
+        class TwoGetters extends ReactiveNode {
+            public a = 1;
+            public b = 1;
+            public aCount = 0;
+            public bCount = 0;
+
+            get fromA(): number {
+                return this.memo(() => {
+                    this.aCount += 1;
+                    return this.a * 10;
+                }, [this.a]);
+            }
+
+            get fromB(): number {
+                return this.memo(() => {
+                    this.bCount += 1;
+                    return this.b * 100;
+                }, [this.b]);
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new TwoGetters()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.fromA).toBe(10);
+        expect(root.fromB).toBe(100);
+        expect(root.aCount).toBe(1);
+        expect(root.bCount).toBe(1);
+
+        // Change a; b stays cached.
+        root.a = 2;
+        expect(root.fromA).toBe(20);
+        expect(root.fromB).toBe(100);
+        expect(root.aCount).toBe(2);
+        expect(root.bCount).toBe(1);
+    });
+
+    it("works for nested getters (each getter pushes its own frame)", () => {
+        class Nested extends ReactiveNode {
+            public x = 1;
+            public innerCount = 0;
+            public outerCount = 0;
+
+            get inner(): number {
+                return this.memo(() => {
+                    this.innerCount += 1;
+                    return this.x * 10;
+                }, [this.x]);
+            }
+
+            get outer(): number {
+                return this.memo(() => {
+                    this.outerCount += 1;
+                    // Outer reads inner; both should memoize independently.
+                    return this.inner + 1;
+                }, [this.x]);
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Nested()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.outer).toBe(11);
+        expect(root.innerCount).toBe(1);
+        expect(root.outerCount).toBe(1);
+
+        // Repeat read: both stay cached.
+        root.outer;
+        expect(root.innerCount).toBe(1);
+        expect(root.outerCount).toBe(1);
+
+        root.x = 2;
+        expect(root.outer).toBe(21);
+        expect(root.innerCount).toBe(2);
+        expect(root.outerCount).toBe(2);
+    });
+
+    it("throws if called outside a getter (e.g. from a method)", () => {
+        class FromMethod extends ReactiveNode {
+            public callIt(): number {
+                return this.memo(() => 42);
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new FromMethod()));
+        expect(() => root.callIt()).toThrow(/without a key outside of/i);
+    });
+
+    it("throws if called twice in the same getter without explicit keys", () => {
+        class Double extends ReactiveNode {
+            get bad(): number {
+                this.memo(() => 1);
+                return this.memo(() => 2);
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Double()));
+        expect(() => root.bad).toThrow(/more than once in getter 'bad'/i);
+    });
+
+    it("does not leave stale frames after a throwing getter", () => {
+        class Throws extends ReactiveNode {
+            public shouldThrow = true;
+            get bad(): number {
+                if (this.shouldThrow) throw new Error("boom");
+                return this.memo(() => 1);
+            }
+            get good(): number {
+                return this.memo(() => 99);
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Throws()));
+        expect(() => root.bad).toThrow("boom");
+        // If push/pop weren't balanced, `good`'s memo would inherit `bad`'s frame
+        // and either collide or pick up an already-consumed frame.
+        expect(root.good).toBe(99);
     });
 });

--- a/packages/retree-core/src/memo.spec.ts
+++ b/packages/retree-core/src/memo.spec.ts
@@ -1,0 +1,455 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReactiveNode } from "./ReactiveNode";
+import { Retree } from "./Retree";
+import { memo } from "./decorators";
+import { Transactions } from "./internals/transactions";
+
+const rootsToCleanup: object[] = [];
+
+function trackRoot<T extends object>(root: T): T {
+    rootsToCleanup.push(root);
+    return root;
+}
+
+afterEach(() => {
+    for (const root of rootsToCleanup.splice(0)) {
+        clearListenersRecursively(root);
+    }
+    Transactions.skipEmit = false;
+    Transactions.skipReproxy = false;
+    Transactions.runningTransaction = false;
+    Transactions.runPendingTransactions();
+});
+
+function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
+    if (!node || typeof node !== "object" || seen.has(node)) {
+        return;
+    }
+    seen.add(node);
+    Retree.clearListeners(node as never);
+    for (const child of Object.values(node)) {
+        clearListenersRecursively(child, seen);
+    }
+}
+
+interface Card {
+    text: string;
+}
+
+class ListFilterMethod extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText: string = "";
+    public computeCount = 0;
+
+    get filtered(): Card[] {
+        return this.memo(
+            "filtered",
+            () => {
+                this.computeCount += 1;
+                return this.list.filter((c) => c.text === this.searchText);
+            },
+            [this.list, this.searchText]
+        );
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+
+class ListFilterDecorator extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText: string = "";
+    public computeCount = 0;
+
+    @memo((self: ListFilterDecorator) => [self.list, self.searchText])
+    get filtered(): Card[] {
+        this.computeCount += 1;
+        return this.list.filter((c) => c.text === this.searchText);
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+
+describe("memo (method form)", () => {
+    it("recomputes when comparison cells change and reuses cache otherwise", () => {
+        const root = trackRoot(Retree.root(new ListFilterMethod()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        // First read computes once.
+        expect(root.filtered).toEqual([]);
+        expect(root.computeCount).toBe(1);
+
+        // Repeated read with no change reuses the cache.
+        root.filtered;
+        root.filtered;
+        expect(root.computeCount).toBe(1);
+
+        // Change a comparison value (searchText). Reads after recompute once.
+        root.searchText = "match";
+        expect(root.filtered).toEqual([]);
+        expect(root.computeCount).toBe(2);
+        root.filtered;
+        expect(root.computeCount).toBe(2);
+
+        // Mutate list (a comparison ref); next read recomputes.
+        root.list.push({ text: "match" });
+        expect(root.filtered).toEqual([{ text: "match" }]);
+        expect(root.computeCount).toBe(3);
+    });
+
+    it("with empty comparisons array, computes once and caches forever", () => {
+        class OnceNode extends ReactiveNode {
+            public counter = 0;
+            public computeCount = 0;
+
+            get cached(): number {
+                return this.memo(
+                    "cached",
+                    () => {
+                        this.computeCount += 1;
+                        return this.counter;
+                    },
+                    []
+                );
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new OnceNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.cached).toBe(0);
+        root.counter = 5;
+        expect(root.cached).toBe(0); // still cached
+        expect(root.computeCount).toBe(1);
+    });
+
+    it("with undefined comparisons, recomputes once per reproxy", () => {
+        class UndefinedDepsNode extends ReactiveNode {
+            public counter = 0;
+            public computeCount = 0;
+
+            get cached(): number {
+                return this.memo("cached", () => {
+                    this.computeCount += 1;
+                    return this.counter;
+                });
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new UndefinedDepsNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        // Multiple reads in the same reproxy share the cache.
+        expect(root.cached).toBe(0);
+        expect(root.cached).toBe(0);
+        expect(root.cached).toBe(0);
+        expect(root.computeCount).toBe(1);
+
+        // A property set reproxies the ReactiveNode → next read recomputes.
+        root.counter = 1;
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+
+        // Repeated reads are cached again until the next reproxy.
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("uses Object.is for comparisons (NaN equals NaN, signed zeros not equal)", () => {
+        class CompareNode extends ReactiveNode {
+            public x: number = 0;
+            public computeCount = 0;
+
+            get cached(): number {
+                return this.memo(
+                    "cached",
+                    () => {
+                        this.computeCount += 1;
+                        return this.x;
+                    },
+                    [this.x]
+                );
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new CompareNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        root.x = NaN;
+        root.cached;
+        const before = root.computeCount;
+        root.x = NaN;
+        root.cached;
+        // NaN compared via Object.is is equal — should NOT recompute.
+        expect(root.computeCount).toBe(before);
+    });
+
+    it("snapshots the comparisons array (later mutation of the same array does not cause spurious hits)", () => {
+        class SnapshotNode extends ReactiveNode {
+            public computeCount = 0;
+            public sharedDeps: unknown[] = [1];
+
+            get cached(): number {
+                return this.memo(
+                    "cached",
+                    () => {
+                        this.computeCount += 1;
+                        return this.sharedDeps.length;
+                    },
+                    this.sharedDeps
+                );
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new SnapshotNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(1);
+
+        // Replace the deps array entirely with a different one of the same length.
+        root.sharedDeps = [2];
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("supports multiple memo cells in the same getter via distinct keys", () => {
+        class MultiNode extends ReactiveNode {
+            public a = 1;
+            public b = 1;
+            public aCount = 0;
+            public bCount = 0;
+
+            get pair(): { a: number; b: number } {
+                const a = this.memo(
+                    "pair.a",
+                    () => {
+                        this.aCount += 1;
+                        return this.a * 10;
+                    },
+                    [this.a]
+                );
+                const b = this.memo(
+                    "pair.b",
+                    () => {
+                        this.bCount += 1;
+                        return this.b * 100;
+                    },
+                    [this.b]
+                );
+                return { a, b };
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new MultiNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        root.pair;
+        expect(root.aCount).toBe(1);
+        expect(root.bCount).toBe(1);
+
+        // Change only `a`; `b` cell stays cached.
+        root.a = 2;
+        const result = root.pair;
+        expect(result).toEqual({ a: 20, b: 100 });
+        expect(root.aCount).toBe(2);
+        expect(root.bCount).toBe(1);
+    });
+
+    it("isolates cache per ReactiveNode instance", () => {
+        const a = trackRoot(Retree.root(new ListFilterMethod()));
+        const b = trackRoot(Retree.root(new ListFilterMethod()));
+        Retree.on(a, "nodeChanged", vi.fn());
+        Retree.on(b, "nodeChanged", vi.fn());
+
+        a.list.push({ text: "x" });
+        a.searchText = "x";
+        expect(a.filtered).toEqual([{ text: "x" }]);
+        expect(b.filtered).toEqual([]);
+        expect(a.computeCount).toBe(1);
+        expect(b.computeCount).toBe(1);
+    });
+});
+
+describe("@memo decorator", () => {
+    it("caches by getter name and recomputes when the deps function returns different cells", () => {
+        const root = trackRoot(Retree.root(new ListFilterDecorator()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.filtered).toEqual([]);
+        expect(root.computeCount).toBe(1);
+
+        root.filtered;
+        expect(root.computeCount).toBe(1);
+
+        root.searchText = "match";
+        expect(root.filtered).toEqual([]);
+        expect(root.computeCount).toBe(2);
+
+        root.list.push({ text: "match" });
+        expect(root.filtered).toEqual([{ text: "match" }]);
+        expect(root.computeCount).toBe(3);
+    });
+
+    it("supports the dynamic-deps form (function captures live `this`)", () => {
+        // Sanity check: the decorator's deps function is called every read with the
+        // current instance, so it sees mutations made after class declaration.
+        class Dyn extends ReactiveNode {
+            public toggle = false;
+            public a = 1;
+            public b = 2;
+            public computeCount = 0;
+
+            @memo((self: Dyn) => (self.toggle ? [self.a] : [self.b]))
+            get value(): number {
+                this.computeCount += 1;
+                return this.toggle ? this.a : this.b;
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Dyn()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.value).toBe(2);
+        expect(root.computeCount).toBe(1);
+
+        // Changing `a` while toggle=false reads the [b]-shaped deps; no recompute.
+        root.a = 99;
+        expect(root.value).toBe(2);
+        expect(root.computeCount).toBe(1);
+
+        // Flip toggle. Deps shape changes from [b] to [a]; counts as a change.
+        root.toggle = true;
+        expect(root.value).toBe(99);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("with no deps function (undefined comparisons), recomputes once per reproxy", () => {
+        class UndefDeps extends ReactiveNode {
+            public counter = 0;
+            public computeCount = 0;
+
+            @memo()
+            get cached(): number {
+                this.computeCount += 1;
+                return this.counter;
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new UndefDeps()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        root.cached;
+        root.cached;
+        root.cached;
+        expect(root.computeCount).toBe(1);
+
+        root.counter = 1;
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("returns []-style 'cache forever' when the deps function returns []", () => {
+        class Once extends ReactiveNode {
+            public counter = 0;
+            public computeCount = 0;
+
+            @memo(() => [])
+            get cached(): number {
+                this.computeCount += 1;
+                return this.counter;
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Once()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.cached).toBe(0);
+        root.counter = 99;
+        expect(root.cached).toBe(0);
+        expect(root.computeCount).toBe(1);
+    });
+
+    it("isolates cache per instance", () => {
+        const a = trackRoot(Retree.root(new ListFilterDecorator()));
+        const b = trackRoot(Retree.root(new ListFilterDecorator()));
+        Retree.on(a, "nodeChanged", vi.fn());
+        Retree.on(b, "nodeChanged", vi.fn());
+
+        a.searchText = "match";
+        a.list.push({ text: "match" });
+        expect(a.filtered).toEqual([{ text: "match" }]);
+        expect(b.filtered).toEqual([]);
+        expect(a.computeCount).toBeGreaterThanOrEqual(1);
+        expect(b.computeCount).toBe(1);
+    });
+
+    it("works with subclassing — derived getter @memo cell is independent of base", () => {
+        class Base extends ReactiveNode {
+            public x = 1;
+            public baseCount = 0;
+            @memo((self: Base) => [self.x])
+            get computed(): number {
+                this.baseCount += 1;
+                return this.x * 2;
+            }
+            get dependencies() {
+                return [];
+            }
+        }
+        class Derived extends Base {
+            public y = 1;
+            public derivedCount = 0;
+            @memo((self: Derived) => [self.y])
+            get other(): number {
+                this.derivedCount += 1;
+                return this.y * 3;
+            }
+        }
+
+        const root = trackRoot(Retree.root(new Derived()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        root.computed;
+        root.other;
+        expect(root.baseCount).toBe(1);
+        expect(root.derivedCount).toBe(1);
+
+        root.x = 2;
+        root.computed;
+        root.other;
+        expect(root.baseCount).toBe(2);
+        expect(root.derivedCount).toBe(1); // y didn't change
+    });
+});

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.1.34",
+    "version": "0.2.0",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.1.34",
+        "@retreejs/core": "0.2.0",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.1.34",
+        "@retreejs/core": "0.2.0",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.2.0",
+        "@retreejs/core": "0.2.1",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.2.0",
+        "@retreejs/core": "0.2.1",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.34"
+        "@retreejs/core": "0.2.0"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.2.0"
+        "@retreejs/core": "0.2.1"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.1.34",
-        "@retreejs/react": "0.1.34"
+        "@retreejs/core": "0.2.0",
+        "@retreejs/react": "0.2.0"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.2.0",
-        "@retreejs/react": "0.2.0"
+        "@retreejs/core": "0.2.1",
+        "@retreejs/react": "0.2.1"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.2.0",
-        "@retreejs/react": "0.2.0",
+        "@retreejs/core": "0.2.1",
+        "@retreejs/react": "0.2.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.1.34",
-        "@retreejs/react": "0.1.34",
+        "@retreejs/core": "0.2.0",
+        "@retreejs/react": "0.2.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/src/TreeExample.tsx
+++ b/samples/03.react-recursion/src/TreeExample.tsx
@@ -81,11 +81,11 @@ const _TreeExample: FC = () => {
                 {"This should be ignored"}
                 <button
                     onClick={() => {
-                        root.ignore.count++;
+                        root.ignoreEx.count++;
                         console.log(root);
                     }}
                 >
-                    {root.ignore.count}++
+                    {root.ignoreEx.count}++
                 </button>
             </div>
         </div>

--- a/samples/03.react-recursion/src/node-state.ts
+++ b/samples/03.react-recursion/src/node-state.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from "uuid";
-import { Retree, ReactiveNode, retreeIgnore } from "@retreejs/core";
+import { Retree, ReactiveNode, ignore } from "@retreejs/core";
 import { globalState } from "./global-state";
 
 export class Card extends ReactiveNode {
@@ -120,12 +120,12 @@ export class IgnoreExample extends ReactiveNode {
 export class Tree extends ReactiveNode {
     public readonly title: string;
     public card: Card = new Card(1);
-    @retreeIgnore
-    public ignore: IgnoreExample;
+    @ignore
+    public ignoreEx: IgnoreExample;
     constructor(title: string) {
         super();
         this.title = title;
-        this.ignore = new IgnoreExample();
+        this.ignoreEx = new IgnoreExample();
     }
     get dependencies() {
         return [this.dependency(globalState, [globalState.memoize])];


### PR DESCRIPTION
- Added `@memo` decorator and `this.memo` to `ReactiveNode`.
- Renamed `@retreeIgnore` to `@ignore`
- Released version 0.2.1