### PR TITLE
Revamped decorators, link decorators, and move apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ The generated static site is written to `docs/` and ignored by Git. The docs bui
 -   [`useRoot`](#useroot-hook) creates one Retree root for a React component lifetime. Use it when state belongs to a React subtree.
 -   [`useNode`](#usenode-hook) re-renders a React component for direct `nodeChanged` events on one node. Use it for rows, panels, forms, and focused child components.
 -   [`useTree`](#usetree-hook) re-renders for `treeChanged` events from a node or any descendant. Use it sparingly for small subtrees that truly need broad invalidation.
--   [`useSelect`](#useselect-hook) re-renders only when a selected derived value changes. Use it for counts, totals, booleans, and other narrow projections.
+-   [`useSelect`](#useselect-hook) re-renders only when a selected value or ordered dependency list changes. Use it for counts, totals, booleans, and other narrow projections.
 -   [`Retree.on`](#core-api-examples) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
 -   [`Retree.select`](#core-api-examples) is the non-React version of `useSelect`. Use it to narrow notifications; it is not a cache.
 -   [`Retree.parent`](#core-api-examples) returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
 -   [`Retree.move`](#core-api-examples) transfers an existing node to a new structural parent. Use it when ownership should change.
 -   [`Retree.link` and `@link`](#core-api-examples) store a reactive pointer without reparenting. Use them for selected items and cross-references.
 -   [`Retree.clone`](#core-api-examples) makes a detached copy. Use it when two places need independent state.
--   [`ReactiveNode.dependencies`](#reactivenode) makes one node emit when another node changes. Use it as a narrow bridge instead of a broad `treeChanged` subscription.
+-   [`@select`](#reactivenode) decorates a getter with an ordered dependency list so VM logic can stay in the node while `useNode(node)` stays selective.
+-   [`ReactiveNode.dependencies`](#reactivenode) makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or wrap one slot with `this.dependency(node, comparisons)`.
 -   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Use them to avoid recomputation; they do not emit changes by themselves.
 -   [`@ignore`](#opt-fields-out-of-reactivity-with-ignore) keeps a field out of Retree emissions. Use it for caches, subscriptions, framework handles, and non-rendered state.
 -   [`Retree.runTransaction`](#transactions) batches synchronous writes into one listener flush per changed node.
@@ -208,7 +209,7 @@ This is ideal in cases when you want to use child nodes as props into other chil
 
 #### useSelect hook
 
-Use `useSelect` when a component needs one derived value from a Retree node and should only re-render when that value changes. It listens to `nodeChanged` by default; pass `listenerType: "treeChanged"` when the selector reads descendants.
+Use `useSelect` when a component needs a selected value or ordered dependency list from a Retree node and should only re-render when that selection changes. It listens to `nodeChanged` by default; pass `listenerType: "treeChanged"` when the selector reads descendants.
 
 ```tsx
 import { Retree } from "@retreejs/core";
@@ -233,6 +234,16 @@ function DoneCount() {
 
 project.tasks[0].done = true; // ✅ re-renders DoneCount: 1 -> 2
 project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
+```
+
+Selectors can also return ordered dependency lists. Reactive entries subscribe; primitive entries compare:
+
+```tsx
+const [, , attribute] = useSelect(row, (self) => [
+    self.attributes,
+    self.attributeId,
+    self.attribute,
+]);
 ```
 
 `useSelect` is a subscription primitive, not a memo cache. Use `memo`, `@memo`, or `@fnMemo` for expensive computation you want to cache, then select the cached value when you want narrower renders.
@@ -370,7 +381,7 @@ While `useTree` is powerful and can make things a lot easier, it is important to
 Retree performs best when components subscribe to the narrowest node or value they need:
 
 -   Prefer `useNode(child)` for item rows and focused panels.
--   Prefer `useSelect(node, selector)` for derived values that should only re-render when the selected result changes.
+-   Prefer `useSelect(node, selector)` for selected values or dependency lists that should only re-render when the selection changes.
 -   Treat `useTree` / `treeChanged` as broad subtree invalidation, especially in hot paths.
 -   Keep `ReactiveNode.dependencies` stable in length and order, with comparison values when only some dependency changes should emit.
 -   Avoid constructing large Retree roots or `ReactiveNode` graphs during React render; create them once, or initialize them through `useMemo` / `useState`.
@@ -387,8 +398,10 @@ Recent stable medium benchmark runs show the main direction of the architecture 
 
 The `ReactiveNode` class allows nodes in your tree to reactively update when their declared dependencies change. This offers a middleground between `useTree` and `useNode` that can be extremely powerful for minimizing re-renders in your application.
 
+Dependency arrays accept raw reactive nodes and primitives. Reactive nodes subscribe; primitives compare. Use `this.dependency(node, comparisons)` when one slot needs custom comparison values.
+
 ```tsx
-import { Retree, ReactiveNode } from "@retreejs/core";
+import { Retree, ReactiveNode, memo, select } from "@retreejs/core";
 import { useNode } from "@retreejs/react";
 
 class EvenCounter extends ReactiveNode {
@@ -399,13 +412,7 @@ class EvenCounter extends ReactiveNode {
     }
 
     get dependencies() {
-        return [
-            this.dependency(
-                this.numbers,
-                // Only emit when the derived value changes.
-                [this.evenNumberCount]
-            ),
-        ];
+        return [this.dependency(this.numbers, [this.evenNumberCount])];
     }
 }
 
@@ -418,6 +425,31 @@ function EvenBadge() {
 
 counter.numbers.push(2); // ✅ re-renders: evenNumberCount 0 -> 1
 counter.numbers.push(3); // ❌ no re-render: evenNumberCount stayed 1
+```
+
+Use `@select` when the dependency list belongs to a getter and `useNode(node)` should update only for that getter's selected dependencies:
+
+```ts
+import { ReactiveNode, memo, select } from "@retreejs/core";
+
+class AttributeRow extends ReactiveNode {
+    public attributes: { id: string; label: string }[] = [];
+    public attributeId!: string;
+
+    @memo((self: AttributeRow) => [self.attributes, self.attributeId])
+    private get _attribute() {
+        return this.attributes.find((check) => check.id === this.attributeId);
+    }
+
+    @select((self) => [
+        self.attributes,
+        self.attributeId,
+        self.dependency(self._attribute, [self._attribute?.id]),
+    ])
+    get attribute() {
+        return this._attribute;
+    }
+}
 ```
 
 ##### ReactiveNode lifecycle hooks
@@ -776,7 +808,7 @@ tree.todos.push(new Todo()); // ✅ nodeChanged, ✅ treeChanged
 tree.todos[0].toggle(); //    ❌ nodeChanged on list, ✅ treeChanged on list
 ```
 
-Use `Retree.select` when only one derived value matters:
+Use `Retree.select` when only one selected value or dependency list matters:
 
 ```ts
 const unsubscribeDoneCount = Retree.select(
@@ -789,6 +821,16 @@ const unsubscribeDoneCount = Retree.select(
 tree.todos[0].toggle(); // ✅ emits if done count changes
 tree.todos[0].text = "Docs"; // ❌ no emit if done count is unchanged
 unsubscribeDoneCount();
+```
+
+`Retree.select` also accepts ordered dependency lists. Reactive entries subscribe; primitive entries compare:
+
+```ts
+Retree.select(
+    row,
+    (self) => [self.attributes, self.attributeId, self.attribute],
+    ([, , attribute]) => console.log(attribute)
+);
 ```
 
 Use `Retree.move`, `Retree.link`, and `Retree.clone` to make ownership explicit:

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ const [, , attribute] = useSelect(row, (self) => [
 ]);
 ```
 
+Dependency-list subscriptions in `useSelect` are observational: selected dependency changes can re-render the component, but they do not force the node passed to `useSelect` to receive a fresh reproxy. Use `@select` when a `ReactiveNode` owner should emit `nodeChanged`.
+
 `useSelect` is a subscription primitive, not a memo cache. Use `memo`, `@memo`, or `@fnMemo` for expensive computation you want to cache, then select the cached value when you want narrower renders.
 
 #### useTree hook
@@ -383,7 +385,8 @@ Retree performs best when components subscribe to the narrowest node or value th
 -   Prefer `useNode(child)` for item rows and focused panels.
 -   Prefer `useSelect(node, selector)` for selected values or dependency lists that should only re-render when the selection changes.
 -   Treat `useTree` / `treeChanged` as broad subtree invalidation, especially in hot paths.
--   Keep `ReactiveNode.dependencies` stable in length and order, with comparison values when only some dependency changes should emit.
+-   Keep `ReactiveNode.dependencies` deterministic. Length/order can change; Retree treats shape changes as invalidation and refreshes subscriptions.
+-   Prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when the selected items or selected order changes.
 -   Avoid constructing large Retree roots or `ReactiveNode` graphs during React render; create them once, or initialize them through `useMemo` / `useState`.
 
 Large `ReactiveNode` object and array fields are prepared lazily. This improves initial setup, but the first nested read pays the preparation cost. Use `node.prepareTree({ depth })` or `super({ prepare: { autoPrepare: true, depth } })` if you want to pay that cost during a controlled loading phase.
@@ -832,6 +835,8 @@ Retree.select(
     ([, , attribute]) => console.log(attribute)
 );
 ```
+
+Dependency-list subscriptions in `Retree.select` are observational: selected dependency changes can call the callback, but they do not force the node passed to `Retree.select` to receive a fresh reproxy.
 
 Use `Retree.move`, `Retree.link`, and `Retree.clone` to make ownership explicit:
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ project.tasks[0].done = true; // ✅ re-renders DoneCount: 1 -> 2
 project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
 ```
 
+`useSelect` can also infer dependencies when you pass only a selector function. Whole Retree-managed values read by the selector subscribe automatically. Property reads subscribe to the owner node but compare the specific property value, so `task.done` reacts to task replacement or `done` changes without reacting to unrelated task fields. Primitive reads compare.
+
+```tsx
+const doneCount = useSelect(
+    () => project.tasks.filter((task) => task.done).length
+);
+```
+
 Selectors can also return ordered dependency lists. Reactive entries subscribe; primitive entries compare:
 
 ```tsx
@@ -431,6 +439,25 @@ counter.numbers.push(3); // ❌ no re-render: evenNumberCount stayed 1
 ```
 
 Use `@select` when the dependency list belongs to a getter and `useNode(node)` should update only for that getter's selected dependencies:
+
+```ts
+import { ReactiveNode, link, memo, select } from "@retreejs/core";
+
+class TaskRow extends ReactiveNode {
+    @link public task!: { isCompleted: boolean };
+    @link public filter!: { isComplete: boolean | null };
+
+    @select()
+    get isVisible() {
+        return (
+            this.filter.isComplete === null ||
+            this.task.isCompleted === this.filter.isComplete
+        );
+    }
+}
+```
+
+`@select()` without a selector traps dependencies while the getter runs. Whole Retree-managed values read by the getter subscribe; property reads subscribe to the owner node but compare the specific property value; primitive values read by the getter compare. Pass an explicit selector when you want to choose or customize dependency slots:
 
 ```ts
 import { ReactiveNode, memo, select } from "@retreejs/core";
@@ -824,6 +851,15 @@ const unsubscribeDoneCount = Retree.select(
 tree.todos[0].toggle(); // ✅ emits if done count changes
 tree.todos[0].text = "Docs"; // ❌ no emit if done count is unchanged
 unsubscribeDoneCount();
+```
+
+`Retree.select` can also infer dependencies when you pass only a selector function and callback:
+
+```ts
+Retree.select(
+    () => tree.todos.filter((todo) => todo.checked).length,
+    (doneCount) => console.log(doneCount)
+);
 ```
 
 `Retree.select` also accepts ordered dependency lists. Reactive entries subscribe; primitive entries compare:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The generated static site is written to `docs/` and ignored by Git. The docs bui
 -   [`Retree.clone`](#core-api-examples) makes a detached copy. Use it when two places need independent state.
 -   [`@select`](#reactivenode) decorates a getter with an ordered dependency list so VM logic can stay in the node while `useNode(node)` stays selective.
 -   [`ReactiveNode.dependencies`](#reactivenode) makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or wrap one slot with `this.dependency(node, comparisons)`.
--   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Use them to avoid recomputation; they do not emit changes by themselves.
+-   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Prefer bare decorators for automatic dependency trapping; pass comparison functions for finer cache-key control.
 -   [`@ignore`](#opt-fields-out-of-reactivity-with-ignore) keeps a field out of Retree emissions. Use it for caches, subscriptions, framework handles, and non-rendered state.
 -   [`Retree.runTransaction`](#transactions) batches synchronous writes into one listener flush per changed node.
 -   [`Retree.runSilent`](#skip-re-rendering-changes) performs writes without emitting listeners.
@@ -466,7 +466,7 @@ class AttributeRow extends ReactiveNode {
     public attributes: { id: string; label: string }[] = [];
     public attributeId!: string;
 
-    @memo((self: AttributeRow) => [self.attributes, self.attributeId])
+    @memo
     private get _attribute() {
         return this.attributes.find((check) => check.id === this.attributeId);
     }
@@ -546,14 +546,16 @@ class SearchNode extends ReactiveNode {
 
 `ReactiveNode` provides `memo` to cache the result of a getter, similar in spirit to React's `useMemo`. Use it to skip expensive recomputation when the values it depends on haven't changed.
 
-There are four ways to memoize: a keyless `this.memo(fn, deps?)` form (cleanest, when you want one cache per getter), an explicit-key `this.memo(key, fn, deps?)` form (for stacking multiple memos in one getter or memoizing inside a method), a `@memo` getter decorator form, and a `@fnMemo` method decorator form.
+The simplest path is to decorate computed getters and deterministic methods with `@memo` / `@fnMemo`. With no arguments, the decorator automatically traps the Retree reads inside the getter or method and invalidates the cache when those values change.
 
-##### `this.memo(fn, deps?)` (keyless, inside a getter)
+Pass a comparison function only when you want finer control over the cache keys, such as depending on a cheaper primitive instead of every value read by the computation. The method forms (`this.memo(fn, deps?)` and `this.memo(key, fn, deps?)`) are still available when a decorator does not fit the shape of the code.
 
-The cache key is derived from the active getter's name automatically. Throws if called outside a getter, or more than once in the same getter without an explicit key.
+##### `@memo` decorator (recommended for computed getters)
+
+The cache key is the getter's property name. Use `@memo` or `@memo()` with no comparisons for automatic dependency trapping.
 
 ```ts
-import { Retree, ReactiveNode } from "@retreejs/core";
+import { Retree, ReactiveNode, memo } from "@retreejs/core";
 
 interface Card {
     text: string;
@@ -563,11 +565,9 @@ class ListFilter extends ReactiveNode {
     public list: Card[] = [];
     public searchText = "";
 
+    @memo
     get filteredList(): Card[] {
-        return this.memo(
-            () => this.list.filter((c) => c.text === this.searchText),
-            [this.list, this.searchText]
-        );
+        return this.list.filter((c) => c.text === this.searchText);
     }
 
     get dependencies() {
@@ -576,18 +576,14 @@ class ListFilter extends ReactiveNode {
 }
 ```
 
-##### `@memo` decorator (one memo per getter, no body wrapping)
-
-The cache key is the getter's property name. Pass a function that returns the comparisons array — it's invoked with the current instance on every read, so the values are always live.
+Pass a comparison function when the automatic trapper is broader than you want:
 
 ```ts
-import { Retree, ReactiveNode } from "@retreejs/core";
-import { memo } from "@retreejs/core";
-
 class ListFilter extends ReactiveNode {
     public list: Card[] = [];
     public searchText = "";
 
+    // Only invalidate when the list identity/reproxy or search text changes.
     @memo((self: ListFilter) => [self.list, self.searchText])
     get filteredList(): Card[] {
         return this.list.filter((c) => c.text === this.searchText);
@@ -599,9 +595,9 @@ class ListFilter extends ReactiveNode {
 }
 ```
 
-##### `@fnMemo` decorator (one memo per method return value)
+##### `@fnMemo` decorator (recommended for deterministic methods)
 
-Use this when a method is deterministic for a given argument list plus optional dependencies. Method arguments are always shallow-compared, in addition to the `deps` function result. The `deps` function receives the current instance followed by the method arguments.
+Use this when a method is deterministic for a given argument list plus the Retree values it reads. Method arguments are always shallow-compared. Use `@fnMemo` or `@fnMemo()` with no comparisons for automatic dependency trapping.
 
 ```ts
 import { Retree, ReactiveNode, fnMemo } from "@retreejs/core";
@@ -610,11 +606,56 @@ class ListFilter extends ReactiveNode {
     public list: Card[] = [];
     public searchText = "";
 
-    @fnMemo((self: ListFilter) => [self.list, self.searchText])
+    @fnMemo
     public filteredList(limit: number): Card[] {
         return this.list
             .filter((c) => c.text === this.searchText)
             .slice(0, limit);
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+Pass a comparison function when you want to manually choose the cache keys. The function receives the current instance followed by the method arguments:
+
+```ts
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    @fnMemo((self: ListFilter, limit: number) => [
+        self.list,
+        self.searchText,
+        limit,
+    ])
+    public filteredList(limit: number): Card[] {
+        return this.list
+            .filter((c) => c.text === this.searchText)
+            .slice(0, limit);
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+##### `this.memo(fn, deps?)` (keyless, inside a getter)
+
+Use this when you want decorator-like cache behavior but need to wrap only part of a getter body. The cache key is derived from the active getter's name automatically. Throws if called outside a getter, or more than once in the same getter without an explicit key.
+
+```ts
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    get filteredList(): Card[] {
+        return this.memo(() =>
+            this.list.filter((c) => c.text === this.searchText)
+        );
     }
 
     get dependencies() {
@@ -648,15 +689,16 @@ class ListFilter extends ReactiveNode {
 }
 ```
 
-##### Cache semantics
+##### Cache Semantics
 
-The same `deps` rules apply to all forms. For `@fnMemo`, the method arguments are also compared every call:
+The same comparison rules apply to all forms. For `@fnMemo`, the method arguments are also compared every call:
 
-| `deps` argument | Behavior                                                                                                                                              |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `undefined`     | Recompute whenever the `ReactiveNode` reproxies (a property was set on it or one of its dependencies changed). Useful as a "compute once per render." |
-| `[]`            | Compute once and cache forever for that instance.                                                                                                     |
-| `[a, b, ...]`   | Recompute when any cell shallow-changes (compared with `Object.is`).                                                                                  |
+| Form / comparisons                                                             | Behavior                                                                                                                                              |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@memo`, `@memo()`, `@fnMemo`, `@fnMemo()`, or omitted `this.memo` comparisons | Automatically trap Retree reads and recompute when a trapped value changes.                                                                           |
+| Function returns `undefined`                                                   | Recompute whenever the `ReactiveNode` reproxies (a property was set on it or one of its dependencies changed). Useful as a "compute once per render." |
+| Function returns `[]`                                                          | Compute once and cache forever for that instance.                                                                                                     |
+| Function returns `[a, b, ...]`                                                 | Recompute when any cell shallow-changes (compared with `Object.is`).                                                                                  |
 
 **Tree-node cells in `deps` are compared by their latest reproxy identity, not by the stable buildProxy reference.** That's why `[this.list, this.searchText]` correctly invalidates when `list` mutates — without this, `this.list` would always look unchanged because Retree returns the same buildProxy for the lifetime of the tree.
 

--- a/README.md
+++ b/README.md
@@ -18,68 +18,25 @@ The generated static site is written to `docs/` and ignored by Git. The docs bui
 -   `@retreejs/react` provides React hooks for rendering Retree nodes.
 -   `@retreejs/convex` connects Convex queries, paginated queries, actions, mutations, and connection state to Retree nodes.
 
-## @retreejs/convex
+## Feature glossary
 
-Retree Convex lets a `ReactiveNode` own a Convex client, create typed query nodes with `this.query(...)`, run one-off queries with `this.queryOnce(...)`, call actions and mutations, subscribe to paginated queries, and track connection state. Query results are written into Retree state, Convex document arrays are reconciled by `_id` by default, and optimistic updates can be applied narrowly to existing query state.
-
-### How to install
-
-Install with `npm`:
-
-```bash
-npm i @retreejs/core @retreejs/convex convex
-```
-
-Install with `yarn`:
-
-```bash
-yarn add @retreejs/core @retreejs/convex convex
-```
-
-### How to use
-
-```ts
-import { ConvexNode, ConvexQueryNode } from "@retreejs/convex";
-import { ConvexClient } from "convex/browser";
-import { api } from "../convex/_generated/api";
-import { Id } from "../convex/_generated/dataModel";
-
-class TasksState extends ConvexNode {
-    public readonly tasks: ConvexQueryNode<typeof api.tasks.get>;
-
-    constructor(convexUrl: string) {
-        const client = new ConvexClient(convexUrl);
-        super(client);
-        this.tasks = this.query(api.tasks.get);
-    }
-
-    get dependencies() {
-        return [];
-    }
-
-    public toggleCompleted(taskId: Id<"tasks">): Promise<null> {
-        const toggleCompleted = this.mutation(api.tasks.toggleCompleted);
-        return toggleCompleted(
-            { taskId },
-            {
-                withOptimisticUpdate: (ctx) => {
-                    this.tasks.optimisticUpdate({
-                        ctx,
-                        apply(tasks) {
-                            const task = tasks.find((candidateTask) => {
-                                return candidateTask._id === taskId;
-                            });
-                            if (!task) return;
-
-                            task.isCompleted = !task.isCompleted;
-                        },
-                    });
-                },
-            }
-        );
-    }
-}
-```
+-   [`Retree.root`](#retreejscore) makes one object the root of a Retree-managed tree. Use it once where plain state enters Retree.
+-   [`useRoot`](#useroot-hook) creates one Retree root for a React component lifetime. Use it when state belongs to a React subtree.
+-   [`useNode`](#usenode-hook) re-renders a React component for direct `nodeChanged` events on one node. Use it for rows, panels, forms, and focused child components.
+-   [`useTree`](#usetree-hook) re-renders for `treeChanged` events from a node or any descendant. Use it sparingly for small subtrees that truly need broad invalidation.
+-   [`useSelect`](#useselect-hook) re-renders only when a selected derived value changes. Use it for counts, totals, booleans, and other narrow projections.
+-   [`Retree.on`](#core-api-examples) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
+-   [`Retree.select`](#core-api-examples) is the non-React version of `useSelect`. Use it to narrow notifications; it is not a cache.
+-   [`Retree.parent`](#core-api-examples) returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+-   [`Retree.move`](#core-api-examples) transfers an existing node to a new structural parent. Use it when ownership should change.
+-   [`Retree.link` and `@link`](#core-api-examples) store a reactive pointer without reparenting. Use them for selected items and cross-references.
+-   [`Retree.clone`](#core-api-examples) makes a detached copy. Use it when two places need independent state.
+-   [`ReactiveNode.dependencies`](#reactivenode) makes one node emit when another node changes. Use it as a narrow bridge instead of a broad `treeChanged` subscription.
+-   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Use them to avoid recomputation; they do not emit changes by themselves.
+-   [`@ignore`](#opt-fields-out-of-reactivity-with-ignore) keeps a field out of Retree emissions. Use it for caches, subscriptions, framework handles, and non-rendered state.
+-   [`Retree.runTransaction`](#transactions) batches synchronous writes into one listener flush per changed node.
+-   [`Retree.runSilent`](#skip-re-rendering-changes) performs writes without emitting listeners.
+-   [`ReactiveNode.prepareTree`](#core-api-examples) warms lazy child proxies during a controlled phase.
 
 ## @retreejs/react
 
@@ -101,7 +58,24 @@ yarn add @retreejs/core @retreejs/react
 
 ### How to use
 
-It's extremely easy to get started with Retree. There are two React hooks: `useNode` and `useTree`. Each have specific advantages while leveraging the same simple interface.
+It's extremely easy to get started with Retree. The main React hooks are `useNode`, `useTree`, `useSelect`, and `useRoot`. Each has specific advantages while leveraging the same simple interface.
+
+#### useRoot hook
+
+Use `useRoot` when a component should create and retain its own Retree root. The factory runs once for the component lifetime.
+
+```tsx
+import { useNode, useRoot } from "@retreejs/react";
+
+function CounterPanel() {
+    const counter = useRoot(() => ({ count: 0 }));
+    const state = useNode(counter);
+
+    return <button onClick={() => (state.count += 1)}>{state.count}</button>;
+}
+```
+
+`useRoot` creates the root; `useNode`, `useTree`, or `useSelect` decide what causes the component to re-render.
 
 #### useNode hook
 
@@ -134,7 +108,7 @@ class Todo {
     }
 }
 
-// Todo React component that acceps a Todo object as a prop
+// Todo React component that accepts a Todo object as a prop
 function _ViewTodo({ todo }) {
     // Make todo stateful. Changes to todo will only re-render this component.
     const _todo = useNode(todo);
@@ -232,6 +206,37 @@ whiteboardRoot.shapes.push({ type: "circle" });
 
 This is ideal in cases when you want to use child nodes as props into other child components, such as a `<ViewTodo todo={todo} />`. This ensures that state changes to each individual item in the list won't trigger re-renders of its parent. When using `memo` components or the new React compiler, this also means irrelevant changes to parent nodes won't re-render items in the list.
 
+#### useSelect hook
+
+Use `useSelect` when a component needs one derived value from a Retree node and should only re-render when that value changes. It listens to `nodeChanged` by default; pass `listenerType: "treeChanged"` when the selector reads descendants.
+
+```tsx
+import { Retree } from "@retreejs/core";
+import { useSelect } from "@retreejs/react";
+
+const project = Retree.root({
+    tasks: [
+        { title: "Docs", done: false },
+        { title: "Tests", done: true },
+    ],
+});
+
+function DoneCount() {
+    const doneCount = useSelect(
+        project.tasks,
+        (tasks) => tasks.filter((task) => task.done).length,
+        { listenerType: "treeChanged" }
+    );
+
+    return <span>{doneCount}</span>;
+}
+
+project.tasks[0].done = true; // ✅ re-renders DoneCount: 1 -> 2
+project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
+```
+
+`useSelect` is a subscription primitive, not a memo cache. Use `memo`, `@memo`, or `@fnMemo` for expensive computation you want to cache, then select the cached value when you want narrower renders.
+
 #### useTree hook
 
 In some cases it might be desirable to get re-renders for all child nodes at a given point in your object tree. In such cases, it can be impractical to put each child node in `useNode`. Fortunately, `useTree` makes this very simple.
@@ -264,7 +269,7 @@ function Headers({ headers }) {
 }
 
 function Row({ row }) {
-    // In this simple case, `useNode` and `useTree` can be used interchangably.
+    // In this simple case, `useNode` and `useTree` can be used interchangeably.
     const rowState = useNode(row);
     return (
         <tr>
@@ -382,43 +387,37 @@ Recent stable medium benchmark runs show the main direction of the architecture 
 
 The `ReactiveNode` class allows nodes in your tree to reactively update when their declared dependencies change. This offers a middleground between `useTree` and `useNode` that can be extremely powerful for minimizing re-renders in your application.
 
-```ts
-import { Retree, ReactiveNode } from "@retree/core";
-import { useNode } from "@retree/core";
-// Declare a class that extends `ReactiveNode`
-class Node extends ReactiveNode {
-    numbers: number[] = [];
-    constructor() {
-        super();
-    }
-    // Get count of even numbers in the list
+```tsx
+import { Retree, ReactiveNode } from "@retreejs/core";
+import { useNode } from "@retreejs/react";
+
+class EvenCounter extends ReactiveNode {
+    public numbers: number[] = [];
+
     get evenNumberCount(): number {
         return this.numbers.filter((number) => number % 2 === 0).length;
     }
-    // Implement abstract `dependencies` getter with list of dependencies
+
     get dependencies() {
         return [
-            // Similar to React, dependencies cannot change in length or order between updates.
             this.dependency(
-                // The dependency node to listen to changes for.
                 this.numbers,
-                // Optional comparison dependencies so that only specific changes cause `Node` instances to updates.
-                // If not provided, all changes to `this.numbers` would cause `Node` instances to update.
+                // Only emit when the derived value changes.
                 [this.evenNumberCount]
             ),
         ];
     }
 }
-// Create root `ReactiveNode` instance and listen for changes in `useNode`
-const node = Retree.root(new Node());
-const nodeState = useNode(node);
 
-// ✅ Will re-render
-node.list.push(2);
-node.list.push(100);
-// ❌ Will not re-render
-node.list.push(3);
-node.list.push(99);
+const counter = Retree.root(new EvenCounter());
+
+function EvenBadge() {
+    const state = useNode(counter);
+    return <span>{state.evenNumberCount}</span>;
+}
+
+counter.numbers.push(2); // ✅ re-renders: evenNumberCount 0 -> 1
+counter.numbers.push(3); // ❌ no re-render: evenNumberCount stayed 1
 ```
 
 ##### ReactiveNode lifecycle hooks
@@ -672,7 +671,7 @@ If you are making multiple changes to one or many nodes at once, you can use `Re
 ```ts
 const _counter = Retree.root({ count: 0 });
 const counter = useNode(_counter);
-// Will only emit "valueChanged" once
+// Will only emit "nodeChanged" once
 Retree.runTransaction(() => {
     counter.count = counter.count + 1;
     counter.count = counter.count * 2;
@@ -687,7 +686,7 @@ If you want to skip re-rendering on a change, you can use the `Retree.runSilent`
 const counter = Retree.root({ count: 0, multiplier: 1 });
 const counterState = useNode(counter);
 // Skip re-render on setting the multiplier
-function onClickIncrementMultipler() {
+function onClickIncrementMultiplier() {
     Retree.runSilent(() => {
         counterState.multiplier += 1;
     });
@@ -757,15 +756,141 @@ const tree = Retree.root(new TodoList());
 const unsubscribe = Retree.on(tree.todos, "treeChanged", (todos) => {
     console.log("list updated", todos);
 });
-tree.todos.add();
+tree.add();
 tree.todos[0].toggle();
 tree.todos[0].delete();
 unsubscribe();
 ```
 
+### Core API examples
+
+Use `Retree.on` when you need events outside React:
+
+```ts
+Retree.on(tree.todos, "nodeChanged", () => console.log("list changed"));
+Retree.on(tree.todos, "treeChanged", () =>
+    console.log("list or child changed")
+);
+
+tree.todos.push(new Todo()); // ✅ nodeChanged, ✅ treeChanged
+tree.todos[0].toggle(); //    ❌ nodeChanged on list, ✅ treeChanged on list
+```
+
+Use `Retree.select` when only one derived value matters:
+
+```ts
+const unsubscribeDoneCount = Retree.select(
+    tree.todos,
+    (todos) => todos.filter((todo) => todo.checked).length,
+    (doneCount) => console.log(doneCount),
+    { listenerType: "treeChanged" }
+);
+
+tree.todos[0].toggle(); // ✅ emits if done count changes
+tree.todos[0].text = "Docs"; // ❌ no emit if done count is unchanged
+unsubscribeDoneCount();
+```
+
+Use `Retree.move`, `Retree.link`, and `Retree.clone` to make ownership explicit:
+
+```ts
+const task = projectA.tasks[0];
+
+Retree.move(task, projectB.tasks); // ✅ transfers ownership
+projectA.selected = Retree.link(task); // ✅ points at task without reparenting
+projectA.tasks.push(Retree.clone(task)); // ✅ independent copy
+```
+
+Use `Retree.parent` for tree-local operations:
+
+```ts
+const parent = Retree.parent(tree.todos[0]);
+if (Array.isArray(parent)) {
+    parent.splice(0, 1); // ✅ removes the task and emits on the parent list
+}
+```
+
+Use `ReactiveNode.prepareTree` when you want lazy child proxy setup to happen before first render or first interaction:
+
+```ts
+class ProjectState extends ReactiveNode {
+    public tasks = [{ title: "Docs", comments: [] }];
+
+    get dependencies() {
+        return [];
+    }
+}
+
+const root = Retree.root(new ProjectState());
+root.prepareTree({ depth: 1 });
+```
+
 ### Core samples
 
 See the [useNode React hook](https://github.com/ryanbliss/retree/blob/main/packages/retree-react/src/useNode.ts) or [example 01 project](https://github.com/ryanbliss/retree/tree/main/samples/01.core-example) for more example usages.
+
+## @retreejs/convex
+
+Retree Convex lets a `ReactiveNode` own a Convex client, create typed query nodes with `this.query(...)`, run one-off queries with `this.queryOnce(...)`, call actions and mutations, subscribe to paginated queries, and track connection state. Query results are written into Retree state, Convex document arrays are reconciled by `_id` by default, and optimistic updates can be applied narrowly to existing query state.
+
+### How to install
+
+Install with `npm`:
+
+```bash
+npm i @retreejs/core @retreejs/convex convex
+```
+
+Install with `yarn`:
+
+```bash
+yarn add @retreejs/core @retreejs/convex convex
+```
+
+### How to use
+
+```ts
+import { ConvexNode, ConvexQueryNode } from "@retreejs/convex";
+import { ConvexClient } from "convex/browser";
+import { api } from "../convex/_generated/api";
+import { Id } from "../convex/_generated/dataModel";
+
+class TasksState extends ConvexNode {
+    public readonly tasks: ConvexQueryNode<typeof api.tasks.get>;
+
+    constructor(convexUrl: string) {
+        const client = new ConvexClient(convexUrl);
+        super(client);
+        this.tasks = this.query(api.tasks.get);
+    }
+
+    get dependencies() {
+        return [];
+    }
+
+    public toggleCompleted(taskId: Id<"tasks">): Promise<null> {
+        const toggleCompleted = this.mutation(api.tasks.toggleCompleted);
+        return toggleCompleted(
+            { taskId },
+            {
+                withOptimisticUpdate: (ctx) => {
+                    this.tasks.optimisticUpdate({
+                        ctx,
+                        apply(tasks) {
+                            const task = tasks.find((candidateTask) => {
+                                return candidateTask._id === taskId;
+                            });
+                            if (!task) return;
+
+                            task.isCompleted = !task.isCompleted;
+                        },
+                    });
+                },
+            }
+        );
+    }
+}
+```
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -601,6 +601,33 @@ The same `deps` rules apply to all forms. For `@fnMemo`, the method arguments ar
 
 The cache is per-instance and stored in a `WeakMap` keyed by the unproxied `ReactiveNode`, so it follows the instance's lifetime and is naturally garbage-collected when the node is dropped.
 
+#### Move, link, or clone existing nodes
+
+Retree keeps a pure ownership tree: a node can have one structural parent. If an existing node needs to appear somewhere else, choose the operation that matches your intent.
+
+-   `Retree.move(node, destination, key?)` transfers ownership. Arrays accept a numeric insertion index or append when omitted. Maps and objects require a key. Sets ignore the key.
+-   `Retree.link(node)` creates a reactive pointer object with `.current`. The link can be stored in the tree without reparenting the target.
+-   `@link` marks a `ReactiveNode` field as a reactive pointer. Replacing the field emits on the owner, but the assigned node keeps its existing parent.
+-   `Retree.clone(node)` creates a detached copy that can become a new child elsewhere.
+
+```ts
+import { Retree, ReactiveNode, link } from "@retreejs/core";
+
+const task = projectA.tasks[0];
+Retree.move(task, projectB.tasks);
+
+root.selectedTask = Retree.link(task);
+root.selectedTask.current.title = "Selected";
+
+class EditorState extends ReactiveNode {
+    @link public selectedTask: Task | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+```
+
 #### Opt fields out of reactivity with `@ignore`
 
 `@ignore` is a class-field decorator that excludes a property of a `ReactiveNode` from Retree's reactivity system. Reads and writes to the field still work normally — what's skipped is **listener emission**:
@@ -636,7 +663,7 @@ node.cache = { other: 2 };
 node.count += 1;
 ```
 
-**Caveat:** because the proxy doesn't wrap an `@ignore`-d field's value, you also lose `Retree.parent(...)` for objects stored under it, and they won't appear in `treeChanged` notifications. Treat ignored fields as opaque from Retree's perspective.
+**Caveat:** because the proxy doesn't wrap an `@ignore`-d field's value, plain objects stored under it lose `Retree.parent(...)` and won't appear in `treeChanged` notifications. If you store an existing Retree-managed node in an ignored field, Retree does not reparent it, but reads still return that node's latest reproxy.
 
 #### Transactions
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,7 +15,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DO create one Retree root at the state boundary with `Retree.root(...)` or React's `useRoot(...)`.
 - DO mutate Retree-managed objects directly (`node.title = "New"`, `list.push(item)`) instead of replacing whole app state objects.
 - DO subscribe as narrowly as possible: prefer `useNode(child)` or `Retree.on(child, "nodeChanged", ...)` for focused UI and hot paths.
-- DO use `useSelect(...)`, `Retree.select(...)`, or `@select` for ordered dependency lists. Reactive entries are subscribed to; primitive entries are compared.
+- DO use `useSelect(...)`, `Retree.select(...)`, or `@select` for ordered dependency lists. Reactive entries are subscribed to; primitive entries are compared. Use `useSelect(() => ...)`, `Retree.select(() => ..., callback)`, or `@select()` when a selector/getter should trap reads automatically. Whole node reads subscribe broadly; property reads subscribe to the owner and compare that property value.
 - DO pass `listenerType: "treeChanged"` to `useSelect(...)` / `Retree.select(...)` when the selector reads descendant nodes.
 - DO use `Retree.move(...)` or `node.moveTo(...)` when an existing node should move to a new structural parent.
 - DO use `Retree.link(...)` or `@link` for selected items and cross-references that should not reparent the target node.
@@ -40,6 +40,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DON'T use `useTree(...)` on broad app roots by default. It subscribes to descendant changes and can re-render too much.
 - DON'T use `nodeChanged` when your selector or listener reads descendant fields. Use `treeChanged` or subscribe to the narrower child node.
 - DON'T expect `useSelect(...)` or `Retree.select(...)` dependency lists to reproxy the node passed to the selector. They are observational; use `@select` when a `ReactiveNode` owner should emit.
+- DON'T pass selector-only `useSelect(() => ...)` or `Retree.select(() => ..., callback)` when you need a fixed root listener with `listenerType: "treeChanged"`. The selector-only forms trap Retree-managed reads and subscribe to those nodes automatically.
 - DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
 - DON'T rely on dependency reordering being silent. If `ReactiveNode.dependencies` or `@select` entries are added, removed, or reordered, Retree treats that as changed and emits when the owner is observed.
 - DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
@@ -55,12 +56,12 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 
 - `Retree.root`: Makes one object the root of a Retree-managed tree. Use it once where plain state enters Retree.
 - `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
-- `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use it to narrow notifications; it is not a cache.
+- `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use `Retree.select(node, selector, callback)` for an explicit root, or `Retree.select(() => value, callback)` for automatic dependency trapping. It is not a cache.
 - `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
 - `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
 - `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
 - `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
-- `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use it when VM logic should stay in the node but `useNode(node)` should re-render only for selected dependencies.
+- `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use `@select()` with no selector for MobX-style dependency trapping: whole Retree-managed values read by the getter subscribe broadly, property reads subscribe to the owner and compare that property value, and primitive values read by the getter compare. Pass `@select((self) => [...])` when you want explicit dependency slots.
 - `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Dynamic dependency arrays are allowed; shape changes emit and refresh subscriptions.
 - `ReactiveNode.memo`, `@memo`, and `@fnMemo`: Cache computed values. They do not emit `nodeChanged` or trigger React renders by themselves.
 - `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
@@ -70,7 +71,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - `useRoot`: Creates one Retree root for a React component lifetime.
 - `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
 - `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
-- `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use it for counts, totals, booleans, labels, and VM dependency arrays.
+- `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use `useSelect(node, selector)` for an explicit root, or `useSelect(() => value)` for automatic dependency trapping. Good for counts, totals, booleans, labels, and VM dependency arrays.
 - `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
 - `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
 - `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.

--- a/llms.txt
+++ b/llms.txt
@@ -15,19 +15,20 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DO create one Retree root at the state boundary with `Retree.root(...)` or React's `useRoot(...)`.
 - DO mutate Retree-managed objects directly (`node.title = "New"`, `list.push(item)`) instead of replacing whole app state objects.
 - DO subscribe as narrowly as possible: prefer `useNode(child)` or `Retree.on(child, "nodeChanged", ...)` for focused UI and hot paths.
-- DO use `useSelect(...)` or `Retree.select(...)` for derived counts, totals, booleans, labels, and other values that should only update when the selected result changes.
+- DO use `useSelect(...)`, `Retree.select(...)`, or `@select` for ordered dependency lists. Reactive entries are subscribed to; primitive entries are compared.
 - DO pass `listenerType: "treeChanged"` to `useSelect(...)` / `Retree.select(...)` when the selector reads descendant nodes.
 - DO use `Retree.move(...)` or `node.moveTo(...)` when an existing node should move to a new structural parent.
 - DO use `Retree.link(...)` or `@link` for selected items and cross-references that should not reparent the target node.
 - DO use `Retree.clone(...)` when two places need independent copies of the same current data.
-- DO keep `ReactiveNode.dependencies` arrays stable in length and order; use `null` for inactive dependency slots.
-- DO use comparison values in `ReactiveNode.dependencies` when only some dependency changes should emit.
+- DO keep `ReactiveNode.dependencies` and `@select` arrays stable in length and order; use `null` for inactive dependency slots.
+- DO return raw reactive nodes and primitives directly from `ReactiveNode.dependencies`; wrap a slot with `this.dependency(node, comparisons)` when you need custom comparison cells.
 - DO use `memo`, `@memo`, or `@fnMemo` to cache expensive computation, then use `select` / `useSelect` to narrow notifications.
 - DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
 - DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
 - DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
 - DO dispose Convex query, paginated query, and connection-state nodes when their owner is torn down.
 - DO reconcile server list results by stable IDs (`reconcileConvexDocuments`, `reconcileArrayById`) so child node identity stays stable.
+- DO set the lowest-level value and/or primitive that changed.
 
 ### DON'T
 
@@ -38,7 +39,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DON'T use `useTree(...)` on broad app roots by default. It subscribes to descendant changes and can re-render too much.
 - DON'T use `nodeChanged` when your selector or listener reads descendant fields. Use `treeChanged` or subscribe to the narrower child node.
 - DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
-- DON'T change the number or ordering of `ReactiveNode.dependencies` entries after a node is observed.
+- DON'T change the number or ordering of `ReactiveNode.dependencies` or `@select` entries after a node is observed.
 - DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
 - DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
 - DON'T call `Retree.parent(...)`, `Retree.on(...)`, `Retree.move(...)`, `Retree.link(...)`, or `Retree.clone(...)` with plain unrooted objects.
@@ -46,17 +47,19 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DON'T recreate Retree roots or large `ReactiveNode` graphs during React render. Create them once, or use `useRoot`, `useMemo`, or `useState` initialization.
 - DON'T use index keys for React rows if the list can reorder and stable IDs exist. Stable keys pair best with Retree's child-node identity model.
 - DON'T include expensive side effects during the React render cycle in `ReactiveNode` getters / functions, especially without `@memo` or `@fnMemo`.
+- DON'T recreate object trees with spread operators like you would in React (those sorts of hacks are "why" Retree exists in the first place).
 
 ## Feature Glossary
 
 - `Retree.root`: Makes one object the root of a Retree-managed tree. Use it once where plain state enters Retree.
 - `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
-- `Retree.select`: Subscribes to one derived value and only calls back when that value changes. Use it to narrow notifications; it is not a cache.
+- `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use it to narrow notifications; it is not a cache.
 - `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
 - `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
 - `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
 - `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
-- `ReactiveNode.dependencies`: Makes one node emit when another node changes. Keep dependency array length and order stable; use it as a narrow bridge instead of broad subtree subscriptions.
+- `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use it when VM logic should stay in the node but `useNode(node)` should re-render only for selected dependencies.
+- `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Keep dependency array length and order stable.
 - `ReactiveNode.memo`, `@memo`, and `@fnMemo`: Cache computed values. They do not emit `nodeChanged` or trigger React renders by themselves.
 - `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
 - `Retree.runTransaction`: Batches synchronous writes into one listener flush per changed node.
@@ -65,7 +68,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - `useRoot`: Creates one Retree root for a React component lifetime.
 - `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
 - `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
-- `useSelect`: Re-renders only when a selected derived value changes. Use it for counts, totals, booleans, and labels.
+- `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use it for counts, totals, booleans, labels, and VM dependency arrays.
 - `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
 - `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
 - `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,76 @@
 
 Retree is published as `@retreejs/core`, `@retreejs/react`, and `@retreejs/convex`. Use the links below for installation, API reference, reactivity behavior, React hook behavior, Convex query behavior, and runnable sample apps.
 
+## Recommendation for agents
+
+Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Repository README](https://github.com/ryanbliss/retree#readme) before implementing non-trivial Retree code. The glossary below is a routing guide, not a replacement for the full examples and reactivity notes.
+
+## Quick DOs and DON'Ts
+
+### DO
+
+- DO create one Retree root at the state boundary with `Retree.root(...)` or React's `useRoot(...)`.
+- DO mutate Retree-managed objects directly (`node.title = "New"`, `list.push(item)`) instead of replacing whole app state objects.
+- DO subscribe as narrowly as possible: prefer `useNode(child)` or `Retree.on(child, "nodeChanged", ...)` for focused UI and hot paths.
+- DO use `useSelect(...)` or `Retree.select(...)` for derived counts, totals, booleans, labels, and other values that should only update when the selected result changes.
+- DO pass `listenerType: "treeChanged"` to `useSelect(...)` / `Retree.select(...)` when the selector reads descendant nodes.
+- DO use `Retree.move(...)` or `node.moveTo(...)` when an existing node should move to a new structural parent.
+- DO use `Retree.link(...)` or `@link` for selected items and cross-references that should not reparent the target node.
+- DO use `Retree.clone(...)` when two places need independent copies of the same current data.
+- DO keep `ReactiveNode.dependencies` arrays stable in length and order; use `null` for inactive dependency slots.
+- DO use comparison values in `ReactiveNode.dependencies` when only some dependency changes should emit.
+- DO use `memo`, `@memo`, or `@fnMemo` to cache expensive computation, then use `select` / `useSelect` to narrow notifications.
+- DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
+- DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
+- DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
+- DO dispose Convex query, paginated query, and connection-state nodes when their owner is torn down.
+- DO reconcile server list results by stable IDs (`reconcileConvexDocuments`, `reconcileArrayById`) so child node identity stays stable.
+
+### DON'T
+
+- DON'T assign the same Retree-managed object into a second structural parent. Retree is a pure tree: a node can have one structural parent.
+- DON'T use `@ignore` as a reactive reference mechanism. Ignored fields skip Retree emissions; use `@link` or `Retree.link(...)` for reactive pointers.
+- DON'T expect `Retree.link(...)` / `@link` to make the linked target a child of the owner. Links point to a node owned elsewhere.
+- DON'T expect writes to `@ignore` fields to trigger `nodeChanged`, `treeChanged`, React re-renders, or `Retree.parent(...)` for nested plain objects.
+- DON'T use `useTree(...)` on broad app roots by default. It subscribes to descendant changes and can re-render too much.
+- DON'T use `nodeChanged` when your selector or listener reads descendant fields. Use `treeChanged` or subscribe to the narrower child node.
+- DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
+- DON'T change the number or ordering of `ReactiveNode.dependencies` entries after a node is observed.
+- DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
+- DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
+- DON'T call `Retree.parent(...)`, `Retree.on(...)`, `Retree.move(...)`, `Retree.link(...)`, or `Retree.clone(...)` with plain unrooted objects.
+- DON'T expect Convex `action(...)`, `mutation(...)`, or `queryOnce(...)` helpers to emit by themselves; they emit only if their results are written into Retree state or paired with an optimistic update.
+- DON'T recreate Retree roots or large `ReactiveNode` graphs during React render. Create them once, or use `useRoot`, `useMemo`, or `useState` initialization.
+- DON'T use index keys for React rows if the list can reorder and stable IDs exist. Stable keys pair best with Retree's child-node identity model.
+- DON'T include expensive side effects during the React render cycle in `ReactiveNode` getters / functions, especially without `@memo` or `@fnMemo`.
+
+## Feature Glossary
+
+- `Retree.root`: Makes one object the root of a Retree-managed tree. Use it once where plain state enters Retree.
+- `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
+- `Retree.select`: Subscribes to one derived value and only calls back when that value changes. Use it to narrow notifications; it is not a cache.
+- `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+- `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
+- `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
+- `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
+- `ReactiveNode.dependencies`: Makes one node emit when another node changes. Keep dependency array length and order stable; use it as a narrow bridge instead of broad subtree subscriptions.
+- `ReactiveNode.memo`, `@memo`, and `@fnMemo`: Cache computed values. They do not emit `nodeChanged` or trigger React renders by themselves.
+- `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
+- `Retree.runTransaction`: Batches synchronous writes into one listener flush per changed node.
+- `Retree.runSilent`: Performs writes without emitting listeners. Use it for non-rendered bookkeeping.
+- `ReactiveNode.prepareTree`: Warms lazy child proxies. Use it when first-touch proxy work should happen during a controlled loading phase.
+- `useRoot`: Creates one Retree root for a React component lifetime.
+- `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
+- `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
+- `useSelect`: Re-renders only when a selected derived value changes. Use it for counts, totals, booleans, and labels.
+- `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
+- `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
+- `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.
+- `ConvexPaginatedQueryNode`: Stores one live paginated Convex query and exposes `loadMore(...)`.
+- `ConvexConnectionStateNode`: Stores the Convex client's connection state in Retree state.
+- `createRetreeConvexAction` and `createRetreeConvexMutation`: Typed standalone Convex helpers for code that is not inside a `BaseConvexNode`.
+- `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow.
+
 ## Documentation
 
 - [Retree Docs Home](https://ryanbliss.github.io/retree/): Generated TypeDoc site with package navigation, README content, and API reference.
@@ -17,6 +87,8 @@ Retree is published as `@retreejs/core`, `@retreejs/react`, and `@retreejs/conve
 - [@retreejs/core API](https://ryanbliss.github.io/retree/modules/_retreejs_core.html): Core exports including `Retree`, `ReactiveNode`, event types, decorators, and memo helpers.
 - [Retree class](https://ryanbliss.github.io/retree/classes/_retreejs_core.Retree.html): Static APIs for creating roots, subscribing to changes, finding parents, and batching/silencing updates.
 - [ReactiveNode class](https://ryanbliss.github.io/retree/classes/_retreejs_core.ReactiveNode.html): Base class for derived dependencies, dependency comparison, and memoized computed values.
+- [Core README ownership section](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#move-link-or-clone-existing-nodes): Examples for `Retree.move`, `Retree.link`, `@link`, `ReactiveNode.moveTo`, and `Retree.clone`.
+- [Core README select section](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#select-derived-values): Examples for `Retree.select`, including when to use `listenerType: "treeChanged"`.
 - [@retreejs/react API](https://ryanbliss.github.io/retree/modules/_retreejs_react.html): React exports for stateful Retree nodes and trees.
 - [useNode](https://ryanbliss.github.io/retree/functions/_retreejs_react.useNode.html): React hook for subscribing to direct node changes with fine-grained re-rendering.
 - [useTree](https://ryanbliss.github.io/retree/functions/_retreejs_react.useTree.html): React hook for subscribing to node and descendant-tree changes.

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DO keep `ReactiveNode.dependencies` and `@select` arrays deterministic when possible. Length/order may change at runtime; Retree treats that as an invalidation and refreshes subscriptions.
 - DO return raw reactive nodes and primitives directly from `ReactiveNode.dependencies`; wrap a slot with `this.dependency(node, comparisons)` when you need custom comparison cells.
 - DO prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when selected items or selected order changes.
-- DO use `memo`, `@memo`, or `@fnMemo` to cache expensive computation, then use `select` / `useSelect` to narrow notifications.
+- DO prefer bare `@memo` / `@fnMemo` for cached computed getters and deterministic methods; pass comparison functions only when you need finer cache-key control.
 - DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
 - DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
 - DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
@@ -63,7 +63,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
 - `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use `@select()` with no selector for MobX-style dependency trapping: whole Retree-managed values read by the getter subscribe broadly, property reads subscribe to the owner and compare that property value, and primitive values read by the getter compare. Pass `@select((self) => [...])` when you want explicit dependency slots.
 - `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Dynamic dependency arrays are allowed; shape changes emit and refresh subscriptions.
-- `ReactiveNode.memo`, `@memo`, and `@fnMemo`: Cache computed values. They do not emit `nodeChanged` or trigger React renders by themselves.
+- `ReactiveNode.memo`, `@memo`, `@memo()`, `@fnMemo`, and `@fnMemo()`: Cache computed values. Prefer bare/empty decorator forms for automatic dependency trapping; pass comparison functions for finer cache-key control. They do not emit `nodeChanged` or trigger React renders by themselves.
 - `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
 - `Retree.runTransaction`: Batches synchronous writes into one listener flush per changed node.
 - `Retree.runSilent`: Performs writes without emitting listeners. Use it for non-rendered bookkeeping.

--- a/llms.txt
+++ b/llms.txt
@@ -20,8 +20,9 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DO use `Retree.move(...)` or `node.moveTo(...)` when an existing node should move to a new structural parent.
 - DO use `Retree.link(...)` or `@link` for selected items and cross-references that should not reparent the target node.
 - DO use `Retree.clone(...)` when two places need independent copies of the same current data.
-- DO keep `ReactiveNode.dependencies` and `@select` arrays stable in length and order; use `null` for inactive dependency slots.
+- DO keep `ReactiveNode.dependencies` and `@select` arrays deterministic when possible. Length/order may change at runtime; Retree treats that as an invalidation and refreshes subscriptions.
 - DO return raw reactive nodes and primitives directly from `ReactiveNode.dependencies`; wrap a slot with `this.dependency(node, comparisons)` when you need custom comparison cells.
+- DO prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when selected items or selected order changes.
 - DO use `memo`, `@memo`, or `@fnMemo` to cache expensive computation, then use `select` / `useSelect` to narrow notifications.
 - DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
 - DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
@@ -38,8 +39,9 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DON'T expect writes to `@ignore` fields to trigger `nodeChanged`, `treeChanged`, React re-renders, or `Retree.parent(...)` for nested plain objects.
 - DON'T use `useTree(...)` on broad app roots by default. It subscribes to descendant changes and can re-render too much.
 - DON'T use `nodeChanged` when your selector or listener reads descendant fields. Use `treeChanged` or subscribe to the narrower child node.
+- DON'T expect `useSelect(...)` or `Retree.select(...)` dependency lists to reproxy the node passed to the selector. They are observational; use `@select` when a `ReactiveNode` owner should emit.
 - DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
-- DON'T change the number or ordering of `ReactiveNode.dependencies` or `@select` entries after a node is observed.
+- DON'T rely on dependency reordering being silent. If `ReactiveNode.dependencies` or `@select` entries are added, removed, or reordered, Retree treats that as changed and emits when the owner is observed.
 - DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
 - DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
 - DON'T call `Retree.parent(...)`, `Retree.on(...)`, `Retree.move(...)`, `Retree.link(...)`, or `Retree.clone(...)` with plain unrooted objects.
@@ -59,7 +61,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
 - `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
 - `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use it when VM logic should stay in the node but `useNode(node)` should re-render only for selected dependencies.
-- `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Keep dependency array length and order stable.
+- `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Dynamic dependency arrays are allowed; shape changes emit and refresh subscriptions.
 - `ReactiveNode.memo`, `@memo`, and `@fnMemo`: Cache computed values. They do not emit `nodeChanged` or trigger React renders by themselves.
 - `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
 - `Retree.runTransaction`: Batches synchronous writes into one listener flush per changed node.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5232,9 +5232,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13247,9 +13247,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13458,11 +13458,11 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.3.0"
+                "@retreejs/core": "0.3.1"
             },
             "bin": {
                 "retree-benchmark": "bin/cli.js"
@@ -13476,22 +13476,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -13507,18 +13507,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -13528,7 +13528,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.3.0"
+                "@retreejs/core": "0.3.1"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13977,8 +13977,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.3.0",
-                "@retreejs/react": "0.3.0",
+                "@retreejs/core": "0.3.1",
+                "@retreejs/react": "0.3.1",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13998,8 +13998,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.3.0",
-                "@retreejs/react": "0.3.0",
+                "@retreejs/core": "0.3.1",
+                "@retreejs/react": "0.3.1",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13458,11 +13458,11 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.3.1"
+                "@retreejs/core": "0.4.0"
             },
             "bin": {
                 "retree-benchmark": "bin/cli.js"
@@ -13476,22 +13476,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -13507,18 +13507,18 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -13528,7 +13528,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.3.1"
+                "@retreejs/core": "0.4.0"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13977,8 +13977,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.3.1",
-                "@retreejs/react": "0.3.1",
+                "@retreejs/core": "0.4.0",
+                "@retreejs/react": "0.4.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13998,8 +13998,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.3.1",
-                "@retreejs/react": "0.3.1",
+                "@retreejs/core": "0.4.0",
+                "@retreejs/react": "0.4.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "postdocs": "node -e \"require('node:fs').copyFileSync('llms.txt', 'docs/llms.txt')\"",
         "publish:packages": "node scripts/publish-packages.mjs",
         "test": "vitest run",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "typecheck": "tsc -p packages/retree-core/tsconfig.json --noEmit && tsc -p packages/retree-core/tsconfig.test.json --noEmit && tsc -p packages/retree-react/tsconfig.json --noEmit && tsc -p packages/retree-convex/tsconfig.json --noEmit && tsc -p packages/retree-benchmark-cli/tsconfig.json --noEmit && tsc -p samples/01.core-example/tsconfig.json --noEmit && tsc -b samples/02.react-example/tsconfig.json --pretty false && tsc -b samples/03.react-recursion/tsconfig.json --pretty false && tsc -p samples/04.convex-react-nextjs/tsconfig.json --noEmit --pretty false"
     },
     "author": "Ryan Bliss",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "scripts": {
         "benchmark": "npm run benchmark --workspace @retreejs/benchmark-cli -- --output-dir ../../benchmarks/results",
         "doctor": "prettier --write . && eslint **/src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern",
-        "predocs": "npm run build --workspace @retreejs/core && npm run build --workspace @retreejs/react && npm run build --workspace @retreejs/convex",
+        "predocs": "npm run build:packages",
+        "build:packages": "npm run build --workspace @retreejs/core && npm run build --workspace @retreejs/react && npm run build --workspace @retreejs/convex",
         "docs": "typedoc --options typedoc.json",
         "postdocs": "node -e \"require('node:fs').copyFileSync('llms.txt', 'docs/llms.txt')\"",
         "publish:packages": "node scripts/publish-packages.mjs",

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.3.0"
+        "@retreejs/core": "0.3.1"
     },
     "devDependencies": {
         "@types/node": "^20.2.3",

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.3.1"
+        "@retreejs/core": "0.4.0"
     },
     "devDependencies": {
         "@types/node": "^20.2.3",

--- a/packages/retree-convex/README.md
+++ b/packages/retree-convex/README.md
@@ -16,6 +16,17 @@ Install with `yarn`:
 yarn add @retreejs/core @retreejs/convex convex
 ```
 
+## Feature glossary
+
+-   [`ConvexNode`](#how-to-use) is the full base class for app state that owns a Convex client. Use it when you want `this.query(...)`, `this.paginatedQuery(...)`, `this.connectionState(...)`, `this.mutation(...)`, `this.action(...)`, and `this.queryOnce(...)`.
+-   [`BaseConvexNode`](#how-to-use) is the smaller base class for nodes that only need `this.mutation(...)`, `this.action(...)`, or `this.queryOnce(...)`.
+-   [`ConvexQueryNode`](#query-status-and-skipping) stores one live Convex query in Retree state. Use it for subscribed query results that should trigger Retree/React updates.
+-   [`ConvexPaginatedQueryNode`](#paginated-queries) stores one live paginated Convex query and exposes `loadMore(...)`.
+-   [`ConvexConnectionStateNode`](#connection-state) stores the Convex client's connection state in Retree state.
+-   [`createRetreeConvexMutation`](#standalone-action-and-mutation-helpers) and [`createRetreeConvexAction`](#standalone-action-and-mutation-helpers) create typed imperative helpers when you are not inside a `BaseConvexNode`.
+-   [`optimisticUpdate`](#optimistic-updates) mutates a query node optimistically and emits through Retree immediately.
+-   [`reconcileConvexDocuments` and `reconcileArrayById`](#reconciliation) preserve item identity across server results so child `useNode(item)` components stay narrow.
+
 ## How to use
 
 Create an app state node that extends `ConvexNode`, pass it a Convex client, and build query nodes with the protected `this.query(...)` helper. Query arguments are optional for Convex queries that do not require args.
@@ -79,6 +90,21 @@ const filteredTasks = new ConvexQueryNode(client, api.tasks.byStatus, {
 });
 ```
 
+Query nodes are `ReactiveNode`s. When Convex sends a new value, the query node writes `state`, `result`, and `error`, which emits Retree listeners and re-renders React components subscribed with `useNode`, `useTree`, or `useSelect`.
+
+```tsx
+import { useSelect } from "@retreejs/react";
+
+function TaskCount({
+    tasks,
+}: {
+    tasks: ConvexQueryNode<typeof api.tasks.get>;
+}) {
+    const count = useSelect(tasks, (node) => node.state.length);
+    return <span>{count}</span>;
+}
+```
+
 ## Query status and skipping
 
 `ConvexQueryNode.state` keeps the convenient query value, while `ConvexQueryNode.result` exposes a status union for loading, success, skipped, and error states:
@@ -99,6 +125,12 @@ Pass `"skip"` to the constructor, `this.query(...)`, or `updateArgs(...)` to dis
 this.tasks.updateArgs(projectId ? { projectId } : "skip");
 ```
 
+```ts
+tasks.updateArgs({ projectId: "p1" }); // ✅ changes args and resubscribes
+tasks.updateArgs("skip"); // ✅ emits skipped state and unsubscribes
+tasks.dispose(); // ✅ stops the subscription; call during app cleanup
+```
+
 ## Actions and one-off queries
 
 Use `this.action(...)` for Convex actions and `this.queryOnce(...)` when you need an imperative query result without subscribing:
@@ -108,6 +140,31 @@ const generateSummary = this.action(api.ai.generateSummary);
 const summary = await generateSummary({ taskId });
 
 const task = await this.queryOnce(api.tasks.getById, { taskId });
+```
+
+These helpers do not emit by themselves. They only trigger Retree updates if your code writes their result into a Retree node or uses a mutation optimistic update.
+
+## Standalone action and mutation helpers
+
+Use `createRetreeConvexAction(...)` and `createRetreeConvexMutation(...)` when you want typed helpers without subclassing `BaseConvexNode`.
+
+```ts
+import {
+    createRetreeConvexAction,
+    createRetreeConvexMutation,
+} from "@retreejs/convex";
+
+const generateSummary = createRetreeConvexAction(
+    client,
+    api.ai.generateSummary
+);
+const toggleCompleted = createRetreeConvexMutation(
+    client,
+    api.tasks.toggleCompleted
+);
+
+await generateSummary({ taskId }); // ❌ no Retree emit by itself
+await toggleCompleted({ taskId }); // ❌ no Retree emit unless paired with optimisticUpdate
 ```
 
 ## Paginated queries
@@ -123,12 +180,28 @@ this.messages = this.paginatedQuery(api.messages.list, {
 this.messages.loadMore(20);
 ```
 
+`loadMore(...)` requests another page and returns `false` when there is no active subscription to extend. New pages update the paginated query node and emit through Retree.
+
+```ts
+const didRequestMore = this.messages.loadMore(20);
+this.messages.dispose();
+```
+
 ## Connection state
 
 Use `this.connectionState()` to create a node that tracks the Convex client's connection state:
 
 ```ts
 this.connection = this.connectionState();
+```
+
+```tsx
+import { useSelect } from "@retreejs/react";
+
+function ConnectionBadge({ state }: { state: ConvexConnectionStateNode }) {
+    const status = useSelect(state, (node) => node.state);
+    return <span>{status.hasInflightRequests ? "Syncing" : "Idle"}</span>;
+}
 ```
 
 ## Optimistic updates

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -13,13 +13,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.3.1",
+        "@retreejs/core": "0.4.0",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.3.1",
+        "@retreejs/core": "0.4.0",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -13,13 +13,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.3.0",
+        "@retreejs/core": "0.3.1",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.3.0",
+        "@retreejs/core": "0.3.1",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-convex/src/BaseConvexNode.ts
+++ b/packages/retree-convex/src/BaseConvexNode.ts
@@ -23,6 +23,27 @@ import {
  * Extend this class when you need typed Convex actions, mutations, and one-off
  * queries but do not need the query-node factories provided by
  * {@link ConvexNode}.
+ *
+ * @remarks
+ * The Convex client is stored in an `@ignore` field, so assigning or using the
+ * client does not emit Retree changes. Action, mutation, and one-off query
+ * helpers do not emit by themselves; they only cause Retree updates when your
+ * code writes their result into Retree state or pairs a mutation with an
+ * optimistic query update.
+ *
+ * @example
+ * ```ts
+ * class TaskCommands extends BaseConvexNode {
+ *     get dependencies() {
+ *         return [];
+ *     }
+ *
+ *     public async rename(taskId: Id<"tasks">, text: string) {
+ *         const renameTask = this.mutation(api.tasks.rename);
+ *         await renameTask({ taskId, text }); // ❌ no Retree emit by itself
+ *     }
+ * }
+ * ```
  */
 export abstract class BaseConvexNode extends ReactiveNode {
     /**
@@ -44,8 +65,33 @@ export abstract class BaseConvexNode extends ReactiveNode {
     /**
      * Create a typed mutation function bound to this node's Convex client.
      *
+     * @remarks
+     * The returned function runs the Convex mutation. It does not update Retree
+     * state by itself. Pass `withOptimisticUpdate` when the mutation should
+     * immediately update a {@link ConvexQueryNode}; otherwise wait for the
+     * subscribed query to emit a server value.
+     *
      * @param mutation Convex mutation function reference.
      * @returns A typed mutation function with optional optimistic update support.
+     *
+     * @example
+     * ```ts
+     * const toggle = this.mutation(api.tasks.toggleCompleted);
+     * return toggle(
+     *     { taskId },
+     *     {
+     *         withOptimisticUpdate: (ctx) => {
+     *             this.tasks.optimisticUpdate({
+     *                 ctx,
+     *                 apply(tasks) {
+     *                     const task = tasks.find((item) => item._id === taskId);
+     *                     if (task) task.isCompleted = !task.isCompleted;
+     *                 },
+     *             });
+     *         },
+     *     }
+     * );
+     * ```
      */
     protected mutation<Mutation extends MutationReference>(
         mutation: Mutation
@@ -56,8 +102,19 @@ export abstract class BaseConvexNode extends ReactiveNode {
     /**
      * Create a typed action function bound to this node's Convex client.
      *
+     * @remarks
+     * Actions are imperative calls. They do not emit Retree changes unless you
+     * write their result into a Retree-managed field.
+     *
      * @param action Convex action function reference.
      * @returns A typed action function.
+     *
+     * @example
+     * ```ts
+     * const generateSummary = this.action(api.ai.generateSummary);
+     * const summary = await generateSummary({ taskId });
+     * this.summary = summary; // ✅ this write emits if `summary` is reactive state
+     * ```
      */
     protected action<Action extends ActionReference>(
         action: Action
@@ -68,9 +125,20 @@ export abstract class BaseConvexNode extends ReactiveNode {
     /**
      * Run a Convex query once without creating a subscription.
      *
+     * @remarks
+     * Use this for imperative reads. It does not keep data live and does not
+     * emit Retree changes unless you assign the returned value into Retree
+     * state. Use {@link ConvexNode.query} when the value should stay subscribed.
+     *
      * @param query Convex query function reference.
      * @param args Query arguments. Optional for no-args queries.
      * @returns Promise for the Convex query result.
+     *
+     * @example
+     * ```ts
+     * const task = await this.queryOnce(api.tasks.getById, { taskId });
+     * this.selectedTaskPreview = task; // ✅ emits if this field participates in Retree
+     * ```
      */
     protected queryOnce<Query extends QueryReference>(
         query: Query,

--- a/packages/retree-convex/src/ConvexConnectionStateNode.ts
+++ b/packages/retree-convex/src/ConvexConnectionStateNode.ts
@@ -10,6 +10,21 @@ import { IConvexClient } from "./types";
 
 /**
  * Reactive node that tracks a Convex client's connection state.
+ *
+ * @remarks
+ * Use this directly or through {@link ConvexNode.connectionState} when UI
+ * needs to render sync or connection status. Connection changes update
+ * `state`, which emits through Retree while the node is observed.
+ *
+ * Dispose the node when its owner is torn down.
+ *
+ * @example
+ * ```ts
+ * const connection = Retree.root(new ConvexConnectionStateNode(client));
+ * Retree.on(connection, "nodeChanged", (next) => {
+ *     console.log(next.state.hasInflightRequests);
+ * });
+ * ```
  */
 export class ConvexConnectionStateNode extends BaseConvexNode {
     @ignore
@@ -22,6 +37,10 @@ export class ConvexConnectionStateNode extends BaseConvexNode {
 
     /**
      * Create a node for Convex connection state.
+     *
+     * @remarks
+     * The node reads the initial connection state immediately. It subscribes to
+     * future connection-state updates when Retree observes it.
      *
      * @param client Convex client used for connection-state reads.
      */
@@ -46,6 +65,17 @@ export class ConvexConnectionStateNode extends BaseConvexNode {
 
     /**
      * Stop listening to Convex connection-state changes.
+     *
+     * @remarks
+     * Call this when the owner of the connection-state node is torn down.
+     * Disposing stops future updates; it does not clear the last `state`.
+     *
+     * @example
+     * ```ts
+     * public dispose() {
+     *     this.connection.dispose();
+     * }
+     * ```
      */
     public dispose(): void {
         if (this.unsubscribe === null) {

--- a/packages/retree-convex/src/ConvexNode.ts
+++ b/packages/retree-convex/src/ConvexNode.ts
@@ -17,6 +17,32 @@ import {
 
 /**
  * Base class for Retree nodes that need access to a Convex client.
+ *
+ * @remarks
+ * Extend this when a Retree app state node should own live Convex query
+ * nodes, paginated query nodes, action/mutation helpers, one-off queries, or
+ * connection state. Use {@link BaseConvexNode} when you only need imperative
+ * actions, mutations, or one-off queries.
+ *
+ * Query nodes emit through Retree when Convex sends new values. Actions,
+ * mutations, and `queryOnce` do not emit unless their results are written into
+ * Retree state or paired with an optimistic update.
+ *
+ * @example
+ * ```ts
+ * class TasksState extends ConvexNode {
+ *     public readonly tasks: ConvexQueryNode<typeof api.tasks.list>;
+ *
+ *     constructor(client: IConvexClient) {
+ *         super(client);
+ *         this.tasks = this.query(api.tasks.list);
+ *     }
+ *
+ *     get dependencies() {
+ *         return [];
+ *     }
+ * }
+ * ```
  */
 export abstract class ConvexNode extends BaseConvexNode {
     /**
@@ -31,9 +57,37 @@ export abstract class ConvexNode extends BaseConvexNode {
     /**
      * Create a typed query node bound to this node's Convex client.
      *
+     * @remarks
+     * Use this for live Convex query data that should flow into Retree. The
+     * returned {@link ConvexQueryNode} writes `state`, `result`, and `error`,
+     * which can emit Retree events and re-render React subscribers.
+     *
+     * Pass `"skip"` or later call `updateArgs("skip")` when the query should
+     * be disabled. Prefer reconcilers for arrays so unchanged child items keep
+     * stable identity.
+     *
      * @param query Convex query function reference.
      * @param options Query arguments, optional initial state, and optional reconciler.
      * @returns A {@link ConvexQueryNode} subscribed with this node's Convex client.
+     *
+     * @example
+     * ```ts
+     * class TasksState extends ConvexNode {
+     *     public readonly tasks: ConvexQueryNode<typeof api.tasks.byProject>;
+     *
+     *     constructor(client: IConvexClient) {
+     *         super(client);
+     *         this.tasks = this.query(api.tasks.byProject, {
+     *             args: { projectId: "p1" },
+     *             initialState: [],
+     *         });
+     *     }
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     * }
+     * ```
      */
     protected query<Query extends QueryReference>(
         query: Query,
@@ -45,9 +99,33 @@ export abstract class ConvexNode extends BaseConvexNode {
     /**
      * Create a typed paginated query node bound to this node's Convex client.
      *
+     * @remarks
+     * Use this for live paginated lists. The returned
+     * {@link ConvexPaginatedQueryNode} emits through Retree when pages arrive
+     * and exposes `loadMore(...)` for requesting additional items.
+     *
      * @param query Convex paginated query function reference.
      * @param options Query arguments, initial page size, and optional initial state.
      * @returns A {@link ConvexPaginatedQueryNode} subscribed with this node's Convex client.
+     *
+     * @example
+     * ```ts
+     * class MessagesState extends ConvexNode {
+     *     public readonly messages: ConvexPaginatedQueryNode<typeof api.messages.list>;
+     *
+     *     constructor(client: IConvexClient) {
+     *         super(client);
+     *         this.messages = this.paginatedQuery(api.messages.list, {
+     *             args: { channelId: "general" },
+     *             initialNumItems: 20,
+     *         });
+     *     }
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     * }
+     * ```
      */
     protected paginatedQuery<Query extends PaginatedQueryReference>(
         query: Query,
@@ -59,7 +137,27 @@ export abstract class ConvexNode extends BaseConvexNode {
     /**
      * Create a node that tracks this Convex client's connection state.
      *
+     * @remarks
+     * Use this when UI needs to render connection or sync status. Dispose the
+     * returned node when its owner is torn down.
+     *
      * @returns A {@link ConvexConnectionStateNode} subscribed with this node's Convex client.
+     *
+     * @example
+     * ```ts
+     * class AppState extends ConvexNode {
+     *     public readonly connection: ConvexConnectionStateNode;
+     *
+     *     constructor(client: IConvexClient) {
+     *         super(client);
+     *         this.connection = this.connectionState();
+     *     }
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     * }
+     * ```
      */
     protected connectionState(): ConvexConnectionStateNode {
         return new ConvexConnectionStateNode(this.client);

--- a/packages/retree-convex/src/ConvexPaginatedQueryNode.ts
+++ b/packages/retree-convex/src/ConvexPaginatedQueryNode.ts
@@ -23,6 +23,22 @@ import {
 /**
  * Reactive paginated query node that subscribes to a Convex paginated query and
  * exposes the loaded pages as Retree state.
+ *
+ * @remarks
+ * Use this directly or through {@link ConvexNode.paginatedQuery} for live
+ * paginated lists. New pages update `state`, `result`, and `error`, which can
+ * emit Retree changes and re-render React subscribers.
+ *
+ * Dispose the node when its owner is torn down. Use `"skip"` when the query
+ * should be temporarily disabled.
+ *
+ * @example
+ * ```ts
+ * const messages = new ConvexPaginatedQueryNode(client, api.messages.list, {
+ *     args: { channelId: "general" },
+ *     initialNumItems: 20,
+ * });
+ * ```
  */
 export class ConvexPaginatedQueryNode<
     Query extends PaginatedQueryReference
@@ -51,9 +67,24 @@ export class ConvexPaginatedQueryNode<
     /**
      * Create a node for a Convex paginated query subscription.
      *
+     * @remarks
+     * The subscription starts when the node is observed by Retree. This avoids
+     * opening Convex subscriptions for paginated state nobody is currently
+     * rendering or listening to.
+     *
      * @param client Convex client used for the subscription.
      * @param query Convex paginated query function reference.
      * @param options Query arguments, initial page size, and optional initial state.
+     *
+     * @example
+     * ```ts
+     * const messages = Retree.root(
+     *     new ConvexPaginatedQueryNode(client, api.messages.list, {
+     *         args: { channelId: "general" },
+     *         initialNumItems: 20,
+     *     })
+     * );
+     * ```
      */
     constructor(
         client: IConvexClient,
@@ -86,7 +117,18 @@ export class ConvexPaginatedQueryNode<
      * Update the query arguments and resubscribe when the shallow argument
      * comparison changes. Pass `"skip"` to disable the subscription.
      *
+     * @remarks
+     * Updating args can emit because `state`, `result`, and `error` may change.
+     * Passing `"skip"` disables the active subscription and sets
+     * `result.status` to `"skipped"`.
+     *
      * @param args Next query arguments, or `"skip"`.
+     *
+     * @example
+     * ```ts
+     * messages.updateArgs({ channelId: "random" }); // ✅ may emit
+     * messages.updateArgs("skip"); // ✅ emits skipped state and unsubscribes
+     * ```
      */
     public updateArgs(args: ConvexPaginatedQueryArgs<Query>): void {
         this.args = args;
@@ -151,8 +193,21 @@ export class ConvexPaginatedQueryNode<
     /**
      * Request more items for the active paginated query.
      *
+     * @remarks
+     * Use this from UI actions such as "Load more" buttons or infinite scroll.
+     * It returns `false` when there is no active paginated state to extend.
+     * Passing a non-positive number throws.
+     *
      * @param numItems Number of additional items to load.
      * @returns Whether Convex started a load-more request.
+     *
+     * @example
+     * ```ts
+     * const requested = messages.loadMore(20);
+     * if (!requested) {
+     *     console.log("No active page to extend");
+     * }
+     * ```
      */
     public loadMore(numItems: number): boolean {
         if (numItems <= 0) {
@@ -170,6 +225,18 @@ export class ConvexPaginatedQueryNode<
 
     /**
      * Stop the active Convex paginated query subscription.
+     *
+     * @remarks
+     * Call this when the owner of the paginated query node is torn down.
+     * Disposing stops future Convex updates; it does not clear `state`,
+     * `result`, or `error`.
+     *
+     * @example
+     * ```ts
+     * public dispose() {
+     *     this.messages.dispose();
+     * }
+     * ```
      */
     public dispose(): void {
         if (this.unsubscribe === null) {

--- a/packages/retree-convex/src/ConvexQueryNode.spec.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { Retree } from "@retreejs/core";
+import { ReactiveNode, Retree, select } from "@retreejs/core";
 import type {
     FunctionArgs,
     FunctionReference,
@@ -304,6 +304,27 @@ class TestConvexNode extends ConvexNode {
     }
 }
 
+class SelectedTasksNode extends ReactiveNode {
+    public readonly tasksQuery: ConvexQueryNode<ConvexTasksQuery>;
+
+    constructor(client: FakeConvexClient) {
+        super();
+        this.tasksQuery = new ConvexQueryNode(client, convexTasksQuery, {
+            args: { listId: "today" },
+            initialState: [],
+        });
+    }
+
+    @select
+    public get tasks() {
+        return this.tasksQuery.state?.filter(() => true) ?? [];
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
 describe("ConvexQueryNode", () => {
     it("writes query updates into state through Retree", () => {
         const client = new FakeConvexClient();
@@ -323,6 +344,32 @@ describe("ConvexQueryNode", () => {
             { id: "task-1", text: "Buy groceries", isCompleted: false },
         ]);
         expect(nodeChanged).toHaveBeenCalled();
+    });
+
+    it("reproxies a parent @select owner when a reconciled document array gains an item", () => {
+        const client = new FakeConvexClient();
+        const node = Retree.root(new SelectedTasksNode(client));
+        const nodeChanged = vi.fn();
+
+        Retree.on(node, "nodeChanged", nodeChanged);
+        expect(node.tasks).toEqual([]);
+
+        client.subscriptions[0].callback([
+            {
+                _id: "task-1",
+                text: "Buy groceries",
+                isCompleted: false,
+            },
+        ]);
+
+        expect(nodeChanged).toHaveBeenCalled();
+        expect(node.tasks).toEqual([
+            {
+                _id: "task-1",
+                text: "Buy groceries",
+                isCompleted: false,
+            },
+        ]);
     });
 
     it("resubscribes when args change", () => {

--- a/packages/retree-convex/src/ConvexQueryNode.spec.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.spec.ts
@@ -765,6 +765,68 @@ describe("ConvexQueryNode", () => {
         expect(node.error).toBeNull();
     });
 
+    it("keeps newer optimistic state while a newer optimistic mutation is pending", async () => {
+        const client = new FakeConvexClient();
+        const node = Retree.root(
+            new ConvexQueryNode(client, tasksQuery, {
+                args: { listId: "today" },
+            })
+        );
+        Retree.on(node, "nodeChanged", () => undefined);
+        client.subscriptions[0].callback([
+            { id: "task-1", text: "Buy groceries", isCompleted: false },
+        ]);
+        let resolveFirstMutation!: () => void;
+        const firstMutation = new Promise<null>((resolve) => {
+            resolveFirstMutation = () => resolve(null);
+        });
+        let resolveSecondMutation!: () => void;
+        const secondMutation = new Promise<null>((resolve) => {
+            resolveSecondMutation = () => resolve(null);
+        });
+
+        node.optimisticUpdate({
+            ctx: {
+                args: { taskId: "task-1" },
+                promise: firstMutation,
+            },
+            apply(tasks) {
+                tasks[0].text = "Buy groceries A";
+            },
+        });
+        node.optimisticUpdate({
+            ctx: {
+                args: { taskId: "task-1" },
+                promise: secondMutation,
+            },
+            apply(tasks) {
+                tasks[0].text = "Buy groceries B";
+            },
+        });
+
+        resolveFirstMutation();
+        await firstMutation;
+        await Promise.resolve();
+        client.subscriptions[0].callback([
+            { id: "task-1", text: "Buy groceries A", isCompleted: false },
+        ]);
+
+        expect(node.state).toEqual([
+            { id: "task-1", text: "Buy groceries B", isCompleted: false },
+        ]);
+
+        resolveSecondMutation();
+        await secondMutation;
+        await Promise.resolve();
+        client.subscriptions[0].callback([
+            { id: "task-1", text: "Buy groceries B", isCompleted: false },
+        ]);
+
+        expect(node.state).toEqual([
+            { id: "task-1", text: "Buy groceries B", isCompleted: false },
+        ]);
+    });
+
     it("rolls dirty optimistic state back when a later mutation fails first", async () => {
         const client = new FakeConvexClient();
         const node = Retree.root(

--- a/packages/retree-convex/src/ConvexQueryNode.spec.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.spec.ts
@@ -20,6 +20,7 @@ import {
     OptimisticUpdateContext,
     reconcileArrayById,
 } from "./index";
+import { reconcileArray } from "./internals/reconcile";
 
 type TasksQuery = FunctionReference<
     "query",
@@ -870,5 +871,31 @@ describe("ConvexQueryNode", () => {
 
         expect(node.state?.[0]?.isCompleted).toBe(true);
         expect(node.state?.[1]).toBe(unchangedTask);
+    });
+
+    it("reconciles arrays with sparse current slots", () => {
+        const current: { id: string; text: string }[] = [];
+        current.length = 2;
+        current[1] = { id: "task-2", text: "Read docs" };
+        const preservedTask = current[1];
+
+        reconcileArray(
+            current,
+            [
+                { id: "task-1", text: "Buy groceries" },
+                { id: "task-2", text: "Read better docs" },
+            ],
+            (task) => task.id
+        );
+
+        expect(current[0]).toEqual({
+            id: "task-1",
+            text: "Buy groceries",
+        });
+        expect(current[1]).toBe(preservedTask);
+        expect(current[1]).toEqual({
+            id: "task-2",
+            text: "Read better docs",
+        });
     });
 });

--- a/packages/retree-convex/src/ConvexQueryNode.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.ts
@@ -72,10 +72,39 @@ export class ConvexQueryNode<
      * Latest subscription or mutation rollback error.
      */
     public error: Error | null = null;
+    /**
+     * Last state emitted by the Convex subscription that Retree accepted as a
+     * clean server baseline. During overlapping optimistic updates this may
+     * advance even when `state` intentionally keeps the newer optimistic value.
+     */
     private lastEmittedState: ConvexQueryNodeState<Query>;
+    /**
+     * True while local optimistic state differs from the last clean server
+     * baseline and may still need confirmation or rollback.
+     */
     private isOptimisticDirty = false;
+    /**
+     * Monotonic id assigned to each optimistic update. Promise handlers compare
+     * against this so an older mutation cannot rollback or confirm over newer
+     * local state.
+     */
     private optimisticGeneration = 0;
+    /**
+     * Generation that opened the current dirty window. If a later generation is
+     * still pending, server emissions are treated as older confirmations and do
+     * not overwrite the newer optimistic state.
+     */
+    private dirtyWindowStartGeneration: number | undefined;
+    /**
+     * Snapshot captured before the current dirty window began. Used for default
+     * rollback when the latest optimistic mutation rejects.
+     */
     private optimisticRollbackState: ConvexQueryNodeState<Query>;
+    /**
+     * Newest optimistic mutation promise that has not resolved successfully yet.
+     * Only this generation is allowed to clear the pending marker.
+     */
+    private pendingOptimisticGeneration: number | undefined;
 
     /**
      * Create a node for a Convex query subscription.
@@ -250,12 +279,31 @@ export class ConvexQueryNode<
         transform: IOptimisticTransform<FunctionReturnType<Query>, Mutation>
     ): void {
         const generation = this.markOptimisticDirty();
+        if (transform.ctx !== undefined) {
+            this.pendingOptimisticGeneration = generation;
+            transform.ctx.promise.then(
+                () => {
+                    // A newer optimistic mutation may have started while this
+                    // one was in flight. In that case, this confirmation is too
+                    // old to mark the optimistic state as no longer pending.
+                    if (this.pendingOptimisticGeneration !== generation) {
+                        return;
+                    }
+                    this.pendingOptimisticGeneration = undefined;
+                },
+                () => {
+                    return;
+                }
+            );
+        }
         if (this.state !== undefined) {
             transform.apply(this.state);
         }
 
         transform.ctx?.promise.catch((error: unknown) => {
             Retree.runTransaction(() => {
+                // Rejecting an older mutation should not rollback a newer local
+                // edit. The newest generation owns rollback for the dirty window.
                 if (
                     !this.isOptimisticDirty ||
                     this.optimisticGeneration !== generation
@@ -305,6 +353,21 @@ export class ConvexQueryNode<
     }
 
     private setEmittedState(next: FunctionReturnType<Query>): void {
+        // Convex can confirm an older mutation while a newer optimistic edit is
+        // still pending. Keep that server value as the latest baseline, but do
+        // not restore it into `state` because that would make the UI rubber-band
+        // back to the older value.
+        if (
+            this.isOptimisticDirty &&
+            this.hasPendingSupersedingOptimisticMutation()
+        ) {
+            this.lastEmittedState = this.cloneState(next);
+            return;
+        }
+
+        // When Convex re-emits the baseline that existed before the optimistic
+        // write, the write has not been confirmed yet. Keep the optimistic state
+        // visible and keep waiting for either confirmation or rollback.
         if (
             this.isOptimisticDirty &&
             this.stateEquals(next, this.lastEmittedState)
@@ -417,18 +480,40 @@ export class ConvexQueryNode<
     private markOptimisticDirty(): number {
         if (!this.isOptimisticDirty) {
             this.isOptimisticDirty = true;
-            this.optimisticGeneration++;
             this.optimisticRollbackState = this.cloneState(
                 this.lastEmittedState
             );
         }
 
+        this.optimisticGeneration++;
+        // The first generation in a dirty window is the oldest optimistic write
+        // whose server confirmation could still arrive before newer writes.
+        if (this.dirtyWindowStartGeneration === undefined) {
+            this.dirtyWindowStartGeneration = this.optimisticGeneration;
+        }
         return this.optimisticGeneration;
     }
 
     private clearOptimisticDirty(): void {
         this.isOptimisticDirty = false;
+        this.dirtyWindowStartGeneration = undefined;
         this.optimisticRollbackState = undefined;
+        this.pendingOptimisticGeneration = undefined;
+    }
+
+    private hasPendingSupersedingOptimisticMutation(): boolean {
+        if (this.pendingOptimisticGeneration === undefined) {
+            return false;
+        }
+        if (this.dirtyWindowStartGeneration === undefined) {
+            return false;
+        }
+        // A pending generation after the window start means at least one newer
+        // optimistic write is still in flight, so incoming server state may only
+        // be confirming an older write in the same dirty window.
+        return (
+            this.pendingOptimisticGeneration > this.dirtyWindowStartGeneration
+        );
     }
 
     private stateEquals(

--- a/packages/retree-convex/src/ConvexQueryNode.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.ts
@@ -24,6 +24,27 @@ import {
 /**
  * Reactive query node that subscribes to a Convex query and writes emitted
  * values into Retree state.
+ *
+ * @remarks
+ * Use this directly or through {@link ConvexNode.query} when query results
+ * should be live Retree state. Convex emissions update `state`, `result`, and
+ * `error`, which can emit `nodeChanged` and re-render React subscribers.
+ *
+ * Dispose query nodes when their owner is torn down. Use `"skip"` when the
+ * query should be temporarily disabled. Prefer reconciled arrays so unchanged
+ * child objects keep identity for `useNode(item)` components.
+ *
+ * @example
+ * ```ts
+ * const tasks = new ConvexQueryNode(client, api.tasks.byProject, {
+ *     args: { projectId: "p1" },
+ *     initialState: [],
+ * });
+ *
+ * Retree.on(tasks, "nodeChanged", (next) => {
+ *     console.log(next.result.status);
+ * });
+ * ```
  */
 export class ConvexQueryNode<
     Query extends QueryReference
@@ -59,9 +80,23 @@ export class ConvexQueryNode<
     /**
      * Create a node for a Convex query subscription.
      *
+     * @remarks
+     * The subscription starts when the node is observed by Retree. This avoids
+     * opening Convex subscriptions for state nobody is currently rendering or
+     * listening to.
+     *
      * @param client Convex client used for the subscription.
      * @param query Convex query function reference.
      * @param options Query arguments, optional initial state, and optional reconciler.
+     *
+     * @example
+     * ```ts
+     * const tasks = Retree.root(
+     *     new ConvexQueryNode(client, api.tasks.list, {
+     *         initialState: [],
+     *     })
+     * );
+     * ```
      */
     constructor(
         client: IConvexClient,
@@ -95,7 +130,20 @@ export class ConvexQueryNode<
      * Update the query arguments and resubscribe when the shallow argument
      * comparison changes.
      *
+     * @remarks
+     * Use this when query args are controlled by Retree state, routing, or user
+     * input. Passing `"skip"` disables the active subscription and sets
+     * `result.status` to `"skipped"`.
+     *
+     * Updating args can emit because `state`, `result`, and `error` may change.
+     *
      * @param args Next query arguments, or `"skip"` to disable the subscription.
+     *
+     * @example
+     * ```ts
+     * tasks.updateArgs({ projectId: "p2" }); // ✅ may emit pending/success
+     * tasks.updateArgs("skip"); // ✅ emits skipped state and unsubscribes
+     * ```
      */
     public updateArgs(args: ConvexQueryArgs<Query>): void {
         this.args = args;
@@ -169,7 +217,34 @@ export class ConvexQueryNode<
      * when its promise rejects unless a newer server value resolves the dirty
      * state first.
      *
+     * @remarks
+     * Use this from a mutation's `withOptimisticUpdate` callback when the UI
+     * should update immediately before Convex confirms the write. The transform
+     * mutates the existing query state in place and emits through Retree.
+     *
+     * Prefer small, targeted transforms. Provide `revert(...)` when the default
+     * rollback to the last clean server value is not specific enough.
+     *
      * @param transform Optimistic transform and optional mutation context.
+     *
+     * @example
+     * ```ts
+     * const toggle = this.mutation(api.tasks.toggleCompleted);
+     * return toggle(
+     *     { taskId },
+     *     {
+     *         withOptimisticUpdate: (ctx) => {
+     *             this.tasks.optimisticUpdate({
+     *                 ctx,
+     *                 apply(tasks) {
+     *                     const task = tasks.find((item) => item._id === taskId);
+     *                     if (task) task.isCompleted = !task.isCompleted;
+     *                 },
+     *             });
+     *         },
+     *     }
+     * );
+     * ```
      */
     public optimisticUpdate<Mutation extends MutationReference>(
         transform: IOptimisticTransform<FunctionReturnType<Query>, Mutation>
@@ -284,6 +359,26 @@ export class ConvexQueryNode<
 
     /**
      * Stop the active Convex query subscription.
+     *
+     * @remarks
+     * Call this when the owner of the query node is torn down. Disposing stops
+     * future Convex updates; it does not clear `state`, `result`, or `error`.
+     *
+     * @example
+     * ```ts
+     * class TasksState extends ConvexNode {
+     *     public readonly tasks: ConvexQueryNode<typeof api.tasks.list>;
+     *
+     *     constructor(client: IConvexClient) {
+     *         super(client);
+     *         this.tasks = this.query(api.tasks.list);
+     *     }
+     *
+     *     public dispose() {
+     *         this.tasks.dispose();
+     *     }
+     * }
+     * ```
      */
     public dispose(): void {
         if (this.unsubscribe === null) {

--- a/packages/retree-convex/src/actions.ts
+++ b/packages/retree-convex/src/actions.ts
@@ -14,9 +14,26 @@ import {
  * Create a typed Retree Convex action function from a Convex client and action
  * reference.
  *
+ * @remarks
+ * Use this when you need a typed action helper outside a
+ * {@link BaseConvexNode}. Actions are imperative calls and do not emit Retree
+ * changes by themselves. Assign the action result into Retree state if the UI
+ * should update from it.
+ *
  * @param client Convex client used to run the action.
  * @param action Convex action function reference.
  * @returns A typed action function.
+ *
+ * @example
+ * ```ts
+ * const generateSummary = createRetreeConvexAction(
+ *     client,
+ *     api.ai.generateSummary
+ * );
+ *
+ * const summary = await generateSummary({ taskId });
+ * state.summary = summary; // ✅ emits if `state` is Retree-managed
+ * ```
  */
 export function createRetreeConvexAction<Action extends ActionReference>(
     client: IConvexActionClient,

--- a/packages/retree-convex/src/internals/reconcile.ts
+++ b/packages/retree-convex/src/internals/reconcile.ts
@@ -23,6 +23,14 @@ export function reconcileArray<TItem extends object>(
         for (let index = 0; index < next.length; index++) {
             const currentItem = current[index];
             const nextItem = next[index];
+            if (currentItem === undefined) {
+                allItemsStayedInPlace = false;
+                break;
+            }
+            if (nextItem === undefined) {
+                allItemsStayedInPlace = false;
+                break;
+            }
             if (getId(currentItem) !== getId(nextItem)) {
                 allItemsStayedInPlace = false;
                 break;
@@ -38,11 +46,17 @@ export function reconcileArray<TItem extends object>(
 
     const currentById = new Map<PropertyKey, TItem>();
     for (const currentItem of current) {
+        if (currentItem === undefined) {
+            continue;
+        }
         currentById.set(getId(currentItem), currentItem);
     }
 
     for (let index = 0; index < next.length; index++) {
         const nextItem = next[index];
+        if (nextItem === undefined) {
+            continue;
+        }
         const currentItem = currentById.get(getId(nextItem));
         if (currentItem === undefined) {
             current[index] = nextItem;
@@ -50,7 +64,11 @@ export function reconcileArray<TItem extends object>(
         }
 
         reconcileObject(currentItem, nextItem);
-        if (getId(current[index]) === getId(currentItem)) {
+        const currentSlot = current[index];
+        if (
+            currentSlot !== undefined &&
+            getId(currentSlot) === getId(currentItem)
+        ) {
             continue;
         }
 

--- a/packages/retree-convex/src/mutations.ts
+++ b/packages/retree-convex/src/mutations.ts
@@ -13,9 +13,39 @@ import {
  * Create a typed Retree Convex mutation function from a Convex client and
  * mutation reference.
  *
+ * @remarks
+ * Use this when you need a typed mutation helper outside a
+ * {@link BaseConvexNode}. Mutations are imperative calls and do not emit
+ * Retree changes by themselves. Pair with `withOptimisticUpdate` to update a
+ * query node immediately, or wait for a subscribed query to emit the server
+ * value.
+ *
  * @param client Convex mutation client.
  * @param mutation Convex mutation function reference.
  * @returns A typed mutation function with optional optimistic update support.
+ *
+ * @example
+ * ```ts
+ * const toggleCompleted = createRetreeConvexMutation(
+ *     client,
+ *     api.tasks.toggleCompleted
+ * );
+ *
+ * await toggleCompleted(
+ *     { taskId },
+ *     {
+ *         withOptimisticUpdate: (ctx) => {
+ *             tasks.optimisticUpdate({
+ *                 ctx,
+ *                 apply(items) {
+ *                     const task = items.find((item) => item._id === taskId);
+ *                     if (task) task.isCompleted = !task.isCompleted;
+ *                 },
+ *             });
+ *         },
+ *     }
+ * );
+ * ```
  */
 export function createRetreeConvexMutation<Mutation extends MutationReference>(
     client: IConvexMutationClient,

--- a/packages/retree-convex/src/reconcile.ts
+++ b/packages/retree-convex/src/reconcile.ts
@@ -9,8 +9,24 @@ import { reconcileArray } from "./internals/reconcile";
 /**
  * Create a reconciler for arrays of objects with stable IDs.
  *
+ * @remarks
+ * Use this for non-Convex arrays whose items have stable IDs. Reconciliation
+ * updates matching items in place so child object identity stays stable for
+ * `useNode(item)` rows and Retree parent relationships.
+ *
+ * Do not use index-based reconciliation for lists that can reorder. Prefer a
+ * stable ID from the server.
+ *
  * @param idKey Object key containing the stable item ID.
  * @returns A reconciler that updates matching array items in place.
+ *
+ * @example
+ * ```ts
+ * this.tasks = this.query(api.tasks.listExternal, {
+ *     args: { projectId },
+ *     reconcile: reconcileArrayById("id"),
+ * });
+ * ```
  */
 export function reconcileArrayById<
     TItem extends Record<TKey, PropertyKey>,
@@ -31,7 +47,21 @@ export function reconcileArrayById<
 /**
  * Create a reconciler for Convex document arrays using each document's `_id`.
  *
+ * @remarks
+ * Use this for Convex document arrays when you want explicit reconciliation.
+ * `ConvexQueryNode` also tries Convex `_id` reconciliation by default for
+ * document arrays, but passing this reconciler makes the behavior clear at the
+ * call site.
+ *
  * @returns A reconciler that updates matching Convex documents in place.
+ *
+ * @example
+ * ```ts
+ * this.tasks = this.query(api.tasks.list, {
+ *     args: { projectId },
+ *     reconcile: reconcileConvexDocuments(),
+ * });
+ * ```
  */
 export function reconcileConvexDocuments<
     TDoc extends { _id: PropertyKey }

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -147,6 +147,19 @@ project.tasks[0].done = true; // ✅ emits: selected count changed 1 -> 2
 project.tasks[0].title = "Better docs"; // ❌ no emit: selected count stayed 2
 ```
 
+`Retree.select` can also infer its own dependencies when you pass only a selector function and a callback. Whole Retree-managed values read by the selector subscribe automatically. Property reads subscribe to the owner node but compare the specific property value, so `task.done` reacts to task replacement or `done` changes without reacting to unrelated task fields. Primitive reads compare.
+
+```ts
+const unsubscribeDoneCount = Retree.select(
+    () => project.tasks.filter((task) => task.done).length,
+    (doneCount) => console.log(doneCount)
+);
+
+project.tasks[0].done = true; // ✅ emits: trapped task read changed the count
+project.tasks[0].title = "Better docs"; // ❌ no emit: selected count stayed 2
+unsubscribeDoneCount();
+```
+
 Selectors can also return an ordered dependency list. Reactive entries are subscribed to; primitive and plain entries are compared. This is useful when a broad source can change often, but only a narrowed selected value should notify.
 
 ```ts
@@ -318,6 +331,25 @@ class HeaderState extends ReactiveNode {
 Use `@select` when the dependency list belongs to one getter and you want `useNode(node)` to re-render only when those selected dependencies change:
 
 ```ts
+import { ReactiveNode, link, memo, select } from "@retreejs/core";
+
+class TaskRow extends ReactiveNode {
+    @link public task!: { isCompleted: boolean };
+    @link public filter!: { isComplete: boolean | null };
+
+    @select()
+    get isVisible() {
+        return (
+            this.filter.isComplete === null ||
+            this.task.isCompleted === this.filter.isComplete
+        );
+    }
+}
+```
+
+`@select()` without a selector traps dependencies while the getter runs. Whole Retree-managed values read by the getter subscribe; property reads subscribe to the owner node but compare the specific property value; primitive values read by the getter compare. Pass an explicit selector when you want to choose or customize dependency slots:
+
+```ts
 import { ReactiveNode, memo, select } from "@retreejs/core";
 
 class AttributeRow extends ReactiveNode {
@@ -340,7 +372,7 @@ class AttributeRow extends ReactiveNode {
 }
 ```
 
-In `@select`, raw reactive values subscribe, primitive values compare, and `self.dependency(...)` customizes one slot's comparison behavior.
+In explicit `@select` lists, raw reactive values subscribe, primitive values compare, and `self.dependency(...)` customizes one slot's comparison behavior.
 
 ## Memoize computed getters
 

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -22,12 +22,13 @@ Use this as a quick map before choosing an API:
 
 -   [`Retree.root`](#how-to-use) makes one object the root of a Retree-managed tree. Use it once at the boundary where plain state enters Retree.
 -   [`Retree.on`](#listen-to-nodechanged-treechanged-and-noderemoved) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React or inside lower-level integrations.
--   [`Retree.select`](#select-derived-values) subscribes to one derived value and only calls back when that selected value changes. Use it to narrow notifications; it is not a cache.
+-   [`Retree.select`](#select-derived-values) subscribes to a selected value or ordered dependency list. Use it to narrow notifications; it is not a cache.
 -   [`Retree.parent`](#find-a-parent) returns the structural parent of a node. Use it for tree-local actions like deleting yourself from an array.
 -   [`Retree.move`](#move-link-or-clone-existing-nodes) transfers an existing node to a new structural parent. Use it when ownership should change.
 -   [`Retree.link` and `@link`](#move-link-or-clone-existing-nodes) store a reactive pointer to a node without reparenting it. Use it for selected items and cross-references.
 -   [`Retree.clone`](#move-link-or-clone-existing-nodes) creates a detached copy. Use it when two places need independent state.
--   [`ReactiveNode.dependencies`](#reactive-dependencies) makes one node emit when another node changes. Use it as a narrow bridge instead of broad `treeChanged` subscriptions.
+-   [`@select`](#reactive-dependencies) makes a getter's owning `ReactiveNode` emit from an ordered dependency list. Use it when VM logic should stay in the node while renders stay narrow.
+-   [`ReactiveNode.dependencies`](#reactive-dependencies) makes one node emit when another node changes. Use raw reactive nodes/primitives for simple slots, or `this.dependency(node, comparisons)` for custom comparison cells.
 -   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Use them to skip recomputation; they do not emit changes by themselves.
 -   [`@ignore`](#opt-fields-out-of-reactivity-with-ignore) keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, subscriptions, framework handles, and non-rendered state.
 -   [`Retree.runTransaction`](#transactions) batches synchronous mutations into one listener flush per changed node. Use it for one logical update made of several writes.
@@ -107,7 +108,7 @@ Retree.clearListeners(board.cards, false); // clear the list and child listeners
 
 ## Select derived values
 
-`Retree.select` subscribes to a derived value from any Retree-managed node and only calls your callback when that selected value changes. This is different from `memo` and `fnMemo`: memoization caches computation, while `select` narrows notifications.
+`Retree.select` subscribes to a selected value or ordered dependency list from any Retree-managed node and only calls your callback when that selection changes. This is different from `memo` and `fnMemo`: memoization caches computation, while `select` narrows notifications.
 
 ```ts
 const root = Retree.root({
@@ -146,7 +147,19 @@ project.tasks[0].done = true; // ✅ emits: selected count changed 1 -> 2
 project.tasks[0].title = "Better docs"; // ❌ no emit: selected count stayed 2
 ```
 
-By default, `select` listens to `nodeChanged` on the node you pass. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes, and pass `equals` when the selected value is a new object or array that should be compared structurally.
+Selectors can also return an ordered dependency list. Reactive entries are subscribed to; primitive and plain entries are compared. This is useful when a broad source can change often, but only a narrowed selected value should notify.
+
+```ts
+const unsubscribeAttribute = Retree.select(
+    row,
+    (self) => [self.attributes, self.attributeId, self.attribute],
+    ([, , nextAttribute], [, , previousAttribute]) => {
+        console.log({ nextAttribute, previousAttribute });
+    }
+);
+```
+
+By default, `select` listens to `nodeChanged` on the node you pass. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendants, and pass `equals` when you need custom comparison for the entire selected value or tuple.
 
 `select` does not cache expensive work for later reads. If the selector is expensive and reused from multiple places, put the expensive part behind `memo`, `@memo`, or `@fnMemo`, then select the cached value.
 
@@ -248,6 +261,8 @@ Links are not structural parents: if `editor.selectedTask` is a `@link` field po
 
 `ReactiveNode.dependencies` lets one node emit `nodeChanged` when another node changes. Use it when a node exposes derived state but you do not want broad `treeChanged` subscriptions.
 
+Return raw Retree-managed nodes directly when any change to that node should emit. Return primitives directly when they should be compared only. Wrap one slot with `this.dependency(node, comparisons)` when a reactive dependency needs custom comparison cells.
+
 ```ts
 class ProjectSummary extends ReactiveNode {
     public tasks: { done: boolean }[] = [];
@@ -269,6 +284,46 @@ summary.tasks[0].done = true; //       ✅ emits: doneCount changed 0 -> 1
 ```
 
 Keep dependency arrays stable in length and order. Use `null` as the dependency node for an inactive slot instead of adding or removing array entries.
+
+For simple cases, no wrapper is needed:
+
+```ts
+class FilterState extends ReactiveNode {
+    public tasks: { done: boolean }[] = [];
+    public searchText = "";
+
+    get dependencies() {
+        return [this.tasks, this.searchText];
+    }
+}
+```
+
+Use `@select` when the dependency list belongs to one getter and you want `useNode(node)` to re-render only when those selected dependencies change:
+
+```ts
+import { ReactiveNode, memo, select } from "@retreejs/core";
+
+class AttributeRow extends ReactiveNode {
+    public attributes: { id: string; label: string }[] = [];
+    public attributeId!: string;
+
+    @memo((self: AttributeRow) => [self.attributes, self.attributeId])
+    private get _attribute() {
+        return this.attributes.find((check) => check.id === this.attributeId);
+    }
+
+    @select((self) => [
+        self.attributes,
+        self.attributeId,
+        self.dependency(self._attribute, [self._attribute?.id]),
+    ])
+    get attribute() {
+        return this._attribute;
+    }
+}
+```
+
+In `@select`, raw reactive values subscribe, primitive values compare, and `self.dependency(...)` customizes one slot's comparison behavior.
 
 ## Memoize computed getters
 
@@ -501,7 +556,7 @@ Retree.on(todoList, "treeChanged", (nextList) => {
 });
 ```
 
-`treeChanged` is most expensive when a listener also performs deep reads across the subtree, because the listener is asking Retree to propagate the ancestor change and then traverse the changed graph. If a selector or component only needs one derived value, prefer `Retree.select(...)` on the narrowest node that owns that value.
+`treeChanged` is most expensive when a listener also performs deep reads across the subtree, because the listener is asking Retree to propagate the ancestor change and then traverse the changed graph. If a selector or component only needs one selected value or dependency list, prefer `Retree.select(...)` on the narrowest node that owns that value.
 
 ### Use `ReactiveNode.dependencies` as a narrow bridge
 

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -29,7 +29,7 @@ Use this as a quick map before choosing an API:
 -   [`Retree.clone`](#move-link-or-clone-existing-nodes) creates a detached copy. Use it when two places need independent state.
 -   [`@select`](#reactive-dependencies) makes a getter's owning `ReactiveNode` emit from an ordered dependency list. Use it when VM logic should stay in the node while renders stay narrow.
 -   [`ReactiveNode.dependencies`](#reactive-dependencies) makes one node emit when another node changes. Use raw reactive nodes/primitives for simple slots, or `this.dependency(node, comparisons)` for custom comparison cells.
--   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Use them to skip recomputation; they do not emit changes by themselves.
+-   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Prefer bare decorators for automatic dependency trapping; pass comparison functions for finer cache-key control.
 -   [`@ignore`](#opt-fields-out-of-reactivity-with-ignore) keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, subscriptions, framework handles, and non-rendered state.
 -   [`Retree.runTransaction`](#transactions) batches synchronous mutations into one listener flush per changed node. Use it for one logical update made of several writes.
 -   [`Retree.runSilent`](#skip-emitting-changes) performs writes without emitting listeners. Use it for non-rendered bookkeeping.
@@ -356,7 +356,7 @@ class AttributeRow extends ReactiveNode {
     public attributes: { id: string; label: string }[] = [];
     public attributeId!: string;
 
-    @memo((self: AttributeRow) => [self.attributes, self.attributeId])
+    @memo
     private get _attribute() {
         return this.attributes.find((check) => check.id === this.attributeId);
     }
@@ -376,7 +376,9 @@ In explicit `@select` lists, raw reactive values subscribe, primitive values com
 
 ## Memoize computed getters
 
-`ReactiveNode` exposes a `memo` helper for caching the result of a computed getter, similar in spirit to React's `useMemo`. It also exposes `@fnMemo` for caching deterministic method return values. Four forms are supported:
+`ReactiveNode` exposes `@memo` for caching computed getters and `@fnMemo` for caching deterministic method return values. With no arguments, both decorators automatically trap the Retree reads inside the getter or method and invalidate the cache when those values change.
+
+Pass a comparison function only when you want finer control over the cache keys. The method forms (`this.memo(fn, deps?)` and `this.memo(key, fn, deps?)`) are still available when you need to memoize part of a getter or maintain multiple cache cells.
 
 ```ts
 import { Retree, ReactiveNode, fnMemo, memo } from "@retreejs/core";
@@ -389,35 +391,14 @@ class ListFilter extends ReactiveNode {
     public list: Card[] = [];
     public searchText = "";
 
-    // 1) Keyless method form — cache key is the getter's name.
+    // Recommended: @memo traps the Retree reads in this getter automatically.
+    @memo
     get filteredList(): Card[] {
-        return this.memo(
-            () => this.list.filter((c) => c.text === this.searchText),
-            [this.list, this.searchText]
-        );
-    }
-
-    // 2) Decorator form — same cache-key behavior; pass a function that
-    //    returns deps so they're read live on every access.
-    @memo((self: ListFilter) => [self.list, self.searchText])
-    get filteredListDecorated(): Card[] {
         return this.list.filter((c) => c.text === this.searchText);
     }
 
-    // 3) Explicit-key method form — required for multiple memos in one
-    //    getter, or memoizing inside a method.
-    get pair() {
-        const filtered = this.memo(
-            "filtered",
-            () => this.list.filter((c) => c.text === this.searchText),
-            [this.list, this.searchText]
-        );
-        const count = this.memo("count", () => filtered.length, [filtered]);
-        return { filtered, count };
-    }
-
-    // 4) Function decorator form — compares method arguments plus deps.
-    @fnMemo((self: ListFilter) => [self.list, self.searchText])
+    // Recommended: @fnMemo traps Retree reads and also compares method args.
+    @fnMemo
     filteredListLimited(limit: number): Card[] {
         return this.list
             .filter((c) => c.text === this.searchText)
@@ -430,9 +411,66 @@ class ListFilter extends ReactiveNode {
 }
 ```
 
-`deps` semantics (same for all forms; `@fnMemo` also compares method arguments and passes them to the `deps` function):
+Pass a comparison function when the automatic trapper is broader than you want:
 
--   `undefined` → recompute whenever the `ReactiveNode` reproxies (any dependency changes or a property is set).
+```ts
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    @memo((self: ListFilter) => [self.list, self.searchText])
+    get filteredList(): Card[] {
+        return this.list.filter((c) => c.text === this.searchText);
+    }
+
+    @fnMemo((self: ListFilter, limit: number) => [
+        self.list,
+        self.searchText,
+        limit,
+    ])
+    filteredListLimited(limit: number): Card[] {
+        return this.list
+            .filter((c) => c.text === this.searchText)
+            .slice(0, limit);
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+Use the method forms when a decorator does not fit:
+
+```ts
+class ListFilter extends ReactiveNode {
+    public list: Card[] = [];
+    public searchText = "";
+
+    get filteredList(): Card[] {
+        return this.memo(() =>
+            this.list.filter((c) => c.text === this.searchText)
+        );
+    }
+
+    get pair() {
+        const filtered = this.memo("filtered", () =>
+            this.list.filter((c) => c.text === this.searchText)
+        );
+        const count = this.memo("count", () => filtered.length, [filtered]);
+        return { filtered, count };
+    }
+
+    get dependencies() {
+        return [this.dependency(this.list)];
+    }
+}
+```
+
+Comparison semantics (same for all forms; `@fnMemo` also compares method arguments):
+
+-   Bare/empty decorators, or omitted `this.memo` comparisons → trap Retree reads automatically and recompute when a trapped value changes.
+-   Function returns `undefined` → recompute whenever the `ReactiveNode` reproxies (any dependency changes or a property is set).
 -   `[]` → compute once and cache forever for that instance.
 -   `[a, b, ...]` → recompute when any cell shallow-changes (compared with `Object.is`). Tree-node cells are compared by their latest reproxy identity, so passing `this.list` correctly invalidates when `list` mutates.
 

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -6,10 +6,8 @@ Retree is a lightweight and simple state management library, specifically design
 
 Install with `npm`:
 
-xretree
-
 ```bash
-npm i @evergreen/core
+npm i @retreejs/core
 ```
 
 Install with `yarn`:
@@ -17,6 +15,24 @@ Install with `yarn`:
 ```bash
 yarn add @retreejs/core
 ```
+
+## Feature glossary
+
+Use this as a quick map before choosing an API:
+
+-   [`Retree.root`](#how-to-use) makes one object the root of a Retree-managed tree. Use it once at the boundary where plain state enters Retree.
+-   [`Retree.on`](#listen-to-nodechanged-treechanged-and-noderemoved) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React or inside lower-level integrations.
+-   [`Retree.select`](#select-derived-values) subscribes to one derived value and only calls back when that selected value changes. Use it to narrow notifications; it is not a cache.
+-   [`Retree.parent`](#find-a-parent) returns the structural parent of a node. Use it for tree-local actions like deleting yourself from an array.
+-   [`Retree.move`](#move-link-or-clone-existing-nodes) transfers an existing node to a new structural parent. Use it when ownership should change.
+-   [`Retree.link` and `@link`](#move-link-or-clone-existing-nodes) store a reactive pointer to a node without reparenting it. Use it for selected items and cross-references.
+-   [`Retree.clone`](#move-link-or-clone-existing-nodes) creates a detached copy. Use it when two places need independent state.
+-   [`ReactiveNode.dependencies`](#reactive-dependencies) makes one node emit when another node changes. Use it as a narrow bridge instead of broad `treeChanged` subscriptions.
+-   [`memo`, `@memo`, and `@fnMemo`](#memoize-computed-getters) cache computed values. Use them to skip recomputation; they do not emit changes by themselves.
+-   [`@ignore`](#opt-fields-out-of-reactivity-with-ignore) keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, subscriptions, framework handles, and non-rendered state.
+-   [`Retree.runTransaction`](#transactions) batches synchronous mutations into one listener flush per changed node. Use it for one logical update made of several writes.
+-   [`Retree.runSilent`](#skip-emitting-changes) performs writes without emitting listeners. Use it for non-rendered bookkeeping.
+-   [`ReactiveNode.prepareTree`](#prepare-lazy-reactivenode-fields) warms lazy child proxies. Use it when first-touch proxy cost should happen during a controlled loading phase.
 
 ## How to use
 
@@ -55,10 +71,38 @@ const tree = Retree.root(new TodoList());
 const unsubscribe = Retree.on(tree.todos, "treeChanged", (todos) => {
     console.log("list updated", todos);
 });
-tree.todos.add();
+tree.add();
 tree.todos[0].toggle();
 tree.todos[0].delete();
 unsubscribe();
+```
+
+## Listen to nodeChanged, treeChanged, and nodeRemoved
+
+`Retree.on` is the core subscription primitive. `nodeChanged` fires for direct changes to that node. `treeChanged` fires for the node and descendant changes. `nodeRemoved` fires when that node is detached from its parent.
+
+```ts
+const board = Retree.root({
+    title: "Roadmap",
+    cards: [{ text: "Ship docs", done: false }],
+});
+
+Retree.on(board, "nodeChanged", () => console.log("board changed"));
+Retree.on(board, "treeChanged", () => console.log("board subtree changed"));
+Retree.on(board.cards[0], "nodeRemoved", () => console.log("card removed"));
+
+board.title = "Q2 Roadmap"; // ✅ nodeChanged(board), ✅ treeChanged(board)
+board.cards[0].done = true; // ❌ nodeChanged(board), ✅ treeChanged(board)
+board.cards.splice(0, 1); // ✅ nodeRemoved(card), ✅ treeChanged(board)
+```
+
+Call the unsubscribe returned by `Retree.on(...)` when you only want to remove one listener. Use `Retree.clearListeners(node)` when you own all listeners for a node and want to remove them at once.
+
+```ts
+const unsubscribe = Retree.on(board, "nodeChanged", () => {});
+unsubscribe();
+
+Retree.clearListeners(board.cards, false); // clear the list and child listeners
 ```
 
 ## Select derived values
@@ -83,7 +127,28 @@ root.total = 25;
 unsubscribe();
 ```
 
+```ts
+const project = Retree.root({
+    tasks: [
+        { title: "Docs", done: false },
+        { title: "Tests", done: true },
+    ],
+});
+
+Retree.select(
+    project.tasks,
+    (tasks) => tasks.filter((task) => task.done).length,
+    (doneCount) => console.log(doneCount),
+    { listenerType: "treeChanged" }
+);
+
+project.tasks[0].done = true; // ✅ emits: selected count changed 1 -> 2
+project.tasks[0].title = "Better docs"; // ❌ no emit: selected count stayed 2
+```
+
 By default, `select` listens to `nodeChanged` on the node you pass. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes, and pass `equals` when the selected value is a new object or array that should be compared structurally.
+
+`select` does not cache expensive work for later reads. If the selector is expensive and reused from multiple places, put the expensive part behind `memo`, `@memo`, or `@fnMemo`, then select the cached value.
 
 ## Move, link, or clone existing nodes
 
@@ -98,6 +163,20 @@ Retree.move(task, tasksById, task.id); // Map key or object key
 ```
 
 `ReactiveNode` also has `moveTo(destination, key?)`, which wraps `Retree.move(this, destination, key)`.
+
+```ts
+class Task extends ReactiveNode {
+    public title = "";
+
+    get dependencies() {
+        return [];
+    }
+
+    public archive(archiveList: Task[]) {
+        this.moveTo(archiveList); // same as Retree.move(this, archiveList)
+    }
+}
+```
 
 Use `Retree.link(node)` or `@link` when one part of your state should point at a node that remains owned somewhere else. Replacing the link emits on the owner, but the target keeps its original parent. Reads return the latest reproxy for the linked node.
 
@@ -115,13 +194,81 @@ root.selectedTask.current.title = "Write better docs";
 class EditorState extends ReactiveNode {
     @link public selectedTask: { title: string } | null = null;
 
+    public select(task: { title: string }) {
+        this.selectedTask = task;
+    }
+
+    public selectedTaskLink(task: { title: string }) {
+        return this.link(task); // same as Retree.link(task)
+    }
+
     get dependencies() {
         return [];
     }
 }
 ```
 
+```ts
+const state = Retree.root(new EditorState());
+state.selectedTask = root.tasks[0]; // ✅ emits on state, ❌ does not reparent task
+state.selectedTask.title = "Renamed"; // ✅ emits where the task is structurally owned
+state.selectedTask = root.tasks[0]; // ❌ no emit if the field already points there
+```
+
 Use `Retree.clone(node)` when you want a detached copy that can become a new child somewhere else.
+
+```ts
+const copy = Retree.clone(root.tasks[0]);
+root.tasks.push(copy); // ✅ emits for root.tasks; copy is a new structural child
+```
+
+## Find a parent
+
+`Retree.parent(node)` returns the node's structural parent, or `null` for a root.
+
+```ts
+class Task {
+    public title = "";
+
+    public removeSelf() {
+        const parent = Retree.parent(this);
+        if (!Array.isArray(parent)) return;
+
+        const index = parent.indexOf(this);
+        if (index >= 0) {
+            parent.splice(index, 1); // ✅ emits on the parent list
+        }
+    }
+}
+```
+
+Links are not structural parents: if `editor.selectedTask` is a `@link` field pointing at `project.tasks[0]`, `Retree.parent(editor.selectedTask)` still returns `project.tasks`.
+
+## Reactive dependencies
+
+`ReactiveNode.dependencies` lets one node emit `nodeChanged` when another node changes. Use it when a node exposes derived state but you do not want broad `treeChanged` subscriptions.
+
+```ts
+class ProjectSummary extends ReactiveNode {
+    public tasks: { done: boolean }[] = [];
+
+    get doneCount() {
+        return this.tasks.filter((task) => task.done).length;
+    }
+
+    get dependencies() {
+        return [this.dependency(this.tasks, [this.doneCount])];
+    }
+}
+
+const summary = Retree.root(new ProjectSummary());
+Retree.on(summary, "nodeChanged", () => console.log(summary.doneCount));
+
+summary.tasks.push({ done: false }); // ❌ no emit: doneCount stayed 0
+summary.tasks[0].done = true; //       ✅ emits: doneCount changed 0 -> 1
+```
+
+Keep dependency arrays stable in length and order. Use `null` as the dependency node for an inactive slot instead of adding or removing array entries.
 
 ## Memoize computed getters
 
@@ -286,6 +433,54 @@ class EagerNode extends ReactiveNode {
         return [];
     }
 }
+```
+
+## Transactions
+
+Use `Retree.runTransaction(...)` when several synchronous writes are one logical update. Retree still updates every changed node, but listener callbacks flush once per changed node after the transaction finishes.
+
+```ts
+const counter = Retree.root({ count: 0 });
+let emits = 0;
+
+Retree.on(counter, "nodeChanged", () => {
+    emits += 1;
+});
+
+Retree.runTransaction(() => {
+    counter.count += 1;
+    counter.count *= 2;
+});
+
+console.log(counter.count); // 2
+console.log(emits); // ✅ 1 emit, not 2
+```
+
+## Skip emitting changes
+
+Use `Retree.runSilent(...)` for writes that should update state without notifying listeners. By default it also skips reproxying, which means old and new object identities remain equal for comparison checks.
+
+```ts
+const settings = Retree.root({
+    renderedCount: 0,
+    telemetryCount: 0,
+});
+
+Retree.on(settings, "nodeChanged", () => console.log("render"));
+
+Retree.runSilent(() => {
+    settings.telemetryCount += 1;
+}); // ❌ no emit
+
+settings.renderedCount += 1; // ✅ emits
+```
+
+Pass `false` as the second argument when you want to suppress listener emission but still refresh reproxy identities for later comparisons:
+
+```ts
+Retree.runSilent(() => {
+    settings.telemetryCount += 1;
+}, false);
 ```
 
 ## Performance model

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -85,6 +85,44 @@ unsubscribe();
 
 By default, `select` listens to `nodeChanged` on the node you pass. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes, and pass `equals` when the selected value is a new object or array that should be compared structurally.
 
+## Move, link, or clone existing nodes
+
+Retree keeps a pure ownership tree: a node can have one structural parent. If you need to put an existing node somewhere else, choose the operation that matches your intent.
+
+Use `Retree.move(node, destination, key?)` when ownership should move. Arrays accept a numeric `key` as the insertion index, or omit it to append. Maps and objects require a key. Sets ignore the key.
+
+```ts
+const task = projectA.tasks[0];
+Retree.move(task, projectB.tasks); // append to projectB.tasks
+Retree.move(task, tasksById, task.id); // Map key or object key
+```
+
+`ReactiveNode` also has `moveTo(destination, key?)`, which wraps `Retree.move(this, destination, key)`.
+
+Use `Retree.link(node)` or `@link` when one part of your state should point at a node that remains owned somewhere else. Replacing the link emits on the owner, but the target keeps its original parent. Reads return the latest reproxy for the linked node.
+
+```ts
+import { Retree, ReactiveNode, link } from "@retreejs/core";
+
+const root = Retree.root({
+    tasks: [{ title: "Write docs" }],
+    selectedTask: null as null | ReturnType<typeof Retree.link>,
+});
+
+root.selectedTask = Retree.link(root.tasks[0]);
+root.selectedTask.current.title = "Write better docs";
+
+class EditorState extends ReactiveNode {
+    @link public selectedTask: { title: string } | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+```
+
+Use `Retree.clone(node)` when you want a detached copy that can become a new child somewhere else.
+
 ## Memoize computed getters
 
 `ReactiveNode` exposes a `memo` helper for caching the result of a computed getter, similar in spirit to React's `useMemo`. It also exposes `@fnMemo` for caching deterministic method return values. Four forms are supported:
@@ -334,7 +372,7 @@ node.cache.something = 1; // ❌ no log
 node.count = 1; //            ✅ logs "changed"
 ```
 
-**Caveat:** because the field's value isn't wrapped, you also lose `Retree.parent(...)` for objects stored under it, and they won't appear in `treeChanged` notifications. Treat ignored fields as opaque from Retree's perspective.
+**Caveat:** because the field's value isn't wrapped, plain objects stored under it lose `Retree.parent(...)` and won't appear in `treeChanged` notifications. If you store an existing Retree-managed node in an ignored field, Retree does not reparent it, but reads still return that node's latest reproxy.
 
 ## Core samples
 

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -161,6 +161,8 @@ const unsubscribeAttribute = Retree.select(
 
 By default, `select` listens to `nodeChanged` on the node you pass. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendants, and pass `equals` when you need custom comparison for the entire selected value or tuple.
 
+Dependency-list subscriptions in `Retree.select` are observational. If `self.attributes` or `self.attribute` changes in the example above, the callback can run, but the `row` node passed to `Retree.select` is not forced to receive a fresh reproxy. Use `@select` when a `ReactiveNode` owner should emit `nodeChanged`.
+
 `select` does not cache expensive work for later reads. If the selector is expensive and reused from multiple places, put the expensive part behind `memo`, `@memo`, or `@fnMemo`, then select the cached value.
 
 ## Move, link, or clone existing nodes
@@ -283,17 +285,32 @@ summary.tasks.push({ done: false }); // ❌ no emit: doneCount stayed 0
 summary.tasks[0].done = true; //       ✅ emits: doneCount changed 0 -> 1
 ```
 
-Keep dependency arrays stable in length and order. Use `null` as the dependency node for an inactive slot instead of adding or removing array entries.
+Dependency arrays should be deterministic, but they may change length or order at runtime. Retree treats added, removed, or reordered entries as invalidation and refreshes subscriptions. Use `null` when you want an inactive slot to keep its position, but it is not required for correctness.
 
 For simple cases, no wrapper is needed:
 
 ```ts
-class FilterState extends ReactiveNode {
-    public tasks: { done: boolean }[] = [];
-    public searchText = "";
+import { ReactiveNode, link } from "@retreejs/core";
+
+class AuthStore extends ReactiveNode {
+    public session: { userId: string; role: string } | null = null;
 
     get dependencies() {
-        return [this.tasks, this.searchText];
+        return [];
+    }
+}
+
+class HeaderState extends ReactiveNode {
+    @link
+    public auth: AuthStore;
+
+    constructor(auth: AuthStore) {
+        super();
+        this.auth = auth;
+    }
+
+    get dependencies() {
+        return [this.auth, this.auth.session?.userId];
     }
 }
 ```
@@ -560,10 +577,11 @@ Retree.on(todoList, "treeChanged", (nextList) => {
 
 ### Use `ReactiveNode.dependencies` as a narrow bridge
 
-`ReactiveNode.dependencies` is a good way to make one node react to another node without subscribing a broad tree. Keep the getter deterministic and stable:
+`ReactiveNode.dependencies` is a good way to make one node react to another node without subscribing a broad tree. Keep the getter deterministic:
 
--   Keep dependency list length and order stable.
+-   Dependency list length/order can change; Retree treats shape changes as invalidation and refreshes subscriptions.
 -   Use comparison values when only some changes should emit.
+-   Prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when the selected items or selected order changes.
 -   Avoid doing setup, network subscriptions, or synchronization inside `dependencies`; use `onObserved()`, `onUnobserved()`, and `onChanged()` for lifecycle work.
 -   Prefer one dependency on a narrow child node over a dependency on a broad parent.
 

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -4,7 +4,10 @@ import { Retree } from "./Retree";
 import { ignore } from "./decorators";
 import { getCustomProxyHandler, getUnproxiedNode } from "./internals";
 import { proxiedChildrenKey } from "./internals/proxy-types";
-import { getReactiveDependencies } from "./internals/reactive-node-utils";
+import {
+    getReactiveDependencies,
+    getReactiveDependents,
+} from "./internals/reactive-node-utils";
 import { Transactions } from "./internals/transactions";
 
 const rootsToCleanup: object[] = [];
@@ -142,6 +145,16 @@ class SharedDependencyNode extends ReactiveNode {
     }
 }
 
+class DuplicateDependencyNode extends ReactiveNode {
+    constructor(public target: SharedDependencyTargetNode) {
+        super();
+    }
+
+    get dependencies() {
+        return [this.target.values, this.target.values];
+    }
+}
+
 class CountingStableDependencyNode extends ReactiveNode {
     @ignore
     public dependenciesReadCount = 0;
@@ -221,6 +234,35 @@ class OptionalDependencyNode extends ReactiveNode {
     }
 }
 
+class DynamicDependencyTargetNode extends ReactiveNode {
+    public items = Array.from({ length: 12 }, (_, index) => ({
+        id: String(index),
+        value: 0,
+    }));
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class DynamicItemListDependencyNode extends ReactiveNode {
+    public activeIds = Array.from({ length: 10 }, (_, index) => String(index));
+
+    @ignore
+    public target: DynamicDependencyTargetNode;
+
+    constructor(target: DynamicDependencyTargetNode) {
+        super();
+        this.target = target;
+    }
+
+    get dependencies() {
+        return this.activeIds.map(
+            (id) => this.target.items.find((item) => item.id === id) ?? null
+        );
+    }
+}
+
 describe("ReactiveNode", () => {
     it("emits only when comparison values change", () => {
         const root = trackRoot(Retree.root(new EvenNumberNode()));
@@ -235,22 +277,29 @@ describe("ReactiveNode", () => {
         expect(nodeChanged.mock.calls.at(-1)?.[0].evenNumberCount).toBe(2);
     });
 
-    it("throws when dependency list length changes while subscribed", () => {
+    it("allows dependency list length changes and resubscribes", () => {
         const root = trackRoot(Retree.root(new DynamicDependencyNode()));
-        Retree.on(root, "nodeChanged", vi.fn());
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
 
         expect(() => {
             root.includeSecond = true;
-        }).toThrow(/dependencies/i);
+        }).not.toThrow();
+
+        root.second.push(1);
+
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
     });
 
-    it("throws when comparison list length changes for a dependency", () => {
+    it("emits when comparison list length changes for a dependency", () => {
         const root = trackRoot(Retree.root(new DynamicComparisonNode()));
-        Retree.on(root, "nodeChanged", vi.fn());
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
 
         expect(() => {
             root.numbers.push(1);
-        }).toThrow(/comparisons/i);
+        }).not.toThrow();
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
     });
 
     it("accepts direct reactive and primitive dependency values", () => {
@@ -276,6 +325,62 @@ describe("ReactiveNode", () => {
         expect(activeDependencies?.[1]?.comparisons).toEqual([0]);
         expect(activeDependencies?.[2]?.node).toBeUndefined();
         expect(activeDependencies?.[2]?.comparisons).toEqual([0]);
+    });
+
+    it("supports dynamic dependency lists", () => {
+        const target = trackRoot(
+            Retree.root(new DynamicDependencyTargetNode())
+        );
+        const root = trackRoot(
+            Retree.root(new DynamicItemListDependencyNode(target))
+        );
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        root.activeIds = ["0", "10"];
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+
+        target.items[1].value = 1;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+
+        target.items[10].value = 1;
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
+    });
+
+    it("unsubscribes removed dependencies even when another value takes the same position", () => {
+        const target = trackRoot(
+            Retree.root(new DynamicDependencyTargetNode())
+        );
+        const root = trackRoot(
+            Retree.root(new DynamicItemListDependencyNode(target))
+        );
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        const rawRoot = getUnproxiedNode(root);
+        const rawRemovedItem = getUnproxiedNode(target.items[9]);
+        if (!rawRoot) {
+            throw new Error("Expected dependent root to be Retree managed.");
+        }
+        if (!rawRemovedItem) {
+            throw new Error("Expected removed item to be Retree managed.");
+        }
+
+        root.activeIds = ["8", "7", "6", "5", "4", "3", "2", "1", "0", "10"];
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        nodeChanged.mockClear();
+
+        expect(
+            getReactiveDependents(rawRemovedItem)?.some(
+                (dependent) => dependent.unproxiedReactiveNode === rawRoot
+            ) ?? false
+        ).toBe(false);
+
+        target.items[9].value = 1;
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        target.items[10].value = 1;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
     });
 
     it("does not run changed effects when the node is first observed", () => {
@@ -464,6 +569,20 @@ describe("ReactiveNode", () => {
         target.values.push(3);
         expect(firstChanged).toHaveBeenCalledTimes(1);
         expect(secondChanged).toHaveBeenCalledTimes(2);
+    });
+
+    it("emits once when the same dependency appears in multiple slots", () => {
+        const target = trackRoot(Retree.root(new SharedDependencyTargetNode()));
+        const dependent = trackRoot(
+            Retree.root(new DuplicateDependencyNode(target))
+        );
+        const nodeChanged = vi.fn();
+
+        Retree.on(dependent, "nodeChanged", nodeChanged);
+
+        target.values.push(1);
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
     });
 
     it("reads dependencies once per reactive-node update when dependency nodes stay stable", () => {

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -181,6 +181,22 @@ class CountingComparisonDependencyNode extends ReactiveNode {
     }
 }
 
+class DirectDependencySyntaxNode extends ReactiveNode {
+    public threshold = 0;
+
+    constructor(public target: SharedDependencyTargetNode) {
+        super();
+    }
+
+    get dependencies() {
+        return [
+            this.target.values,
+            this.threshold,
+            this.dependency(this.threshold),
+        ];
+    }
+}
+
 class ReplacingDependencyNode extends ReactiveNode {
     public useSecond = false;
 
@@ -235,6 +251,31 @@ describe("ReactiveNode", () => {
         expect(() => {
             root.numbers.push(1);
         }).toThrow(/comparisons/i);
+    });
+
+    it("accepts direct reactive and primitive dependency values", () => {
+        const target = trackRoot(Retree.root(new SharedDependencyTargetNode()));
+        const root = trackRoot(
+            Retree.root(new DirectDependencySyntaxNode(target))
+        );
+        const nodeChanged = vi.fn();
+
+        Retree.on(root, "nodeChanged", nodeChanged);
+        target.values.push(1);
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+
+        const rawRoot = getUnproxiedNode(root);
+        if (!rawRoot) {
+            throw new Error("Expected root to be Retree managed.");
+        }
+        const activeDependencies = getReactiveDependencies(rawRoot);
+
+        expect(activeDependencies?.[0]?.node).toBe(root.target.values);
+        expect(activeDependencies?.[1]?.node).toBeUndefined();
+        expect(activeDependencies?.[1]?.comparisons).toEqual([0]);
+        expect(activeDependencies?.[2]?.node).toBeUndefined();
+        expect(activeDependencies?.[2]?.comparisons).toEqual([0]);
     });
 
     it("does not run changed effects when the node is first observed", () => {

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -468,11 +468,18 @@ describe("ReactiveNode", () => {
         target.values.push(1);
         target.values.push(2);
 
+        const targetValuesRaw = getUnproxiedNode(target.values);
+        if (targetValuesRaw === undefined) {
+            throw new Error(
+                "ReactiveNode comparison dependency test expected target.values to be proxied."
+            );
+        }
         expect(nodeChanged).toHaveBeenCalledTimes(2);
         expect(
             onSpy.mock.calls.filter(
                 ([node, listenerType]) =>
-                    node === target.values && listenerType === "nodeChanged"
+                    getUnproxiedNode(node) === targetValuesRaw &&
+                    listenerType === "nodeChanged"
             )
         ).toHaveLength(1);
         expect(root.dependenciesReadCount).toBe(5);

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -1,5 +1,48 @@
 import { consumeCurrentMemoGetter, runMemo } from "./internals/memo";
-import { OptionalNode, TreeNode } from "./types";
+import type { RetreeLink } from "./Retree";
+import { OptionalNode, RetreeObjectMoveKey, TreeNode } from "./types";
+
+type LinkReactiveNode = <TNode extends TreeNode>(
+    node: TNode
+) => RetreeLink<TNode>;
+
+let linkReactiveNode: LinkReactiveNode = () => {
+    // @retree-throws
+    throw new Error(
+        "ReactiveNode.link: Retree link support has not been initialized. This is unexpected and likely a Retree packaging or module-loading bug. Fix: import ReactiveNode and Retree from the same @retreejs/core package instance. If your app already does that, please file a Retree issue with your package manager lockfile and a minimal reproduction."
+    );
+};
+
+type MoveReactiveNode = <TNode extends ReactiveNode>(
+    node: TNode,
+    destination: TreeNode,
+    key?: unknown
+) => TNode;
+
+let moveReactiveNode: MoveReactiveNode = () => {
+    // @retree-throws
+    throw new Error(
+        "ReactiveNode.moveTo: Retree move support has not been initialized. This is unexpected and likely a Retree packaging or module-loading bug. Fix: import ReactiveNode and Retree from the same @retreejs/core package instance. If your app already does that, please file a Retree issue with your package manager lockfile and a minimal reproduction."
+    );
+};
+
+/**
+ * @internal
+ */
+export function setReactiveNodeLinkImplementation(
+    implementation: LinkReactiveNode
+) {
+    linkReactiveNode = implementation;
+}
+
+/**
+ * @internal
+ */
+export function setReactiveNodeMoveImplementation(
+    implementation: MoveReactiveNode
+) {
+    moveReactiveNode = implementation;
+}
 
 /**
  * A dependency for {@link ReactiveNode}.
@@ -53,6 +96,7 @@ export interface IRetreeNodeOptions {
 }
 
 export const COLLECTED_KEYS_SYMBOL = "RETREE_COLLECTED_KEYS_SYMBOL";
+export const LINKED_KEYS_SYMBOL = "RETREE_LINKED_KEYS_SYMBOL";
 export const RUN_CHANGED_EFFECT_SYMBOL = "RETREE_RUN_CHANGED_EFFECT_SYMBOL";
 export const RUN_OBSERVED_EFFECT_SYMBOL = "RETREE_RUN_OBSERVED_EFFECT_SYMBOL";
 export const RUN_UNOBSERVED_EFFECT_SYMBOL =
@@ -100,6 +144,9 @@ export abstract class ReactiveNode {
     public [COLLECTED_KEYS_SYMBOL]: Set<string | symbol> = new Set<
         string | symbol
     >();
+    public [LINKED_KEYS_SYMBOL]: Set<string | symbol> = new Set<
+        string | symbol
+    >();
 
     /**
      * Runtime options for this Retree node.
@@ -111,9 +158,45 @@ export abstract class ReactiveNode {
 
     constructor(options?: IRetreeNodeOptions) {
         this[COLLECTED_KEYS_SYMBOL].add("options");
+        this[COLLECTED_KEYS_SYMBOL].add(LINKED_KEYS_SYMBOL);
         if (options !== undefined) {
             this.options = options;
         }
+    }
+
+    /**
+     * Move this node to a new structural parent.
+     *
+     * @remarks
+     * This is a convenience wrapper around {@link Retree.move}.
+     */
+    public moveTo<TValue extends TreeNode = this>(
+        destination: this extends TValue ? TValue[] : never,
+        key?: number
+    ): this;
+    public moveTo<TKey = unknown, TValue extends TreeNode = this>(
+        destination: this extends TValue ? Map<TKey, TValue> : never,
+        key: TKey
+    ): this;
+    public moveTo<TValue extends TreeNode = this>(
+        destination: this extends TValue ? Set<TValue> : never
+    ): this;
+    public moveTo<TDestination extends TreeNode = TreeNode>(
+        destination: TDestination,
+        key: RetreeObjectMoveKey<TDestination, this>
+    ): this;
+    public moveTo(destination: TreeNode, key?: unknown): this {
+        return moveReactiveNode(this, destination, key);
+    }
+
+    /**
+     * Create a reactive pointer to an existing Retree-managed node.
+     *
+     * @remarks
+     * This is a convenience wrapper around {@link Retree.link}.
+     */
+    public link<TNode extends TreeNode>(node: TNode): RetreeLink<TNode> {
+        return linkReactiveNode(node);
     }
 
     /**
@@ -177,8 +260,9 @@ export abstract class ReactiveNode {
     public prepareTree(options: IRetreePrepareTreeOptions = {}): void {
         const depth = options.depth ?? Infinity;
         if (depth < 0) {
+            // @retree-throws
             throw new Error(
-                "ReactiveNode.prepareTree: depth must be greater than or equal to 0."
+                "ReactiveNode.prepareTree: depth must be greater than or equal to 0. This is a caller configuration error. Fix: omit depth to prepare the full tree, pass 0 to prepare only this node, or pass a positive integer."
             );
         }
         prepareObject(this, depth, new WeakSet<object>());
@@ -334,7 +418,10 @@ function shouldSkipMaterializeKey(
     if (key === COLLECTED_KEYS_SYMBOL) {
         return true;
     }
-    return object[COLLECTED_KEYS_SYMBOL].has(key);
+    if (object[COLLECTED_KEYS_SYMBOL].has(key)) {
+        return true;
+    }
+    return object[LINKED_KEYS_SYMBOL].has(key);
 }
 
 function descriptorHasValue(

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -1,4 +1,8 @@
-import { consumeCurrentMemoGetter, runMemo } from "./internals/memo";
+import {
+    consumeCurrentMemoGetter,
+    runMemo,
+    runTrappedMemo,
+} from "./internals/memo";
 import type { RetreeLink } from "./Retree";
 import { OptionalNode, RetreeObjectMoveKey, TreeNode } from "./types";
 
@@ -498,8 +502,8 @@ export abstract class ReactiveNode {
      *   stacking multiple memo cells in one getter, or memoizing inside a method.
      *
      * Cache semantics for `comparisons`:
-     * - `undefined`: recompute whenever this {@link ReactiveNode} reproxies (a dependency
-     *   changed or a property was set on it). Useful as a "compute once per render" cache.
+     * - Omitted/`undefined`: run `fn` under automatic dependency trapping and
+     *   recompute when one of the trapped reads changes.
      * - `[]`: compute once and cache forever for this instance.
      * - `[a, b, ...]`: recompute when any cell shallow-changes using `Object.is`.
      *   Tree-node cells are compared by their latest reproxy identity, so passing
@@ -551,6 +555,9 @@ export abstract class ReactiveNode {
             key = args[0];
             fn = args[1] as () => T;
             comparisons = args[2];
+        }
+        if (comparisons === undefined) {
+            return runTrappedMemo(this, key, fn);
         }
         return runMemo(this, key, fn, comparisons);
     }

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -66,6 +66,17 @@ export interface IReactiveDependency<TNode extends TreeNode = TreeNode> {
     comparisons?: any[];
 }
 
+export type ReactiveNodeDependency =
+    | IReactiveDependency
+    | TreeNode
+    | null
+    | undefined
+    | string
+    | number
+    | boolean
+    | symbol
+    | bigint;
+
 export interface IRetreePrepareTreeOptions {
     /**
      * Maximum nested object depth to prepare.
@@ -101,12 +112,23 @@ export const RUN_CHANGED_EFFECT_SYMBOL = "RETREE_RUN_CHANGED_EFFECT_SYMBOL";
 export const RUN_OBSERVED_EFFECT_SYMBOL = "RETREE_RUN_OBSERVED_EFFECT_SYMBOL";
 export const RUN_UNOBSERVED_EFFECT_SYMBOL =
     "RETREE_RUN_UNOBSERVED_EFFECT_SYMBOL";
+export const SELECT_GETTERS_SYMBOL = "RETREE_SELECT_GETTERS_SYMBOL";
+
+export interface IReactiveSelectGetter<
+    This extends ReactiveNode = ReactiveNode,
+    Dependencies = unknown
+> {
+    getDependencies: (self: This) => Dependencies;
+}
 
 /**
  * Declare dependencies for other nodes in the tree to conditionally emit changes for the node.
  * @remarks
- * Build dependencies with {@link ReactiveNode.dependency}. Keep dependency
- * arrays stable in length and order while the node is observed.
+ * Return Retree-managed nodes directly when any change to that node should
+ * emit. Return primitive values directly when they should be compared only.
+ * Use {@link ReactiveNode.dependency} when a reactive dependency needs
+ * explicit comparison cells. Keep dependency arrays stable in length and order
+ * while the node is observed.
  * 
  * @example
  ```ts
@@ -145,6 +167,10 @@ export abstract class ReactiveNode {
     public [LINKED_KEYS_SYMBOL]: Set<string | symbol> = new Set<
         string | symbol
     >();
+    public [SELECT_GETTERS_SYMBOL]: Map<
+        string | symbol,
+        IReactiveSelectGetter
+    > = new Map();
 
     /**
      * Runtime options for this Retree node.
@@ -157,6 +183,7 @@ export abstract class ReactiveNode {
     constructor(options?: IRetreeNodeOptions) {
         this[COLLECTED_KEYS_SYMBOL].add("options");
         this[COLLECTED_KEYS_SYMBOL].add(LINKED_KEYS_SYMBOL);
+        this[COLLECTED_KEYS_SYMBOL].add(SELECT_GETTERS_SYMBOL);
         if (options !== undefined) {
             this.options = options;
         }
@@ -274,7 +301,7 @@ export abstract class ReactiveNode {
      * }
      * ```
      */
-    abstract get dependencies(): IReactiveDependency[];
+    abstract get dependencies(): ReactiveNodeDependency[];
 
     /**
      * Runs when this {@link ReactiveNode} gets its first active
@@ -364,10 +391,11 @@ export abstract class ReactiveNode {
      * Creates a new {@link IReactiveDependency} instance.
      *
      * @remarks
-     * Use this inside the {@link ReactiveNode.dependencies} getter. The
-     * dependency `node` is observed with `nodeChanged`; optional comparison
-     * values decide whether this `ReactiveNode` should emit after that
-     * dependency changes.
+     * Use this inside the {@link ReactiveNode.dependencies} getter or an
+     * `@select` dependency selector when one slot needs explicit comparison
+     * cells. If `node` is a Retree-managed object, it is observed with
+     * `nodeChanged`. If `node` is a primitive or unproxied value, Retree
+     * treats it as a comparison-only dependency.
      *
      * Comparisons should be stable in length and order. If no comparisons are
      * provided, every `nodeChanged` event from the dependency emits for this
@@ -381,19 +409,37 @@ export abstract class ReactiveNode {
      * ```ts
      * get dependencies() {
      *     return [
-     *         this.dependency(this.items, [this.items.length]),
-     *         this.dependency(this.selectedItem ?? null),
+     *         this.items,
+     *         this.searchText,
+     *         this.dependency(this.selectedItem ?? null, [this.selectedId]),
      *     ];
      * }
      * ```
      */
-    protected dependency<TNode extends TreeNode = TreeNode>(
+    public dependency<TNode extends TreeNode = TreeNode>(
         node: OptionalNode<TNode>,
         comparisons?: any[]
-    ): IReactiveDependency<TNode> {
+    ): IReactiveDependency<TNode>;
+    public dependency<TValue>(value: TValue): IReactiveDependency;
+    public dependency(node: unknown, comparisons?: any[]): IReactiveDependency {
+        if (
+            comparisons === undefined &&
+            (node === null || typeof node !== "object")
+        ) {
+            return {
+                node: undefined,
+                comparisons: [node],
+            };
+        }
+        if (node === undefined || node === null || typeof node === "object") {
+            return {
+                node,
+                comparisons,
+            };
+        }
         return {
-            node,
-            comparisons,
+            node: undefined,
+            comparisons: [node, ...(comparisons ?? [])],
         };
     }
 

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -127,8 +127,9 @@ export interface IReactiveSelectGetter<
  * Return Retree-managed nodes directly when any change to that node should
  * emit. Return primitive values directly when they should be compared only.
  * Use {@link ReactiveNode.dependency} when a reactive dependency needs
- * explicit comparison cells. Keep dependency arrays stable in length and order
- * while the node is observed.
+ * explicit comparison cells. Dependency arrays should be deterministic, but
+ * may change length or order at runtime. Retree treats shape changes as
+ * invalidation and refreshes subscriptions.
  * 
  * @example
  ```ts
@@ -282,9 +283,11 @@ export abstract class ReactiveNode {
      * {@link ReactiveNode.onUnobserved}, and {@link ReactiveNode.onChanged} for
      * lifecycle work.
      *
-     * The returned array must keep the same length and ordering while the node
-     * is observed. Use `null` dependency nodes for inactive slots instead of
-     * adding or removing entries.
+     * The returned array may change length or ordering while the node is
+     * observed. Retree treats added, removed, or reordered entries as
+     * invalidation and refreshes subscriptions. Use `null` when you want an
+     * inactive slot to keep its position, but it is not required for
+     * correctness.
      *
      * @example
      * ```ts
@@ -397,9 +400,10 @@ export abstract class ReactiveNode {
      * `nodeChanged`. If `node` is a primitive or unproxied value, Retree
      * treats it as a comparison-only dependency.
      *
-     * Comparisons should be stable in length and order. If no comparisons are
-     * provided, every `nodeChanged` event from the dependency emits for this
-     * node.
+     * Comparison cells should be deterministic. If their length/order changes,
+     * Retree treats that as invalidation and emits for this node. If no
+     * comparisons are provided, every `nodeChanged` event from the dependency
+     * emits for this node.
      *
      * @param node the node to listen to "nodeChanged" events for.
      * @param comparisons Optional. Values to compare between updates to `node`.
@@ -409,9 +413,9 @@ export abstract class ReactiveNode {
      * ```ts
      * get dependencies() {
      *     return [
-     *         this.items,
-     *         this.searchText,
-     *         this.dependency(this.selectedItem ?? null, [this.selectedId]),
+     *         this.authStore,
+     *         this.authStore.session?.userId,
+     *         this.dependency(this.selectedProject ?? null, [this.projectId]),
      *     ];
      * }
      * ```

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -105,18 +105,16 @@ export const RUN_UNOBSERVED_EFFECT_SYMBOL =
 /**
  * Declare dependencies for other nodes in the tree to conditionally emit changes for the node.
  * @remarks
- * Only one dependency needs to change to
- * You can build {@link IReactiveDependency} instances with {@link ReactiveNode.dependency}.
+ * Build dependencies with {@link ReactiveNode.dependency}. Keep dependency
+ * arrays stable in length and order while the node is observed.
  * 
  * @example
  ```ts
- import { Retree, ReactiveNode } from "@retree/core";
+ import { Retree, ReactiveNode } from "@retreejs/core";
  // Declare a class that extends ReactiveNode
  class Node extends ReactiveNode {
     numbers: number[] = [];
-    constructor() {
-        super();
-    }
+
     // Get count of even numbers in the list
     get evenNumberCount(): number {
         return this.numbers.filter((number) => number % 2 === 0).length;
@@ -132,9 +130,9 @@ export const RUN_UNOBSERVED_EFFECT_SYMBOL =
     console.log(node.evenNumberCount);
  });
  // Will emit "nodeChanged"
- node.list.push(2);
+ node.numbers.push(2);
  // Will not emit "nodeChanged"
- node.list.push(3);
+ node.numbers.push(3);
  ```
  */
 export abstract class ReactiveNode {
@@ -168,7 +166,31 @@ export abstract class ReactiveNode {
      * Move this node to a new structural parent.
      *
      * @remarks
-     * This is a convenience wrapper around {@link Retree.move}.
+     * This is a convenience wrapper around {@link Retree.move}. Use it from
+     * instance methods when a node should transfer ownership to another
+     * Retree-managed array, map, set, or object.
+     *
+     * Do not call `moveTo` on a root node; roots have no parent to remove from.
+     * Do not manually remove the node from its current parent before moving.
+     *
+     * @param destination Retree-managed destination collection or object.
+     * @param key Optional array insertion index, map key, or object property key.
+     * @returns The latest reproxy for this node after it moves.
+     *
+     * @example
+     * ```ts
+     * class Task extends ReactiveNode {
+     *     public title = "";
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     *
+     *     public complete(done: Task[]) {
+     *         this.moveTo(done); // same as Retree.move(this, done)
+     *     }
+     * }
+     * ```
      */
     public moveTo<TValue extends TreeNode = this>(
         destination: this extends TValue ? TValue[] : never,
@@ -193,7 +215,31 @@ export abstract class ReactiveNode {
      * Create a reactive pointer to an existing Retree-managed node.
      *
      * @remarks
-     * This is a convenience wrapper around {@link Retree.link}.
+     * This is a convenience wrapper around {@link Retree.link}. Use it when a
+     * `ReactiveNode` method needs to return or store a pointer to a node owned
+     * elsewhere without reparenting that node.
+     *
+     * Do not use `link` when ownership should move; use {@link Retree.move} or
+     * {@link ReactiveNode.moveTo}. Do not use it when two locations need
+     * independent state; use {@link Retree.clone}.
+     *
+     * @param node Existing Retree-managed node to point at.
+     * @returns A Retree-managed `RetreeLink` whose `current` points at `node`.
+     *
+     * @example
+     * ```ts
+     * class EditorState extends ReactiveNode {
+     *     public selected = null as RetreeLink<Task> | null;
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     *
+     *     public select(task: Task) {
+     *         this.selected = this.link(task);
+     *     }
+     * }
+     * ```
      */
     public link<TNode extends TreeNode>(node: TNode): RetreeLink<TNode> {
         return linkReactiveNode(node);
@@ -203,6 +249,30 @@ export abstract class ReactiveNode {
      * Dependencies to listen for changes to.
      * @remarks
      * When any {@link IReactiveDependency} criteria is met, a change will be emitted for this {@link ReactiveNode} instance.
+     *
+     * Keep this getter deterministic. Do not start subscriptions, perform
+     * network work, or mutate state here. Use {@link ReactiveNode.onObserved},
+     * {@link ReactiveNode.onUnobserved}, and {@link ReactiveNode.onChanged} for
+     * lifecycle work.
+     *
+     * The returned array must keep the same length and ordering while the node
+     * is observed. Use `null` dependency nodes for inactive slots instead of
+     * adding or removing entries.
+     *
+     * @example
+     * ```ts
+     * class ProjectSummary extends ReactiveNode {
+     *     public tasks: { done: boolean }[] = [];
+     *
+     *     get doneCount() {
+     *         return this.tasks.filter((task) => task.done).length;
+     *     }
+     *
+     *     get dependencies() {
+     *         return [this.dependency(this.tasks, [this.doneCount])];
+     *     }
+     * }
+     * ```
      */
     abstract get dependencies(): IReactiveDependency[];
 
@@ -212,12 +282,47 @@ export abstract class ReactiveNode {
      * @remarks
      * Override this for work that requires the proxied instance, such as
      * starting external subscriptions that write back into Retree state.
+     *
+     * Keep setup idempotent. Retree calls this when the first active
+     * `nodeChanged` or `treeChanged` listener starts observing the node, not
+     * when the node is constructed.
+     *
+     * @example
+     * ```ts
+     * class LiveValue extends ReactiveNode {
+     *     public value = "";
+     *     @ignore private unsubscribe: (() => void) | null = null;
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     *
+     *     protected onObserved() {
+     *         this.unsubscribe = subscribe((value) => {
+     *             this.value = value; // ✅ emits through Retree
+     *         });
+     *     }
+     * }
+     * ```
      */
     protected onObserved(): void {}
 
     /**
      * Runs when this {@link ReactiveNode} loses its last active
      * `nodeChanged` or `treeChanged` observer.
+     *
+     * @remarks
+     * Use this to clean up resources created in
+     * {@link ReactiveNode.onObserved}. Do not rely on it as a destructor for
+     * unobserved nodes; it only runs after observation had started.
+     *
+     * @example
+     * ```ts
+     * protected onUnobserved() {
+     *     this.unsubscribe?.();
+     *     this.unsubscribe = null;
+     * }
+     * ```
      */
     protected onUnobserved(): void {}
 
@@ -229,14 +334,58 @@ export abstract class ReactiveNode {
      * `treeChanged` listeners flush. If no transaction is already active,
      * Retree starts one so state updates made here are batched with the reproxy
      * that triggered the effect.
+     *
+     * Use this for small synchronization writes that should happen only after
+     * Retree has confirmed a real change. Avoid writing unconditionally here;
+     * guard against loops by checking whether the derived value actually
+     * changed.
+     *
+     * @example
+     * ```ts
+     * class SearchState extends ReactiveNode {
+     *     public query = "";
+     *     public normalizedQuery = "";
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     *
+     *     protected onChanged() {
+     *         const next = this.query.trim().toLowerCase();
+     *         if (this.normalizedQuery !== next) {
+     *             this.normalizedQuery = next;
+     *         }
+     *     }
+     * }
+     * ```
      */
     protected onChanged(): void {}
     /**
      * Creates a new {@link IReactiveDependency} instance.
      *
+     * @remarks
+     * Use this inside the {@link ReactiveNode.dependencies} getter. The
+     * dependency `node` is observed with `nodeChanged`; optional comparison
+     * values decide whether this `ReactiveNode` should emit after that
+     * dependency changes.
+     *
+     * Comparisons should be stable in length and order. If no comparisons are
+     * provided, every `nodeChanged` event from the dependency emits for this
+     * node.
+     *
      * @param node the node to listen to "nodeChanged" events for.
      * @param comparisons Optional. Values to compare between updates to `node`.
      * @returns dependency object.
+     *
+     * @example
+     * ```ts
+     * get dependencies() {
+     *     return [
+     *         this.dependency(this.items, [this.items.length]),
+     *         this.dependency(this.selectedItem ?? null),
+     *     ];
+     * }
+     * ```
      */
     protected dependency<TNode extends TreeNode = TreeNode>(
         node: OptionalNode<TNode>,
@@ -256,6 +405,26 @@ export abstract class ReactiveNode {
      * phase, such as while showing a loading spinner. This walks only own data
      * properties, so computed getters like `dependencies` are not evaluated or
      * cached as child nodes. Fields marked with `@ignore` are skipped.
+     *
+     * Do not call this for every render. Call it once during setup, loading, or
+     * before a known interaction that will traverse a large subtree.
+     *
+     * @param options Optional depth limit. Omit to prepare all reachable
+     * non-ignored child objects.
+     *
+     * @example
+     * ```ts
+     * class LargeNode extends ReactiveNode {
+     *     public sections = [{ title: "Intro", cards: [] }];
+     *
+     *     get dependencies() {
+     *         return [];
+     *     }
+     * }
+     *
+     * const node = Retree.root(new LargeNode());
+     * node.prepareTree({ depth: 1 });
+     * ```
      */
     public prepareTree(options: IRetreePrepareTreeOptions = {}): void {
         const depth = options.depth ?? Infinity;
@@ -285,6 +454,11 @@ export abstract class ReactiveNode {
      * - `[a, b, ...]`: recompute when any cell shallow-changes using `Object.is`.
      *   Tree-node cells are compared by their latest reproxy identity, so passing
      *   `this.list` correctly invalidates when `list` mutates.
+     *
+     * `memo` is a cache, not a subscription. It does not emit
+     * `nodeChanged` or trigger React renders by itself. Pair it with
+     * `dependencies`, `Retree.select`, or `useSelect` when you also need
+     * notification behavior.
      *
      * @example
      ```ts

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -175,6 +175,92 @@ describe("Retree", () => {
         expect(selected).toHaveBeenCalledWith(13, 11);
     });
 
+    it("selects with trapped dependencies when only a selector function is passed", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 1,
+                label: "one",
+            })
+        );
+        const selected = vi.fn();
+        Retree.select(() => root.count, selected);
+
+        root.label = "two";
+        expect(selected).not.toHaveBeenCalled();
+
+        root.count = 2;
+        expect(selected).toHaveBeenCalledTimes(1);
+        expect(selected).toHaveBeenCalledWith(2, 1);
+    });
+
+    it("trapped select subscriptions follow reproxy child reads", () => {
+        const root = trackRoot(
+            Retree.root({
+                child: {
+                    count: 1,
+                    label: "one",
+                },
+            })
+        );
+        const selected = vi.fn();
+        Retree.select(() => root.child.count, selected);
+
+        root.child.label = "two";
+        expect(selected).not.toHaveBeenCalled();
+
+        root.child.count = 2;
+        expect(selected).toHaveBeenCalledTimes(1);
+        expect(selected).toHaveBeenCalledWith(2, 1);
+    });
+
+    it("trapped select compares primitive reads even when the selected value is equal", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 1,
+            })
+        );
+        const selected = vi.fn();
+        Retree.select(() => root.count > 0, selected);
+
+        root.count = 2;
+
+        expect(selected).toHaveBeenCalledTimes(1);
+        expect(selected).toHaveBeenCalledWith(true, true);
+    });
+
+    it("infers selector-only select callback values from the selector return type", () => {
+        type Task = {
+            id: string;
+            text: string;
+        };
+        type QueryStatus = "pending" | "success";
+        const root = trackRoot(
+            Retree.root({
+                tasks: {
+                    state: undefined as Task[] | undefined,
+                    result: {
+                        status: "pending" as QueryStatus,
+                    },
+                },
+                filter: {
+                    isComplete: null as boolean | null,
+                },
+            })
+        );
+
+        Retree.select(
+            () => {
+                const tasks = root.tasks.state ?? [];
+                return [tasks, root.filter, root.tasks.result.status] as const;
+            },
+            ([tasks, filter, queryStatus]) => {
+                expectTypeOf(tasks).toEqualTypeOf<Task[]>();
+                expectTypeOf(filter).toEqualTypeOf<typeof root.filter>();
+                expectTypeOf(queryStatus).toEqualTypeOf<QueryStatus>();
+            }
+        );
+    });
+
     it("selects dependency tuples and uses reactive entries as ordered subscriptions", () => {
         const root = trackRoot(
             Retree.root({

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -1,8 +1,13 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { Retree } from "./Retree";
+import { ReactiveNode } from "./ReactiveNode";
 import { Transactions } from "./internals/transactions";
 import { getReproxyNode } from "./internals/reproxy";
-import { getBaseProxy, getCustomProxyHandler } from "./internals/proxy";
+import {
+    getBaseProxy,
+    getCustomProxyHandler,
+    getUnproxiedNode,
+} from "./internals/proxy";
 import { proxiedChildrenKey } from "./internals/proxy-types";
 
 const rootsToCleanup: object[] = [];
@@ -654,7 +659,276 @@ describe("Retree", () => {
 
         expect(() => {
             root2.other = root1.child;
-        }).toThrow(/single parent/i);
+        }).toThrow(/already has a structural parent/i);
+        expect(() => {
+            root2.other = root1.child;
+        }).toThrow(/Current parent: Object at key child/i);
+        expect(() => {
+            root2.other = root1.child;
+        }).toThrow(/Retree.move/);
+    });
+
+    it("stores a Retree.link without reparenting the linked target", () => {
+        const source = trackRoot(Retree.root({ child: { value: 1 } }));
+        const owner = trackRoot(
+            Retree.root({
+                selected: null as null | ReturnType<typeof Retree.link>,
+            })
+        );
+        const nodeChanged = vi.fn();
+        Retree.on(owner, "nodeChanged", nodeChanged);
+
+        owner.selected = Retree.link(source.child);
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        if (!owner.selected) {
+            throw new Error("Expected Retree.link to create a selected link.");
+        }
+        expect(Retree.parent(owner.selected)).toBe(owner);
+        expect(Retree.parent(owner.selected.current)).toBe(source);
+    });
+
+    it("returns the latest linked current reproxy", () => {
+        const source = trackRoot(Retree.root({ child: { value: 1 } }));
+        const link = trackRoot(Retree.root(Retree.link(source.child)));
+        const beforeChange = link.current;
+
+        source.child.value = 2;
+
+        expect(link.current).not.toBe(beforeChange);
+        expect(link.current.value).toBe(2);
+    });
+
+    it("creates links from ReactiveNode.link", () => {
+        class LinkOwnerNode extends ReactiveNode {
+            public selected: ReturnType<
+                typeof Retree.link<{ value: number }>
+            > | null = null;
+
+            get dependencies() {
+                return [];
+            }
+
+            select(node: { value: number }) {
+                this.selected = this.link(node);
+                return this.selected;
+            }
+        }
+
+        const source = trackRoot(Retree.root({ child: { value: 1 } }));
+        const owner = trackRoot(Retree.root(new LinkOwnerNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(owner, "nodeChanged", nodeChanged);
+
+        const selected = owner.select(source.child);
+        expectTypeOf(selected.current).toEqualTypeOf<{ value: number }>();
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(owner.selected).toBe(selected);
+        expect(Retree.parent(selected)).toBe(owner);
+        expect(Retree.parent(selected.current)).toBe(source);
+
+        const beforeChange = selected.current;
+        source.child.value = 2;
+
+        expect(selected.current).not.toBe(beforeChange);
+        expect(selected.current.value).toBe(2);
+    });
+
+    it("moves a node from one array parent to another array parent", () => {
+        interface Task {
+            title: string;
+        }
+        interface Note {
+            body: string;
+        }
+        const root = trackRoot(
+            Retree.root({
+                projectA: { tasks: [{ title: "a" }] as Task[] },
+                projectB: { tasks: [] as Task[] },
+            })
+        );
+        const task = root.projectA.tasks[0];
+        if (!task) {
+            throw new Error("Expected source task to exist before move.");
+        }
+
+        const moved = Retree.move(task, root.projectB.tasks, 0);
+        expectTypeOf(moved).toEqualTypeOf<Task>();
+
+        expect(root.projectA.tasks).toHaveLength(0);
+        expect(root.projectB.tasks).toHaveLength(1);
+        expect(getUnproxiedNode(root.projectB.tasks[0]!)).toBe(
+            getUnproxiedNode(moved)
+        );
+        expect(Retree.parent(moved)).toBe(root.projectB.tasks);
+
+        expect(() => {
+            // @ts-expect-error Array move keys must be numbers.
+            Retree.move(moved, root.projectA.tasks, "first");
+        }).toThrow(/array destinations require a numeric key/i);
+
+        if (false) {
+            const noteRoot = Retree.root({ note: { body: "note" } as Note });
+            // @ts-expect-error Node must be assignable to the array element type.
+            Retree.move(noteRoot.note, root.projectA.tasks);
+        }
+    });
+
+    it("moves a node from an object parent to a Map parent", () => {
+        interface Task {
+            title: string;
+        }
+        interface Note {
+            body: string;
+        }
+        const root = trackRoot(
+            Retree.root({
+                task: { title: "a" } as Task,
+                tasks: new Map<string, Task>(),
+            })
+        );
+        const task = root.task;
+
+        const moved = Retree.move(task, root.tasks, "task-a");
+        expectTypeOf(moved).toEqualTypeOf<Task>();
+
+        expect("task" in root).toBe(false);
+        expect(getUnproxiedNode(root.tasks.get("task-a")!)).toBe(
+            getUnproxiedNode(moved)
+        );
+        expect(Retree.parent(moved)).toBe(root.tasks);
+
+        if (false) {
+            const noteRoot = Retree.root({ note: { body: "note" } as Note });
+            // @ts-expect-error Map key must match the destination Map key type.
+            Retree.move(moved, root.tasks, 1);
+            // @ts-expect-error Node must be assignable to the Map value type.
+            Retree.move(noteRoot.note, root.tasks, "note-id");
+        }
+    });
+
+    it("moves a node into typed object keys", () => {
+        interface Task {
+            title: string;
+        }
+        interface Note {
+            body: string;
+        }
+        const taskKey = Symbol("task");
+        const root = trackRoot(
+            Retree.root({
+                source: { task: { title: "a" } as Task },
+                destinations: {
+                    task: null as Task | null,
+                    note: null as Note | null,
+                    optionalTask: undefined as Task | undefined,
+                    [taskKey]: null as Task | null,
+                },
+            })
+        );
+
+        const moved = Retree.move(root.source.task, root.destinations, taskKey);
+        expectTypeOf(moved).toEqualTypeOf<Task>();
+
+        expect("task" in root.source).toBe(false);
+        expect(getUnproxiedNode(root.destinations[taskKey]!)).toBe(
+            getUnproxiedNode(moved)
+        );
+        expect(Retree.parent(moved)).toBe(root.destinations);
+
+        if (false) {
+            // @ts-expect-error Object key must point to a compatible value slot.
+            Retree.move(moved, root.destinations, "note");
+            // @ts-expect-error Object key must exist on the destination.
+            Retree.move(moved, root.destinations, "missing");
+        }
+    });
+
+    it("moves a ReactiveNode with moveTo", () => {
+        class TaskNode extends ReactiveNode {
+            public value = 1;
+            public taskTitle = "";
+
+            get dependencies() {
+                return [];
+            }
+        }
+        class NoteNode extends ReactiveNode {
+            public noteBody = "";
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(
+            Retree.root({
+                a: [new TaskNode()],
+                b: [] as TaskNode[],
+                byId: new Map<string, TaskNode>(),
+                selected: {
+                    task: null as TaskNode | null,
+                    note: null as NoteNode | null,
+                },
+            })
+        );
+        const task = root.a[0];
+        if (!task) {
+            throw new Error("Expected reactive task to exist before move.");
+        }
+
+        task.moveTo(root.b);
+
+        expect(root.a).toHaveLength(0);
+        expect(root.b[0]).toBe(task);
+        expect(Retree.parent(task)).toBe(root.b);
+
+        const movedToMap = task.moveTo(root.byId, "task-id");
+        expectTypeOf(movedToMap).toEqualTypeOf<TaskNode>();
+        expect(root.b).toHaveLength(0);
+        expect(root.byId.get("task-id")).toBe(task);
+        expect(Retree.parent(task)).toBe(root.byId);
+
+        const movedToObject = task.moveTo(root.selected, "task");
+        expectTypeOf(movedToObject).toEqualTypeOf<TaskNode>();
+        expect(root.byId.size).toBe(0);
+        expect(root.selected.task).toBe(task);
+        expect(Retree.parent(task)).toBe(root.selected);
+
+        expect(() => {
+            // @ts-expect-error Array move keys must be numbers.
+            task.moveTo(root.b, "first");
+        }).toThrow(/array destinations require a numeric key/i);
+
+        if (false) {
+            // @ts-expect-error Node must be assignable to the array element type.
+            task.moveTo([] as NoteNode[]);
+            // @ts-expect-error Map key must match the destination Map key type.
+            task.moveTo(root.byId, 1);
+            // @ts-expect-error Object key must point to a compatible value slot.
+            task.moveTo(root.selected, "note");
+        }
+    });
+
+    it("clones a node into a detached value that can be assigned elsewhere", () => {
+        const root = trackRoot(
+            Retree.root({
+                source: { nested: { value: 1 } },
+                copy: null as null | { nested: { value: number } },
+            })
+        );
+
+        root.copy = Retree.clone(root.source);
+
+        if (!root.copy) {
+            throw new Error("Expected cloned value to be assigned.");
+        }
+        expect(root.copy).not.toBe(root.source);
+        expect(root.copy.nested).not.toBe(root.source.nested);
+        expect(root.copy.nested.value).toBe(1);
+        expect(Retree.parent(root.copy)).toBe(root);
+        expect(Retree.parent(root.copy.nested)).toBe(root.copy);
     });
 
     it("batches transaction notifications per node", () => {

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -175,6 +175,92 @@ describe("Retree", () => {
         expect(selected).toHaveBeenCalledWith(13, 11);
     });
 
+    it("selects dependency tuples and uses reactive entries as ordered subscriptions", () => {
+        const root = trackRoot(
+            Retree.root({
+                attributeId: "a",
+                attributes: [
+                    { id: "a", value: 0 },
+                    { id: "b", value: 0 },
+                ],
+            })
+        );
+        const selected = vi.fn();
+        Retree.select(
+            root,
+            (node) =>
+                [
+                    node.attributes,
+                    node.attributeId,
+                    node.attributes.find(
+                        (attribute) => attribute.id === node.attributeId
+                    ),
+                ] as const,
+            selected
+        );
+
+        root.attributes.push({ id: "c", value: 0 });
+        root.attributes[1].value = 1;
+
+        expect(selected).not.toHaveBeenCalled();
+
+        root.attributes[0].value = 1;
+        root.attributeId = "b";
+
+        expect(selected).toHaveBeenCalledTimes(2);
+        expect(selected.mock.calls[0]?.[0][2]?.value).toBe(1);
+        expect(selected.mock.calls[1]?.[0][2]?.id).toBe("b");
+    });
+
+    it("handles duplicate reactive dependencies by preserving every dependency slot", () => {
+        const root = trackRoot(
+            Retree.root({
+                child: { value: 1 },
+            })
+        );
+        const selected = vi.fn();
+        Retree.select(
+            root,
+            (node) => [node.child, node.child] as const,
+            selected
+        );
+
+        root.child.value = 2;
+
+        expect(selected).toHaveBeenCalledTimes(1);
+        expect(selected.mock.calls[0]?.[0][1].value).toBe(2);
+    });
+
+    it("infers tuple select values for callbacks and equality", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 1,
+                label: "one",
+            })
+        );
+        Retree.select(
+            root,
+            (node) => [node.count, node.label] as const,
+            (next, previous) => {
+                expectTypeOf(next).toEqualTypeOf<readonly [number, string]>();
+                expectTypeOf(previous).toEqualTypeOf<
+                    readonly [number, string]
+                >();
+            },
+            {
+                equals: (previous, next) => {
+                    expectTypeOf(previous).toEqualTypeOf<
+                        readonly [number, string]
+                    >();
+                    expectTypeOf(next).toEqualTypeOf<
+                        readonly [number, string]
+                    >();
+                    return previous[0] === next[0] && previous[1] === next[1];
+                },
+            }
+        );
+    });
+
     it("tracks parent relationships for nested objects and array items", () => {
         const root = trackRoot(
             Retree.root({

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -18,6 +18,7 @@ import {
     getReactiveDependencies,
     getReactiveDependents,
     IActiveReactiveDependency,
+    IPreviousReactiveDependent,
     retainReactiveDependencySubscription,
     setReactiveDependencies,
     setReactiveDependents,
@@ -29,11 +30,14 @@ import {
 } from "./internals/reproxy";
 import {
     createRetreeSelectionObserver,
-    isRetreeManagedDependency,
     normalizeSelectDependencies,
     RetreeSelectEquals,
     RetreeSelectSelector,
 } from "./internals/select";
+import {
+    getDependencyComparisonValues,
+    normalizeDependencyEntry,
+} from "./internals/dependencies";
 import { Transactions } from "./internals/transactions";
 import {
     LINKED_KEYS_SYMBOL,
@@ -427,6 +431,11 @@ export class Retree {
      * changes. Selectors may return one value or an ordered dependency list.
      * Reactive entries in a dependency list are subscribed to; primitive and
      * plain entries are compared by identity.
+     *
+     * Dependency-list subscriptions are observational: if a selected dependency
+     * emits, `select` calls your callback when the selection changes, but it
+     * does not force the node passed to `select` to receive a fresh reproxy.
+     * Use `@select` when a `ReactiveNode` owner should emit `nodeChanged`.
      * This is a subscription primitive, not a memo cache: use `memo` /
      * `fnMemo` to cache computation, and `select` to narrow notifications.
      *
@@ -1192,37 +1201,31 @@ export class Retree {
             unproxiedDependentNode
         );
         if (currentDependencies.length === 0) {
-            if (
-                previousDependencies !== undefined &&
-                previousDependencies.length !== 0
-            ) {
-                // @retree-throws
-                throw new Error(
-                    "ReactiveNode.dependencies length changed after Retree started observing this node. This is a ReactiveNode implementation error. Fix: return a dependencies array with a stable length and ordering for the lifetime of each ReactiveNode instance; use null dependency nodes when a slot is temporarily inactive."
-                );
-            }
             if (previousDependencies !== undefined) {
+                this.unsubscribeReactiveDependencies(
+                    previousDependencies,
+                    unproxiedDependentNode
+                );
                 deleteReactiveDependencies(unproxiedDependentNode);
             }
             return;
         }
-        if (
-            previousDependencies &&
-            previousDependencies.length !== currentDependencies.length
-        ) {
-            // @retree-throws
-            throw new Error(
-                "ReactiveNode.dependencies length changed after Retree started observing this node. This is a ReactiveNode implementation error. Fix: return a dependencies array with a stable length and ordering for the lifetime of each ReactiveNode instance; use null dependency nodes when a slot is temporarily inactive."
-            );
-        }
+        const previousDependenciesByKey = new Map(
+            previousDependencies?.map((dependency) => [
+                dependency.key,
+                dependency,
+            ]) ?? []
+        );
         const newActiveDependencies: IActiveReactiveDependency[] = [];
         for (
             let depIndex = 0;
             depIndex < currentDependencies.length;
             depIndex++
         ) {
-            const previousDependency = previousDependencies?.[depIndex];
             const currentDependency = currentDependencies[depIndex];
+            const previousDependency = previousDependenciesByKey.get(
+                currentDependency.key
+            );
             const newDependencyNode = currentDependency.node;
             let unsubscribe: (() => void) | undefined;
             const previousUnproxiedDependencyNode =
@@ -1266,7 +1269,7 @@ export class Retree {
                     reactiveNode: proxiedDependentNode,
                     unproxiedReactiveNode: unproxiedDependentNode,
                     comparisons: currentDependency.comparisons,
-                    index: depIndex,
+                    key: currentDependency.key,
                 });
                 unsubscribe = previousDependency?.unsubscribeListener;
             } else {
@@ -1275,7 +1278,7 @@ export class Retree {
                     deleteReactiveDependent(
                         previousUnproxiedDependencyNode,
                         unproxiedDependentNode,
-                        depIndex
+                        currentDependency.key
                     );
                 }
                 if (currentUnproxiedDependencyNode !== undefined) {
@@ -1283,7 +1286,7 @@ export class Retree {
                         reactiveNode: proxiedDependentNode,
                         unproxiedReactiveNode: unproxiedDependentNode,
                         comparisons: currentDependency.comparisons,
-                        index: depIndex,
+                        key: currentDependency.key,
                     });
                     if (newDependencyNode) {
                         unsubscribe = retainReactiveDependencySubscription(
@@ -1301,11 +1304,30 @@ export class Retree {
             }
 
             newActiveDependencies.push({
+                key: currentDependency.key,
                 node: currentDependency.node,
                 comparisons: currentDependency.comparisons,
                 unsubscribeListener: unsubscribe,
                 unproxiedNode: currentUnproxiedDependencyNode,
             });
+        }
+        for (const previousDependency of previousDependencies ?? []) {
+            if (
+                !currentDependencies.some(
+                    (dependency) => dependency.key === previousDependency.key
+                )
+            ) {
+                previousDependency.unsubscribeListener?.();
+                const previousUnproxiedDependencyNode =
+                    previousDependency.unproxiedNode;
+                if (previousUnproxiedDependencyNode !== undefined) {
+                    deleteReactiveDependent(
+                        previousUnproxiedDependencyNode,
+                        unproxiedDependentNode,
+                        previousDependency.key
+                    );
+                }
+            }
         }
         // Set reactive dependencies
         setReactiveDependencies(unproxiedDependentNode, newActiveDependencies);
@@ -1324,7 +1346,7 @@ export class Retree {
                 throw new Error(
                     `@select dependency list for getter '${String(
                         getterName
-                    )}' was empty. This is a ReactiveNode implementation error because @select needs at least one stable dependency slot to observe or compare. Fix: return one or more dependencies, or remove @select from this getter.`
+                    )}' was empty. This is a ReactiveNode implementation error because @select needs at least one dependency slot to observe or compare. Fix: return one or more dependencies, or remove @select from this getter.`
                 );
             }
             for (
@@ -1334,18 +1356,21 @@ export class Retree {
             ) {
                 const selectedDependency =
                     selectedDependencies[dependencyIndex];
-                const laterComparisons =
-                    this.getReactiveDependencyComparisonValues(
-                        selectedDependencies.slice(dependencyIndex + 1)
-                    );
-                const explicitDependency =
-                    this.isExplicitReactiveDependency(selectedDependency);
+                const key = `select:${String(getterName)}:${dependencyIndex}`;
                 const normalizedDependency =
-                    this.normalizeReactiveNodeDependency(selectedDependency);
+                    this.normalizeReactiveNodeDependency(
+                        selectedDependency,
+                        key
+                    );
+                const laterComparisons = getDependencyComparisonValues(
+                    selectedDependencies.slice(dependencyIndex + 1)
+                );
                 dependencies.push({
+                    key,
                     node: normalizedDependency.node,
                     comparisons:
-                        explicitDependency || laterComparisons.length === 0
+                        normalizeDependencyEntry(selectedDependency).explicit ||
+                        laterComparisons.length === 0
                             ? normalizedDependency.comparisons
                             : laterComparisons,
                     unsubscribeListener: undefined,
@@ -1360,84 +1385,45 @@ export class Retree {
         proxiedDependentNode: ReactiveNode
     ) {
         return [
-            ...proxiedDependentNode.dependencies.map((dependency) =>
-                this.normalizeReactiveNodeDependency(dependency)
+            ...proxiedDependentNode.dependencies.map((dependency, index) =>
+                this.normalizeReactiveNodeDependency(
+                    dependency,
+                    `dependencies:${index}`
+                )
             ),
             ...this.getReactiveSelectDependencies(proxiedDependentNode),
         ];
     }
 
     private static normalizeReactiveNodeDependency(
-        dependency: unknown
-    ): IReactiveDependency {
-        if (this.isExplicitReactiveDependency(dependency)) {
-            if (isRetreeManagedDependency(dependency.node)) {
-                return dependency;
-            }
-            return {
-                node: undefined,
-                comparisons:
-                    dependency.comparisons === undefined
-                        ? [dependency.node]
-                        : dependency.comparisons,
-            };
-        }
-        if (isRetreeManagedDependency(dependency)) {
-            return {
-                node: dependency,
-            };
-        }
+        dependency: unknown,
+        key: string
+    ): IActiveReactiveDependency {
+        const normalizedDependency = normalizeDependencyEntry(dependency);
         return {
-            node: undefined,
-            comparisons: [dependency],
+            key,
+            node: normalizedDependency.node,
+            comparisons: normalizedDependency.comparisons,
+            unsubscribeListener: undefined,
+            unproxiedNode: undefined,
         };
     }
 
-    private static getReactiveDependencyComparisonValues(
-        dependencies: unknown[]
+    private static unsubscribeReactiveDependencies(
+        dependencies: IActiveReactiveDependency[],
+        unproxiedNode: TreeNode
     ) {
-        const comparisonValues: unknown[] = [];
         for (const dependency of dependencies) {
-            if (this.isExplicitReactiveDependency(dependency)) {
-                const normalizedDependency =
-                    this.normalizeReactiveNodeDependency(dependency);
-                comparisonValues.push(
-                    normalizedDependency.node ?? dependency.node
+            dependency.unsubscribeListener?.();
+            const unproxiedDependencyNode = dependency.unproxiedNode;
+            if (unproxiedDependencyNode !== undefined) {
+                deleteReactiveDependent(
+                    unproxiedDependencyNode,
+                    unproxiedNode,
+                    dependency.key
                 );
-                if (normalizedDependency.comparisons !== undefined) {
-                    comparisonValues.push(...normalizedDependency.comparisons);
-                }
-                continue;
             }
-            comparisonValues.push(dependency);
         }
-        return comparisonValues;
-    }
-
-    private static isExplicitReactiveDependency(
-        dependency: unknown
-    ): dependency is IReactiveDependency {
-        if (
-            dependency === null ||
-            typeof dependency !== "object" ||
-            isRetreeManagedDependency(dependency)
-        ) {
-            return false;
-        }
-        if (!("node" in dependency)) {
-            return false;
-        }
-        if (!this.hasComparisonsProperty(dependency)) {
-            return true;
-        }
-        const comparisons = dependency.comparisons;
-        return comparisons === undefined || Array.isArray(comparisons);
-    }
-
-    private static hasComparisonsProperty(
-        dependency: object
-    ): dependency is { comparisons: unknown } {
-        return "comparisons" in dependency;
     }
 
     private static stopReactiveNode(
@@ -1458,7 +1444,7 @@ export class Retree {
                 deleteReactiveDependent(
                     prevUnproxiedDependentNode,
                     unproxiedNode,
-                    depIndex
+                    depPrevious.key
                 );
             }
         }
@@ -1484,42 +1470,17 @@ export class Retree {
         if (!dependents) {
             return;
         }
-        dependents.forEach((dependent) => {
-            const previousComparisons = dependent.comparisons;
-            let shouldNotify = previousComparisons === undefined;
-            // If our comparisons exist, we check to see if any changed
-            if (!shouldNotify) {
-                // Need to get the latest dependency values for our comparison
-                const latest = this.getReactiveNodeDependencies(
-                    dependent.reactiveNode
-                )[dependent.index];
-                if (latest === undefined) {
-                    // @retree-throws
-                    throw new Error(
-                        "ReactiveNode dependency slot disappeared while handling a dependency change. This is a ReactiveNode implementation error. Fix: keep ReactiveNode.dependencies and @select dependency arrays stable in length and order while the node is observed."
-                    );
-                }
-                const latestComparisons = latest.comparisons;
-                if (
-                    latestComparisons === undefined ||
-                    !previousComparisons ||
-                    latestComparisons.length !== previousComparisons.length
-                ) {
-                    // @retree-throws
-                    throw new Error(
-                        "ReactiveNode dependency comparisons changed shape. This is a ReactiveNode implementation error. Fix: keep each dependency's comparisons array either undefined or a stable-length array in a stable order for the lifetime of that dependency slot."
-                    );
-                }
-                for (let i = 0; i < latestComparisons.length; i++) {
-                    if (latestComparisons[i] !== previousComparisons[i]) {
-                        shouldNotify = true;
-                        continue;
-                    }
-                }
+        const groupedDependents = this.groupReactiveDependents(dependents);
+        groupedDependents.forEach((group) => {
+            if (
+                !group.dependents.some((dependent) =>
+                    this.shouldNotifyReactiveDependent(dependent, _unproxy)
+                )
+            ) {
+                return;
             }
-            if (!shouldNotify) return;
             // Reproxy node and emit listener
-            const dependentBaseProxy = getBaseProxy(dependent.reactiveNode);
+            const dependentBaseProxy = getBaseProxy(group.reactiveNode);
             const dependentUnproxied =
                 getUnproxiedNodeFromProxy(dependentBaseProxy);
             const dependentReproxy = Transactions.skipReproxy
@@ -1537,5 +1498,64 @@ export class Retree {
                 dependentReproxy
             );
         });
+    }
+
+    private static groupReactiveDependents(
+        dependents: IPreviousReactiveDependent[]
+    ) {
+        const groups = new Map<
+            TreeNode,
+            {
+                reactiveNode: ReactiveNode;
+                dependents: IPreviousReactiveDependent[];
+            }
+        >();
+        for (const dependent of dependents) {
+            const group = groups.get(dependent.unproxiedReactiveNode);
+            if (group !== undefined) {
+                group.reactiveNode = dependent.reactiveNode;
+                group.dependents.push(dependent);
+                continue;
+            }
+            groups.set(dependent.unproxiedReactiveNode, {
+                reactiveNode: dependent.reactiveNode,
+                dependents: [dependent],
+            });
+        }
+        return Array.from(groups.values());
+    }
+
+    private static shouldNotifyReactiveDependent(
+        dependent: IPreviousReactiveDependent,
+        changedUnproxiedNode: TreeNode
+    ) {
+        const previousComparisons = dependent.comparisons;
+        if (previousComparisons === undefined) {
+            return true;
+        }
+        const latest = this.getReactiveNodeDependencies(
+            dependent.reactiveNode
+        ).find((dependency) => dependency.key === dependent.key);
+        if (latest === undefined) {
+            return true;
+        }
+        if (latest.node !== undefined && latest.node !== null) {
+            if (getUnproxiedNode(latest.node) !== changedUnproxiedNode) {
+                return true;
+            }
+        }
+        const latestComparisons = latest.comparisons;
+        if (latestComparisons === undefined) {
+            return true;
+        }
+        if (latestComparisons.length !== previousComparisons.length) {
+            return true;
+        }
+        for (let i = 0; i < latestComparisons.length; i++) {
+            if (latestComparisons[i] !== previousComparisons[i]) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -36,6 +36,7 @@ import {
     RetreeSelectSelector,
     RetreeTrackedSelectSelector,
 } from "./internals/select";
+import { runWithIsolatedDependencyTracking } from "./internals/dependency-tracking";
 import {
     areDependencyValuesEqual,
     getDependencyComparisonValues,
@@ -958,48 +959,54 @@ export class Retree {
         proxyNode: TCustomProxy<TreeNode>,
         reproxyNode: TreeNode
     ) {
-        const isReactiveNode = proxyNode instanceof ReactiveNode;
-        if (isReactiveNode) {
-            this.handleReactiveNode(proxyNode, unproxiedNode);
-        }
-
-        const emitNodeChangedListeners = () => {
-            const nodeChangedListnersToNotify =
-                this.nodeChangedListeners.get(unproxiedNode) ?? [];
-            // We copy the list because it could get changed if the first callback triggers an unsubscribe
-            [...nodeChangedListnersToNotify].forEach((callback) => {
-                callback(reproxyNode);
-            });
-        };
-
-        const scheduleNodeChangedListeners = () => {
-            // If running a transaction, schedule this to emit later.
-            // That way if this same node gets changed later, we can only emit once for that node.
-            if (Transactions.runningTransaction) {
-                Transactions.upsertPendingTransaction(unproxiedNode, {
-                    emitNodeChanged: emitNodeChangedListeners,
-                });
-                return;
+        return runWithIsolatedDependencyTracking(() => {
+            const isReactiveNode = proxyNode instanceof ReactiveNode;
+            if (isReactiveNode) {
+                this.handleReactiveNode(proxyNode, unproxiedNode);
             }
 
-            // emit immediately
-            emitNodeChangedListeners();
-        };
+            const emitNodeChangedListeners = () => {
+                const nodeChangedListnersToNotify =
+                    this.nodeChangedListeners.get(unproxiedNode) ?? [];
+                // We copy the list because it could get changed if the first callback triggers an unsubscribe
+                [...nodeChangedListnersToNotify].forEach((callback) => {
+                    callback(reproxyNode);
+                });
+            };
 
-        if (!Transactions.skipEmit) {
-            scheduleNodeChangedListeners();
-        }
+            const scheduleNodeChangedListeners = () => {
+                // If running a transaction, schedule this to emit later.
+                // That way if this same node gets changed later, we can only emit once for that node.
+                if (Transactions.runningTransaction) {
+                    Transactions.upsertPendingTransaction(unproxiedNode, {
+                        emitNodeChanged: emitNodeChangedListeners,
+                    });
+                    return;
+                }
 
-        // Still handle here so we reproxy parents, despite skipping emit later in biz logic.
-        // If no treeChanged listeners exist, no parent can observe this work.
-        // Note that we should never have gotten this far if skipReproxy is true, so we skip checking again.
-        if (this.treeChangedListeners.size > 0) {
-            this.handleNotifyTreeChanged(unproxiedNode, proxyNode, proxyNode);
-        }
+                // emit immediately
+                emitNodeChangedListeners();
+            };
 
-        if (isReactiveNode) {
-            ReactiveNode[RUN_CHANGED_EFFECT_SYMBOL](proxyNode);
-        }
+            if (!Transactions.skipEmit) {
+                scheduleNodeChangedListeners();
+            }
+
+            // Still handle here so we reproxy parents, despite skipping emit later in biz logic.
+            // If no treeChanged listeners exist, no parent can observe this work.
+            // Note that we should never have gotten this far if skipReproxy is true, so we skip checking again.
+            if (this.treeChangedListeners.size > 0) {
+                this.handleNotifyTreeChanged(
+                    unproxiedNode,
+                    proxyNode,
+                    proxyNode
+                );
+            }
+
+            if (isReactiveNode) {
+                ReactiveNode[RUN_CHANGED_EFFECT_SYMBOL](proxyNode);
+            }
+        });
     }
 
     private static stopListening() {

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -27,13 +27,22 @@ import {
     getReproxyNodeForUnproxiedNode,
     updateReproxyNode,
 } from "./internals/reproxy";
+import {
+    createRetreeSelectionObserver,
+    isRetreeManagedDependency,
+    normalizeSelectDependencies,
+    RetreeSelectEquals,
+    RetreeSelectSelector,
+} from "./internals/select";
 import { Transactions } from "./internals/transactions";
 import {
     LINKED_KEYS_SYMBOL,
+    IReactiveDependency,
     ReactiveNode,
     RUN_CHANGED_EFFECT_SYMBOL,
     RUN_OBSERVED_EFFECT_SYMBOL,
     RUN_UNOBSERVED_EFFECT_SYMBOL,
+    SELECT_GETTERS_SYMBOL,
     setReactiveNodeLinkImplementation,
     setReactiveNodeMoveImplementation,
 } from "./ReactiveNode";
@@ -47,7 +56,7 @@ import {
 } from "./types";
 
 export interface RetreeSelectOptions<TSelected = unknown> {
-    equals?: (previous: TSelected, next: TSelected) => boolean;
+    equals?: RetreeSelectEquals<TSelected>;
     listenerType?: TRetreeChangedEvents;
 }
 
@@ -413,20 +422,27 @@ export class Retree {
      * Subscribe to a derived value from any Retree-managed node.
      *
      * @remarks
-     * `select` recomputes the selected value when the observed node emits,
-     * then calls `callback` only when the selected value changes.
+     * `select` recomputes the selected value when the observed node or selected
+     * reactive dependencies emit, then calls `callback` only when the selection
+     * changes. Selectors may return one value or an ordered dependency list.
+     * Reactive entries in a dependency list are subscribed to; primitive and
+     * plain entries are compared by identity.
      * This is a subscription primitive, not a memo cache: use `memo` /
      * `fnMemo` to cache computation, and `select` to narrow notifications.
      *
      * By default `select` listens to `nodeChanged`, which is correct when the
      * selector reads fields directly owned by `node`. Pass
-     * `listenerType: "treeChanged"` when the selector reads descendants.
+     * `listenerType: "treeChanged"` when the selector intentionally reads
+     * descendants that are not included as reactive entries in a dependency
+     * list.
      *
      * @param node Retree-managed node to observe.
-     * @param selector Function that reads a derived value from the latest
-     * reproxy.
-     * @param callback Called only when the selected value changes.
-     * @param options Optional listener type and equality comparison.
+     * @param selector Function that reads a selected value or dependency list
+     * from the latest reproxy.
+     * @param callback Called only when the selected value or dependency list
+     * changes.
+     * @param options Optional listener type and equality comparison for the
+     * whole selected value or tuple.
      * @returns Unsubscribe function.
      *
      * @example
@@ -446,30 +462,32 @@ export class Retree {
      * project.tasks[0].done = true; // ❌ selected value did not change
      * unsubscribe();
      * ```
+     *
+     * @example
+     * ```ts
+     * Retree.select(
+     *     row,
+     *     (self) => [self.attributes, self.attributeId, self.attribute],
+     *     ([, , attribute]) => console.log(attribute)
+     * );
+     * ```
      */
     static select<TNode extends TreeNode, TSelected>(
         node: TNode,
-        selector: (node: TNode) => TSelected,
+        selector: RetreeSelectSelector<TNode, TSelected>,
         callback: (next: TSelected, previous: TSelected) => void,
         options: RetreeSelectOptions<TSelected> = {}
     ): () => void {
-        const equals = options.equals ?? Object.is;
         const listenerType = options.listenerType ?? "nodeChanged";
-        let previous = selector(getReproxyNode(node));
-
-        return this.on<TNode, TRetreeChangedEvents>(
+        return createRetreeSelectionObserver({
             node,
+            selector,
+            equals: options.equals,
             listenerType,
-            (reproxy) => {
-                const next = selector(reproxy);
-                if (equals(previous, next)) {
-                    return;
-                }
-                const previousToEmit = previous;
-                previous = next;
-                callback(next, previousToEmit);
-            }
-        );
+            subscribeToNode: (selectedNode, selectedListenerType, listener) =>
+                this.on(selectedNode, selectedListenerType, listener),
+            onChange: callback,
+        });
     }
 
     /**
@@ -1168,7 +1186,8 @@ export class Retree {
         proxiedDependentNode: ReactiveNode,
         unproxiedDependentNode: TreeNode
     ) {
-        const currentDependencies = proxiedDependentNode.dependencies;
+        const currentDependencies =
+            this.getReactiveNodeDependencies(proxiedDependentNode);
         const previousDependencies = getReactiveDependencies(
             unproxiedDependentNode
         );
@@ -1292,6 +1311,135 @@ export class Retree {
         setReactiveDependencies(unproxiedDependentNode, newActiveDependencies);
     }
 
+    private static getReactiveSelectDependencies(
+        proxiedDependentNode: ReactiveNode
+    ): IActiveReactiveDependency[] {
+        const selectGetters = proxiedDependentNode[SELECT_GETTERS_SYMBOL];
+        const dependencies: IActiveReactiveDependency[] = [];
+        for (const [getterName, selectGetter] of selectGetters.entries()) {
+            const selected = selectGetter.getDependencies(proxiedDependentNode);
+            const selectedDependencies = normalizeSelectDependencies(selected);
+            if (selectedDependencies.length === 0) {
+                // @retree-throws
+                throw new Error(
+                    `@select dependency list for getter '${String(
+                        getterName
+                    )}' was empty. This is a ReactiveNode implementation error because @select needs at least one stable dependency slot to observe or compare. Fix: return one or more dependencies, or remove @select from this getter.`
+                );
+            }
+            for (
+                let dependencyIndex = 0;
+                dependencyIndex < selectedDependencies.length;
+                dependencyIndex++
+            ) {
+                const selectedDependency =
+                    selectedDependencies[dependencyIndex];
+                const laterComparisons =
+                    this.getReactiveDependencyComparisonValues(
+                        selectedDependencies.slice(dependencyIndex + 1)
+                    );
+                const explicitDependency =
+                    this.isExplicitReactiveDependency(selectedDependency);
+                const normalizedDependency =
+                    this.normalizeReactiveNodeDependency(selectedDependency);
+                dependencies.push({
+                    node: normalizedDependency.node,
+                    comparisons:
+                        explicitDependency || laterComparisons.length === 0
+                            ? normalizedDependency.comparisons
+                            : laterComparisons,
+                    unsubscribeListener: undefined,
+                    unproxiedNode: undefined,
+                });
+            }
+        }
+        return dependencies;
+    }
+
+    private static getReactiveNodeDependencies(
+        proxiedDependentNode: ReactiveNode
+    ) {
+        return [
+            ...proxiedDependentNode.dependencies.map((dependency) =>
+                this.normalizeReactiveNodeDependency(dependency)
+            ),
+            ...this.getReactiveSelectDependencies(proxiedDependentNode),
+        ];
+    }
+
+    private static normalizeReactiveNodeDependency(
+        dependency: unknown
+    ): IReactiveDependency {
+        if (this.isExplicitReactiveDependency(dependency)) {
+            if (isRetreeManagedDependency(dependency.node)) {
+                return dependency;
+            }
+            return {
+                node: undefined,
+                comparisons:
+                    dependency.comparisons === undefined
+                        ? [dependency.node]
+                        : dependency.comparisons,
+            };
+        }
+        if (isRetreeManagedDependency(dependency)) {
+            return {
+                node: dependency,
+            };
+        }
+        return {
+            node: undefined,
+            comparisons: [dependency],
+        };
+    }
+
+    private static getReactiveDependencyComparisonValues(
+        dependencies: unknown[]
+    ) {
+        const comparisonValues: unknown[] = [];
+        for (const dependency of dependencies) {
+            if (this.isExplicitReactiveDependency(dependency)) {
+                const normalizedDependency =
+                    this.normalizeReactiveNodeDependency(dependency);
+                comparisonValues.push(
+                    normalizedDependency.node ?? dependency.node
+                );
+                if (normalizedDependency.comparisons !== undefined) {
+                    comparisonValues.push(...normalizedDependency.comparisons);
+                }
+                continue;
+            }
+            comparisonValues.push(dependency);
+        }
+        return comparisonValues;
+    }
+
+    private static isExplicitReactiveDependency(
+        dependency: unknown
+    ): dependency is IReactiveDependency {
+        if (
+            dependency === null ||
+            typeof dependency !== "object" ||
+            isRetreeManagedDependency(dependency)
+        ) {
+            return false;
+        }
+        if (!("node" in dependency)) {
+            return false;
+        }
+        if (!this.hasComparisonsProperty(dependency)) {
+            return true;
+        }
+        const comparisons = dependency.comparisons;
+        return comparisons === undefined || Array.isArray(comparisons);
+    }
+
+    private static hasComparisonsProperty(
+        dependency: object
+    ): dependency is { comparisons: unknown } {
+        return "comparisons" in dependency;
+    }
+
     private static stopReactiveNode(
         proxiedNode: ReactiveNode,
         unproxiedNode: TreeNode
@@ -1342,8 +1490,15 @@ export class Retree {
             // If our comparisons exist, we check to see if any changed
             if (!shouldNotify) {
                 // Need to get the latest dependency values for our comparison
-                const latest =
-                    dependent.reactiveNode.dependencies[dependent.index];
+                const latest = this.getReactiveNodeDependencies(
+                    dependent.reactiveNode
+                )[dependent.index];
+                if (latest === undefined) {
+                    // @retree-throws
+                    throw new Error(
+                        "ReactiveNode dependency slot disappeared while handling a dependency change. This is a ReactiveNode implementation error. Fix: keep ReactiveNode.dependencies and @select dependency arrays stable in length and order while the node is observed."
+                    );
+                }
                 const latestComparisons = latest.comparisons;
                 if (
                     latestComparisons === undefined ||

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -29,12 +29,16 @@ import {
 } from "./internals/reproxy";
 import { Transactions } from "./internals/transactions";
 import {
+    LINKED_KEYS_SYMBOL,
     ReactiveNode,
     RUN_CHANGED_EFFECT_SYMBOL,
     RUN_OBSERVED_EFFECT_SYMBOL,
     RUN_UNOBSERVED_EFFECT_SYMBOL,
+    setReactiveNodeLinkImplementation,
+    setReactiveNodeMoveImplementation,
 } from "./ReactiveNode";
 import {
+    RetreeObjectMoveKey,
     TRetreeEvents,
     TNodeChangedListener,
     TRetreeListeners,
@@ -53,11 +57,34 @@ type TInternalNodeChangedListener = (
     reproxiedNode: TreeNode
 ) => void;
 
+export class RetreeLink<
+    TNode extends TreeNode = TreeNode
+> extends ReactiveNode {
+    public current: TNode;
+
+    constructor(node: TNode) {
+        super();
+        this[LINKED_KEYS_SYMBOL].add("current");
+        this.current = node;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
 /**
  * Main entry point for use with Retree package.
  * Exposes utility functions for observing to changes to an object and its children.
  */
 export class Retree {
+    static {
+        setReactiveNodeLinkImplementation((node) => Retree.link(node));
+        setReactiveNodeMoveImplementation((node, destination, key) =>
+            Retree.moveInternal(node, destination, key)
+        );
+    }
+
     private static nodeChangeListener: TInternalNodeChangedListener | null =
         null;
     private static nodeRemovedListener: TInternalNodeChangedListener | null =
@@ -104,6 +131,89 @@ export class Retree {
     }
 
     /**
+     * Create a reactive pointer to an existing Retree-managed node.
+     *
+     * @remarks
+     * The returned link can be stored in a Retree tree without reparenting the
+     * linked target. Replacing `link.current` emits for the link; mutating the
+     * linked target emits from its structural location.
+     */
+    static link<TNode extends TreeNode>(node: TNode): RetreeLink<TNode> {
+        this.assertRetreeManagedNode(node, "Retree.link");
+        return this.root(new RetreeLink(node));
+    }
+
+    /**
+     * Clone a Retree-managed node into a detached object that can be assigned
+     * somewhere else as a new structural child.
+     */
+    static clone<TNode extends TreeNode>(node: TNode): TNode {
+        this.assertRetreeManagedNode(node, "Retree.clone");
+        return this.cloneValue(getUnproxiedNode(node), new WeakMap()) as TNode;
+    }
+
+    /**
+     * Move an existing Retree-managed node from its current parent to a new parent.
+     */
+    static move<TNode extends TreeNode, TValue extends TreeNode = TNode>(
+        node: TNode extends TValue ? TNode : never,
+        destination: TValue[],
+        key?: number
+    ): TNode;
+    static move<
+        TNode extends TreeNode,
+        TKey = unknown,
+        TValue extends TreeNode = TNode
+    >(
+        node: TNode extends TValue ? TNode : never,
+        destination: Map<TKey, TValue>,
+        key: TKey
+    ): TNode;
+    static move<TNode extends TreeNode, TValue extends TreeNode = TNode>(
+        node: TNode extends TValue ? TNode : never,
+        destination: Set<TValue>
+    ): TNode;
+    static move<
+        TNode extends TreeNode,
+        TDestination extends TreeNode = TreeNode
+    >(
+        node: TNode,
+        destination: TDestination,
+        key: RetreeObjectMoveKey<TDestination, TNode>
+    ): TNode;
+    static move<TNode extends TreeNode>(
+        node: TNode,
+        destination: TreeNode,
+        key?: unknown
+    ): TNode {
+        return this.moveInternal(node, destination, key);
+    }
+
+    private static moveInternal<TNode extends TreeNode>(
+        node: TNode,
+        destination: TreeNode,
+        key?: unknown
+    ): TNode {
+        this.assertRetreeManagedNode(node, "Retree.move");
+        this.assertRetreeManagedNode(destination, "Retree.move");
+
+        const parent = this.getParentInternal(node);
+        if (!parent) {
+            // @retree-throws
+            throw new Error(
+                "Retree.move: cannot move a root node because it does not have a parent. This is expected when the node was created directly with Retree.root(...). Fix: move one of the root's children, assign the root into another tree as a cloned value with Retree.clone(...), or create the root under the desired parent first."
+            );
+        }
+
+        const nodeToMove = getBaseProxy(node);
+        Retree.runTransaction(() => {
+            this.removeNodeFromParent(nodeToMove, parent.proxyNode);
+            this.insertNodeIntoDestination(nodeToMove, destination, key);
+        });
+        return getReproxyNode(nodeToMove) as TNode;
+    }
+
+    /**
      * Listen for changes to a node.
      * @remarks
      * Use listener {@link TRetreeEvents"nodeChanged"} for changes to any leaf child of the node.
@@ -146,8 +256,9 @@ export class Retree {
 
         const unproxiedNode = getUnproxiedNode(node);
         if (!unproxiedNode) {
+            // @retree-throws
             throw new Error(
-                "Retree.on: must use an object that is a proxied node. Pass object to Retree.root first, or get value from another child object."
+                "Retree.on: expected a Retree-managed node but received an unproxied value. This is expected when listening to a plain object. Fix: pass the object to Retree.root(...) first, or listen to a child value read from an existing Retree tree."
             );
         }
         const relevantListenerMap =
@@ -323,7 +434,10 @@ export class Retree {
     public static clearListeners(node: TreeNode, shallow: boolean = true) {
         const rawNode = getUnproxiedNode(node);
         if (!rawNode) {
-            throw new Error("Cannot clear listeners for an unproxied `node`");
+            // @retree-throws
+            throw new Error(
+                "Retree.clearListeners: expected a Retree-managed node but received an unproxied value. This is expected when clearing listeners for a plain object. Fix: pass the same Retree.root(...) result or Retree child proxy that was used with Retree.on(...), or call the unsubscribe function returned by Retree.on(...)."
+            );
         }
         const shouldStopReactiveNode =
             node instanceof ReactiveNode &&
@@ -455,8 +569,9 @@ export class Retree {
                     const unproxiedNode =
                         getUnproxiedNode(proxyNodeThatChanged);
                     if (!unproxiedNode) {
+                        // @retree-throws
                         throw new Error(
-                            "Retree.handleNotifyTreeChanged: Unexpected to not find unproxied node for proxyNodeThatChanged"
+                            "Retree internal invariant failed in handleNotifyTreeChanged: could not find the raw node for proxyNodeThatChanged while scheduling a treeChanged event. This is unexpected and likely a Retree bug. Please file an issue with the mutation that triggered this and whether it happened inside Retree.runTransaction(...)."
                         );
                     }
                     Transactions.upsertPendingTransaction(unproxiedNode, {
@@ -489,8 +604,9 @@ export class Retree {
                     if (Transactions.runningTransaction) {
                         const unproxiedPNode = getUnproxiedNode(pNode);
                         if (!unproxiedPNode) {
+                            // @retree-throws
                             throw new Error(
-                                "Retree.handleNotifyTreeChanged: Unexpected to not find unproxied node for proxyNodeThatChanged"
+                                "Retree internal invariant failed in handleNotifyTreeChanged: could not find the raw node for a parent proxy while scheduling a treeChanged event. This is unexpected and likely a Retree bug. Please file an issue with the mutation that triggered this and whether it happened inside Retree.runTransaction(...)."
                             );
                         }
                         Transactions.upsertPendingTransaction(unproxiedPNode, {
@@ -633,25 +749,241 @@ export class Retree {
         this.treeChangedListeners.clear();
     }
 
-    private static getParentInternal(
-        node: TreeNode
-    ): { rawNode: TreeNode; proxyNode: TCustomProxy<TreeNode> } | null {
+    private static getParentInternal(node: TreeNode): {
+        propName: string | symbol | null;
+        rawNode: TreeNode;
+        proxyNode: TCustomProxy<TreeNode>;
+    } | null {
         const oldHandler = getCustomProxyHandler(node);
         if (oldHandler) {
             const parent = oldHandler[proxiedParentKey];
             if (!parent || !parent.proxyNode) return null;
             const rawNode = getUnproxiedNode(parent.proxyNode);
             if (!rawNode) {
+                // @retree-throws
                 throw new Error(
-                    "Retree.getParentInternal: cannot get parent from an unproxied parent node"
+                    "Retree internal invariant failed in Retree.parent: the child has parent metadata, but the parent is not a Retree-managed proxy. This is unexpected and likely a Retree bug. Please file an issue with how the child was assigned, moved, or deleted."
                 );
             }
             return {
+                propName: parent.propName,
                 proxyNode: getBaseProxy(parent.proxyNode),
                 rawNode,
             };
         }
-        throw new Error("Node must be a valid TreeNode");
+        // @retree-throws
+        throw new Error(
+            "Retree.parent: expected a Retree-managed node but received a value without Retree proxy metadata. This is expected when calling Retree.parent(...) with a plain object, primitive, or object not read from a Retree tree. Fix: pass an object returned by Retree.root(...) or a child read from that tree."
+        );
+    }
+
+    private static assertRetreeManagedNode(node: TreeNode, apiName: string) {
+        if (!getCustomProxyHandler(node)) {
+            // @retree-throws
+            throw new Error(
+                `${apiName}: expected a Retree-managed node but received a value without Retree proxy metadata. This is expected when passing a plain object. Fix: pass an object returned by Retree.root(...) or read a child from an existing Retree tree.`
+            );
+        }
+    }
+
+    private static removeNodeFromParent(
+        node: TreeNode,
+        parent: TCustomProxy<TreeNode>
+    ) {
+        if (Array.isArray(parent)) {
+            const index = this.findArrayChildIndex(parent, node);
+            if (index === -1) {
+                // @retree-throws
+                throw new Error(
+                    "Retree.move: could not find the node in its array parent while removing it. This is unexpected if the node was not manually deleted or reassigned before Retree.move(...) ran. Fix: call Retree.move(node, destination, key) without first mutating the old parent; if that is already true, file a Retree issue with the source and destination."
+                );
+            }
+            parent.splice(index, 1);
+            return;
+        }
+
+        if (parent instanceof Map) {
+            const key = this.findMapChildKey(parent, node);
+            if (!key.found) {
+                // @retree-throws
+                throw new Error(
+                    "Retree.move: could not find the node in its Map parent while removing it. This is unexpected if the node was not manually deleted or reassigned before Retree.move(...) ran. Fix: call Retree.move(node, destination, key) without first mutating the old parent; if that is already true, file a Retree issue with the source and destination."
+                );
+            }
+            parent.delete(key.value);
+            return;
+        }
+
+        if (parent instanceof Set) {
+            if (!parent.delete(node)) {
+                // @retree-throws
+                throw new Error(
+                    "Retree.move: could not find the node in its Set parent while removing it. This is unexpected if the node was not manually deleted or reassigned before Retree.move(...) ran. Fix: call Retree.move(node, destination) without first mutating the old parent; if that is already true, file a Retree issue with the source and destination."
+                );
+            }
+            return;
+        }
+
+        const parentInfo = this.getParentInternal(node);
+        if (!parentInfo || parentInfo.propName === null) {
+            // @retree-throws
+            throw new Error(
+                "Retree.move: could not determine the object property that currently owns this node. This is unexpected for object parents and can happen if parent metadata was detached before the move. Fix: call Retree.move(...) before manually deleting/reassigning the old property; if that is already true, file a Retree issue with the source and destination."
+            );
+        }
+        if (!this.isSameTreeNode((parent as any)[parentInfo.propName], node)) {
+            // @retree-throws
+            throw new Error(
+                `Retree.move: parent property ${String(
+                    parentInfo.propName
+                )} no longer points to the node being moved. This is unexpected if the old parent was not manually mutated before Retree.move(...) ran. Fix: call Retree.move(...) before deleting or overwriting the old property; if that is already true, file a Retree issue with the source and destination.`
+            );
+        }
+        delete (parent as any)[parentInfo.propName];
+    }
+
+    private static insertNodeIntoDestination(
+        node: TreeNode,
+        destination: TreeNode,
+        key: unknown
+    ) {
+        if (Array.isArray(destination)) {
+            if (key === undefined) {
+                destination.push(node);
+                return;
+            }
+            if (typeof key !== "number") {
+                // @retree-throws
+                throw new Error(
+                    "Retree.move: array destinations require a numeric key, or no key to append. This is a caller argument error that TypeScript should usually catch. Fix: pass a number index, or omit the key to append to the array."
+                );
+            }
+            destination.splice(key, 0, node);
+            return;
+        }
+
+        if (destination instanceof Map) {
+            if (key === undefined) {
+                // @retree-throws
+                throw new Error(
+                    "Retree.move: Map destinations require a key. This is a caller argument error that TypeScript should usually catch. Fix: pass the Map key as the third argument."
+                );
+            }
+            destination.set(key, node);
+            return;
+        }
+
+        if (destination instanceof Set) {
+            destination.add(node);
+            return;
+        }
+
+        if (typeof key !== "string" && typeof key !== "symbol") {
+            // @retree-throws
+            throw new Error(
+                "Retree.move: object destinations require a string or symbol key. This is a caller argument error that TypeScript should usually catch. Fix: pass the destination property name as the third argument."
+            );
+        }
+        (destination as any)[key] = node;
+    }
+
+    private static findArrayChildIndex(parent: TreeNode[], node: TreeNode) {
+        for (let index = 0; index < parent.length; index++) {
+            if (this.isSameTreeNode(parent[index], node)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static findMapChildKey(
+        parent: Map<unknown, unknown>,
+        node: TreeNode
+    ): { found: true; value: unknown } | { found: false } {
+        for (const [key, value] of parent.entries()) {
+            if (this.isSameTreeNode(value, node)) {
+                return { found: true, value: key };
+            }
+        }
+        return { found: false };
+    }
+
+    private static isSameTreeNode(value: unknown, node: TreeNode) {
+        if (value !== null && typeof value === "object") {
+            return getUnproxiedNode(value) === getUnproxiedNode(node);
+        }
+        return false;
+    }
+
+    private static cloneValue(
+        value: unknown,
+        seen: WeakMap<object, object>
+    ): unknown {
+        if (value === null || typeof value !== "object") {
+            return value;
+        }
+
+        const rawValue = getUnproxiedNode(value);
+        if (!rawValue) {
+            // @retree-throws
+            throw new Error(
+                "Retree.clone: expected object values to be cloneable Retree nodes while walking the source tree. This is unexpected if the source came from Retree.root(...) and was only mutated through Retree-managed proxies. Fix: avoid storing raw unmanaged objects inside managed nodes except in @ignore fields; if the value is managed, file a Retree issue with the value shape."
+            );
+        }
+        if (seen.has(rawValue)) {
+            return seen.get(rawValue);
+        }
+
+        if (rawValue instanceof Date) {
+            const clonedDate = new Date(rawValue.getTime());
+            seen.set(rawValue, clonedDate);
+            return clonedDate;
+        }
+
+        if (rawValue instanceof Map) {
+            const clonedMap = new Map();
+            seen.set(rawValue, clonedMap);
+            for (const [mapKey, mapValue] of rawValue.entries()) {
+                clonedMap.set(mapKey, this.cloneValue(mapValue, seen));
+            }
+            return clonedMap;
+        }
+
+        if (rawValue instanceof Set) {
+            const clonedSet = new Set();
+            seen.set(rawValue, clonedSet);
+            for (const setValue of rawValue.values()) {
+                clonedSet.add(this.cloneValue(setValue, seen));
+            }
+            return clonedSet;
+        }
+
+        if (Array.isArray(rawValue)) {
+            const clonedArray: unknown[] = [];
+            seen.set(rawValue, clonedArray);
+            rawValue.forEach((item, index) => {
+                clonedArray[index] = this.cloneValue(item, seen);
+            });
+            return clonedArray;
+        }
+
+        const clonedObject = Object.create(Object.getPrototypeOf(rawValue));
+        seen.set(rawValue, clonedObject);
+        for (const key of Reflect.ownKeys(rawValue)) {
+            const descriptor = Reflect.getOwnPropertyDescriptor(rawValue, key);
+            if (!descriptor) {
+                continue;
+            }
+            if ("value" in descriptor) {
+                Reflect.defineProperty(clonedObject, key, {
+                    ...descriptor,
+                    value: this.cloneValue(descriptor.value, seen),
+                });
+                continue;
+            }
+            Reflect.defineProperty(clonedObject, key, descriptor);
+        }
+        return clonedObject;
     }
 
     private static handleReactiveNode(
@@ -667,8 +999,9 @@ export class Retree {
                 previousDependencies !== undefined &&
                 previousDependencies.length !== 0
             ) {
+                // @retree-throws
                 throw new Error(
-                    "ReactiveNode length of dependencies does not equal previous value. Please ensure your dependencies list is consistent in its length and ordering."
+                    "ReactiveNode.dependencies length changed after Retree started observing this node. This is a ReactiveNode implementation error. Fix: return a dependencies array with a stable length and ordering for the lifetime of each ReactiveNode instance; use null dependency nodes when a slot is temporarily inactive."
                 );
             }
             if (previousDependencies !== undefined) {
@@ -680,8 +1013,9 @@ export class Retree {
             previousDependencies &&
             previousDependencies.length !== currentDependencies.length
         ) {
+            // @retree-throws
             throw new Error(
-                "ReactiveNode length of dependencies does not equal previous value. Please ensure your dependencies list is consistent in its length and ordering."
+                "ReactiveNode.dependencies length changed after Retree started observing this node. This is a ReactiveNode implementation error. Fix: return a dependencies array with a stable length and ordering for the lifetime of each ReactiveNode instance; use null dependency nodes when a slot is temporarily inactive."
             );
         }
         const newActiveDependencies: IActiveReactiveDependency[] = [];
@@ -703,8 +1037,9 @@ export class Retree {
                 previousDependency.node !== null &&
                 previousUnproxiedDependencyNode === undefined
             ) {
+                // @retree-throws
                 throw new Error(
-                    "Unexpected missing cached unproxied node for previous dependent reactive node"
+                    "Retree internal invariant failed: a previous ReactiveNode dependency had a node but no cached raw node. This is unexpected and likely a Retree bug. Please file an issue with the ReactiveNode.dependencies implementation and the mutation that triggered this."
                 );
             }
             if (
@@ -717,8 +1052,9 @@ export class Retree {
                 const unproxiedDependencyNode =
                     getUnproxiedNode(newDependencyNode);
                 if (!unproxiedDependencyNode) {
+                    // @retree-throws
                     throw new Error(
-                        "Unexpected unproxied node for current dependent reactive node"
+                        "ReactiveNode.dependencies returned an object that is not Retree-managed. This is expected when a dependency points at a plain object. Fix: return null/undefined for inactive dependencies, or return a node created by Retree.root(...) or read from an existing Retree tree."
                     );
                 }
                 currentUnproxiedDependencyNode = unproxiedDependencyNode;
@@ -813,8 +1149,9 @@ export class Retree {
         // It's cheap to get unproxied node, so doing that for now
         const _unproxy = getUnproxiedNode(reproxy);
         if (!_unproxy) {
+            // @retree-throws
             throw new Error(
-                "Unexpected unproxied node for current dependent reactive node on nodeChanged"
+                "Retree internal invariant failed: a ReactiveNode dependency change arrived with an unproxied node. This is unexpected and likely a Retree bug. Please file an issue with the dependency node and mutation that triggered this."
             );
         }
         const dependents = getReactiveDependents(_unproxy);
@@ -835,8 +1172,9 @@ export class Retree {
                     !previousComparisons ||
                     latestComparisons.length !== previousComparisons.length
                 ) {
+                    // @retree-throws
                     throw new Error(
-                        "Unexpected comparisons value for ReactiveNode. Ensure your comparisons have a consistent length and ordering for each ReactiveNode instance."
+                        "ReactiveNode dependency comparisons changed shape. This is a ReactiveNode implementation error. Fix: keep each dependency's comparisons array either undefined or a stable-length array in a stable order for the lifetime of that dependency slot."
                     );
                 }
                 for (let i = 0; i < latestComparisons.length; i++) {
@@ -855,8 +1193,9 @@ export class Retree {
                 ? getReproxyNodeForUnproxiedNode(dependentUnproxied)
                 : updateReproxyNode(dependentBaseProxy);
             if (!dependentReproxy) {
+                // @retree-throws
                 throw new Error(
-                    "Unexpectely found no existing reproxy value for dependent node."
+                    "Retree internal invariant failed: unexpectedly found no reproxy value for a dependent ReactiveNode. This is unexpected and likely a Retree bug. Please file an issue with the ReactiveNode.dependencies implementation and whether the mutation happened inside Retree.runSilent(...)."
                 );
             }
             this.nodeChangeListener?.(

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -57,9 +57,39 @@ type TInternalNodeChangedListener = (
     reproxiedNode: TreeNode
 ) => void;
 
+/**
+ * Reactive pointer to a Retree-managed node owned somewhere else.
+ *
+ * @remarks
+ * `RetreeLink` is created by {@link Retree.link}. Store it in a Retree tree
+ * when one part of state needs to point at another node without becoming that
+ * node's structural parent. Replacing {@link RetreeLink.current} emits for the
+ * link. Mutating `current` emits from the target's structural location.
+ *
+ * Most code should call {@link Retree.link} instead of constructing this class
+ * directly.
+ *
+ * @example
+ * ```ts
+ * const root = Retree.root({
+ *     tasks: [{ title: "Docs" }],
+ *     selected: null as RetreeLink<{ title: string }> | null,
+ * });
+ *
+ * root.selected = Retree.link(root.tasks[0]);
+ * root.selected.current.title = "Better docs";
+ * ```
+ */
 export class RetreeLink<
     TNode extends TreeNode = TreeNode
 > extends ReactiveNode {
+    /**
+     * The linked Retree-managed node.
+     *
+     * @remarks
+     * Replacing `current` emits for the link node. Mutating the target emits
+     * where that target is structurally owned.
+     */
     public current: TNode;
 
     constructor(node: TNode) {
@@ -106,6 +136,12 @@ export class Retree {
     /**
      * @deprecated
      * Use {@link root} instead.
+     *
+     * @example
+     * ```ts
+     * const state = Retree.use({ count: 0 }); // deprecated
+     * const state = Retree.root({ count: 0 }); // preferred
+     * ```
      */
     static use<T extends TreeNode = TreeNode>(object: T): T {
         return this.root(object);
@@ -114,17 +150,25 @@ export class Retree {
     /**
      * Builds a Retree compatible root node for the root object of your tree.
      * @remarks
-     * Use this function only for a root object.
-     * This will make the object compatible with {@link Retree.on}, {@link Retree.parent}, etc.
-     * For child objects of this root node, simply set values to them like you normally would in JS/TS.
+     * Use this once where plain state enters Retree. The returned proxy is
+     * compatible with {@link Retree.on}, {@link Retree.parent},
+     * {@link Retree.move}, {@link Retree.link}, and React hooks from
+     * `@retreejs/react`.
+     *
+     * Do mutate the returned tree directly with normal JavaScript assignment
+     * and collection methods. Do not call `Retree.root(...)` on every child
+     * you assign into the tree; Retree prepares children as they are attached
+     * or read.
      *
      * @param object a root TreeNode for your tree
      * @returns a Retree compatible object of type T
      * 
      * @example
+     * ```ts
      const counter = Retree.root({ count: 0 });
-     Retree.on(counter, "valueChanged", () => console.log(counter.count));
+     Retree.on(counter, "nodeChanged", () => console.log(counter.count));
      counter.count = counter.count + 1;
+     ```
      */
     static root<T extends TreeNode = TreeNode>(object: T): T {
         return buildProxy<T>(object, this.nodeChangeEmitter);
@@ -137,6 +181,26 @@ export class Retree {
      * The returned link can be stored in a Retree tree without reparenting the
      * linked target. Replacing `link.current` emits for the link; mutating the
      * linked target emits from its structural location.
+     *
+     * Use this for selected items, cross-references, and pointers into another
+     * part of the same tree. Do not use a link when ownership should move; use
+     * {@link Retree.move} instead. Do not use a link when the two locations
+     * should diverge independently; use {@link Retree.clone} instead.
+     *
+     * @param node Existing Retree-managed node to point at.
+     * @returns A Retree-managed link object whose `current` points at `node`.
+     *
+     * @example
+     * ```ts
+     * const root = Retree.root({
+     *     tasks: [{ title: "Docs" }],
+     *     selected: null as RetreeLink<{ title: string }> | null,
+     * });
+     *
+     * root.selected = Retree.link(root.tasks[0]); // ✅ emits on root
+     * root.selected.current.title = "Better docs"; // ✅ emits where task is owned
+     * Retree.parent(root.selected.current) === root.tasks; // true
+     * ```
      */
     static link<TNode extends TreeNode>(node: TNode): RetreeLink<TNode> {
         this.assertRetreeManagedNode(node, "Retree.link");
@@ -146,6 +210,28 @@ export class Retree {
     /**
      * Clone a Retree-managed node into a detached object that can be assigned
      * somewhere else as a new structural child.
+     *
+     * @remarks
+     * Use this when two places need independent state initialized from the
+     * same current data. The clone is detached until you assign it into a
+     * Retree tree. Mutating the clone after assignment emits for the clone's
+     * new structural location, not the source node.
+     *
+     * Do not use `clone` when the original object should simply move; use
+     * {@link Retree.move}. Do not use `clone` for a selected-item pointer; use
+     * {@link Retree.link} or `@link`.
+     *
+     * @param node Existing Retree-managed node to copy.
+     * @returns A detached copy of the node's current raw data.
+     *
+     * @example
+     * ```ts
+     * const project = Retree.root({ tasks: [{ title: "Draft" }] });
+     * const copy = Retree.clone(project.tasks[0]);
+     *
+     * project.tasks.push(copy); // ✅ copy becomes a new child
+     * project.tasks[1].title = "Published"; // source task is unchanged
+     * ```
      */
     static clone<TNode extends TreeNode>(node: TNode): TNode {
         this.assertRetreeManagedNode(node, "Retree.clone");
@@ -154,6 +240,34 @@ export class Retree {
 
     /**
      * Move an existing Retree-managed node from its current parent to a new parent.
+     *
+     * @remarks
+     * Retree is a pure tree: each node has one structural parent. Use `move`
+     * when ownership should transfer from the old parent to the destination.
+     * Retree finds the current parent with {@link Retree.parent} and removes
+     * the node safely before inserting it into the destination.
+     *
+     * Arrays accept an optional numeric insertion index. Maps and plain
+     * objects require a key. Sets ignore the key. Do not manually delete the
+     * node from its old parent before calling `move`.
+     *
+     * @param node Existing Retree-managed node to move.
+     * @param destination Retree-managed array, map, set, or object destination.
+     * @param key Insertion index for arrays, map key for maps, or property key
+     * for objects.
+     * @returns The latest reproxy for the moved node.
+     *
+     * @example
+     * ```ts
+     * const workspace = Retree.root({
+     *     todo: [{ title: "Docs" }],
+     *     done: [] as { title: string }[],
+     * });
+     *
+     * const moved = Retree.move(workspace.todo[0], workspace.done);
+     * workspace.todo.length; // 0
+     * workspace.done[0] === moved; // true
+     * ```
      */
     static move<TNode extends TreeNode, TValue extends TreeNode = TNode>(
         node: TNode extends TValue ? TNode : never,
@@ -216,21 +330,21 @@ export class Retree {
     /**
      * Listen for changes to a node.
      * @remarks
-     * Use listener {@link TRetreeEvents"nodeChanged"} for changes to any leaf child of the node.
-     * Use listener {@link TRetreeEvents"treeChanged"} for changes to any leaf child of the node or its child nodes.
-     * Use listener {@link TRetreeEvents"nodeRemoved"} for when this node was removed from its parent.
+     * Use `nodeChanged` for changes directly owned by the node.
+     * Use `treeChanged` for changes to the node or descendants.
+     * Use `nodeRemoved` for when this node is removed from its parent.
      *
      * @param node the object to listen for changes to.
      * @param listenerType the type of {@link TRetreeEvents} change events to listen to.
      * @param callback the callback function for your listener.
-     * @returns an unsubscribe function to cleanup your listners.
+     * @returns an unsubscribe function to clean up your listeners.
      * 
      * @example
      ```ts
      // Create the root node
      const counter = Retree.root({ count: 0 });
      // Listen for changes to values of the node
-     const unsubscribe = Retree.on(counter, "valueChanged", (reproxy) => {
+     const unsubscribe = Retree.on(counter, "nodeChanged", (reproxy) => {
         console.log(reproxy !== counter); // output: false
         console.log(reproxy.count === counter.count); // output: true
      });
@@ -303,6 +417,35 @@ export class Retree {
      * then calls `callback` only when the selected value changes.
      * This is a subscription primitive, not a memo cache: use `memo` /
      * `fnMemo` to cache computation, and `select` to narrow notifications.
+     *
+     * By default `select` listens to `nodeChanged`, which is correct when the
+     * selector reads fields directly owned by `node`. Pass
+     * `listenerType: "treeChanged"` when the selector reads descendants.
+     *
+     * @param node Retree-managed node to observe.
+     * @param selector Function that reads a derived value from the latest
+     * reproxy.
+     * @param callback Called only when the selected value changes.
+     * @param options Optional listener type and equality comparison.
+     * @returns Unsubscribe function.
+     *
+     * @example
+     * ```ts
+     * const project = Retree.root({
+     *     tasks: [{ done: false }, { done: true }],
+     * });
+     *
+     * const unsubscribe = Retree.select(
+     *     project.tasks,
+     *     (tasks) => tasks.filter((task) => task.done).length,
+     *     (next, previous) => console.log({ next, previous }),
+     *     { listenerType: "treeChanged" }
+     * );
+     *
+     * project.tasks[0].done = true; // ✅ callback: 1 -> 2
+     * project.tasks[0].done = true; // ❌ selected value did not change
+     * unsubscribe();
+     * ```
      */
     static select<TNode extends TreeNode, TSelected>(
         node: TNode,
@@ -367,9 +510,30 @@ export class Retree {
     /**
      * Run a synchronous transaction that will not cause `{@link Retree.on} listeners to emit.
      *
+     * @remarks
+     * Use `runSilent` for non-rendered bookkeeping or integration state that
+     * should update without notifying Retree listeners. By default it also
+     * skips reproxying, so old and new object identities stay equal for later
+     * comparison checks.
+     *
+     * Pass `skipReproxy = false` when you want to suppress listener emission
+     * but still refresh reproxy identities.
+     *
      * @param transaction transaction function to run
      * @param skipReproxy skip reproxying nodes such that subsequent comparisons are equal.
      * defaults to true.
+     *
+     * @example
+     * ```ts
+     * const state = Retree.root({ rendered: 0, telemetry: 0 });
+     * Retree.on(state, "nodeChanged", () => console.log("render"));
+     *
+     * Retree.runSilent(() => {
+     *     state.telemetry += 1;
+     * }); // ❌ no listener emit
+     *
+     * state.rendered += 1; // ✅ emits
+     * ```
      */
     static runSilent(transaction: () => void, skipReproxy = true) {
         Transactions.skipEmit = true;
@@ -395,8 +559,8 @@ export class Retree {
      * @example
      ```ts
      const counter = Retree.root({ count: 0 });
-     Retree.on(counter, "valueChanged", () => console.log(counter.count));
-     // Will only emit "valueChanged" once
+     Retree.on(counter, "nodeChanged", () => console.log(counter.count));
+     // Will only emit "nodeChanged" once
      Retree.runTransaction(() => {
         counter.count = counter.count + 1;
         counter.count = counter.count * 2;
@@ -428,8 +592,22 @@ export class Retree {
      * @remarks
      * Equivalent to calling each `unsubscribe` function returned by {@link Retree.on}.
      *
+     * Prefer storing and calling the unsubscribe returned from
+     * {@link Retree.on} when you own a single subscription. Use
+     * `clearListeners` when you own every listener for a node, such as during
+     * teardown of a Retree-managed integration.
+     *
      * @param node node to clear all listeners for
      * @param shallow when false, will unsubscribe to all child nodes as well.
+     *
+     * @example
+     * ```ts
+     * const root = Retree.root({ child: { count: 0 } });
+     * Retree.on(root, "nodeChanged", () => {});
+     * Retree.on(root.child, "nodeChanged", () => {});
+     *
+     * Retree.clearListeners(root, false); // clears root and child listeners
+     * ```
      */
     public static clearListeners(node: TreeNode, shallow: boolean = true) {
         const rawNode = getUnproxiedNode(node);
@@ -663,10 +841,10 @@ export class Retree {
             // If in a skipEmit transaction state, skip emitting
             if (Transactions.skipEmit) return;
             const emitNodeRemovedListeners = () => {
-                const listnersToNotify =
+                const listenersToNotify =
                     this.nodeRemovedListeners.get(node) ?? [];
                 // We copy the list because it could get changed if the first callback triggers an unsubscribe
-                [...listnersToNotify].forEach((callback) => {
+                [...listenersToNotify].forEach((callback) => {
                     callback();
                 });
             };

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -30,11 +30,14 @@ import {
 } from "./internals/reproxy";
 import {
     createRetreeSelectionObserver,
+    createRetreeTrackedSelectionObserver,
     normalizeSelectDependencies,
     RetreeSelectEquals,
     RetreeSelectSelector,
+    RetreeTrackedSelectSelector,
 } from "./internals/select";
 import {
+    areDependencyValuesEqual,
     getDependencyComparisonValues,
     normalizeDependencyEntry,
 } from "./internals/dependencies";
@@ -445,6 +448,14 @@ export class Retree {
      * descendants that are not included as reactive entries in a dependency
      * list.
      *
+     * You can also call `Retree.select(() => value, callback)` without a node.
+     * That form traps reads automatically. Whole Retree-managed values are
+     * subscribed to broadly. Property reads subscribe to the owner node but
+     * compare the specific property value, so `task.done` can react to task
+     * replacement or `done` changes without reacting to unrelated task fields.
+     * Primitive reads are kept as comparison values, so the callback only runs
+     * when the trapped reads make the selected value or dependency set change.
+     *
      * @param node Retree-managed node to observe.
      * @param selector Function that reads a selected value or dependency list
      * from the latest reproxy.
@@ -480,13 +491,64 @@ export class Retree {
      *     ([, , attribute]) => console.log(attribute)
      * );
      * ```
+     *
+     * @example
+     * ```ts
+     * Retree.select(
+     *     () => project.tasks.filter((task) => task.done).length,
+     *     (doneCount) => console.log(doneCount)
+     * );
+     * ```
      */
     static select<TNode extends TreeNode, TSelected>(
         node: TNode,
         selector: RetreeSelectSelector<TNode, TSelected>,
         callback: (next: TSelected, previous: TSelected) => void,
+        options?: RetreeSelectOptions<TSelected>
+    ): () => void;
+    static select<TSelector extends RetreeTrackedSelectSelector<unknown>>(
+        selector: TSelector,
+        callback: (
+            next: ReturnType<TSelector>,
+            previous: ReturnType<TSelector>
+        ) => void,
+        options?: RetreeSelectOptions<ReturnType<TSelector>>
+    ): () => void;
+    static select<TNode extends TreeNode, TSelected>(
+        nodeOrSelector: TNode | RetreeTrackedSelectSelector<TSelected>,
+        selectorOrCallback:
+            | RetreeSelectSelector<TNode, TSelected>
+            | ((next: TSelected, previous: TSelected) => void),
+        callbackOrOptions?:
+            | ((next: TSelected, previous: TSelected) => void)
+            | RetreeSelectOptions<TSelected>,
         options: RetreeSelectOptions<TSelected> = {}
     ): () => void {
+        if (typeof nodeOrSelector === "function") {
+            return createRetreeTrackedSelectionObserver({
+                selector: nodeOrSelector,
+                equals: (callbackOrOptions as RetreeSelectOptions<TSelected>)
+                    ?.equals,
+                subscribeToNode: (
+                    selectedNode,
+                    selectedListenerType,
+                    listener
+                ) => this.on(selectedNode, selectedListenerType, listener),
+                onChange: selectorOrCallback as (
+                    next: TSelected,
+                    previous: TSelected
+                ) => void,
+            });
+        }
+        const node = nodeOrSelector;
+        const selector = selectorOrCallback as RetreeSelectSelector<
+            TNode,
+            TSelected
+        >;
+        const callback = callbackOrOptions as (
+            next: TSelected,
+            previous: TSelected
+        ) => void;
         const listenerType = options.listenerType ?? "nodeChanged";
         return createRetreeSelectionObserver({
             node,
@@ -1338,16 +1400,12 @@ export class Retree {
     ): IActiveReactiveDependency[] {
         const selectGetters = proxiedDependentNode[SELECT_GETTERS_SYMBOL];
         const dependencies: IActiveReactiveDependency[] = [];
+        const unproxiedDependentNode = getUnproxiedNode(proxiedDependentNode);
         for (const [getterName, selectGetter] of selectGetters.entries()) {
             const selected = selectGetter.getDependencies(proxiedDependentNode);
             const selectedDependencies = normalizeSelectDependencies(selected);
             if (selectedDependencies.length === 0) {
-                // @retree-throws
-                throw new Error(
-                    `@select dependency list for getter '${String(
-                        getterName
-                    )}' was empty. This is a ReactiveNode implementation error because @select needs at least one dependency slot to observe or compare. Fix: return one or more dependencies, or remove @select from this getter.`
-                );
+                continue;
             }
             for (
                 let dependencyIndex = 0;
@@ -1362,6 +1420,14 @@ export class Retree {
                         selectedDependency,
                         key
                     );
+                if (
+                    normalizedDependency.node !== undefined &&
+                    normalizedDependency.node !== null &&
+                    getUnproxiedNode(normalizedDependency.node) ===
+                        unproxiedDependentNode
+                ) {
+                    continue;
+                }
                 const laterComparisons = getDependencyComparisonValues(
                     selectedDependencies.slice(dependencyIndex + 1)
                 );
@@ -1552,7 +1618,12 @@ export class Retree {
             return true;
         }
         for (let i = 0; i < latestComparisons.length; i++) {
-            if (latestComparisons[i] !== previousComparisons[i]) {
+            if (
+                !areDependencyValuesEqual(
+                    previousComparisons[i],
+                    latestComparisons[i]
+                )
+            ) {
                 return true;
             }
         }

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -121,6 +121,66 @@ class DynamicSelectNode extends ReactiveNode {
     }
 }
 
+class AutoSelectTotalNode extends ReactiveNode {
+    public price = { value: 2 };
+    public amount = { value: 3 };
+    public note = { value: "ignored" };
+
+    @select()
+    get total() {
+        return this.price.value * this.amount.value;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class AutoSelectTaskRowNode extends ReactiveNode {
+    @link
+    public task: { isCompleted: boolean; text: string };
+
+    constructor(task: { isCompleted: boolean; text: string }) {
+        super();
+        this.task = task;
+    }
+
+    @select()
+    get isVisible() {
+        return !this.task.isCompleted;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+interface FilteredTask {
+    isCompleted: boolean;
+    text: string;
+}
+
+class AutoSelectTaskListNode extends ReactiveNode {
+    public filters = { isCompleted: null as boolean | null };
+    public allTasks: FilteredTask[] = [
+        { isCompleted: false, text: "Write docs" },
+        { isCompleted: true, text: "Ship release" },
+    ];
+
+    @select()
+    public get tasks(): FilteredTask[] {
+        return this.allTasks.filter(
+            (task) =>
+                this.filters.isCompleted === null ||
+                task.isCompleted === this.filters.isCompleted
+        );
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
 const rootsToCleanup: object[] = [];
 
 function trackRoot<T extends object>(node: T): T {
@@ -297,5 +357,89 @@ describe("select", () => {
 
         root.second.value = 2;
         expect(nodeChanged).toHaveBeenCalledTimes(2);
+    });
+
+    it("captures accessed Retree nodes when @select is called without a selector", () => {
+        const root = trackRoot(Retree.root(new AutoSelectTotalNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        root.note.value = "still ignored";
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.price.value = 4;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(root.total).toBe(12);
+
+        root.amount.value = 5;
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
+        expect(root.total).toBe(20);
+    });
+
+    it("captures primitive reads as comparisons for @select without a selector", () => {
+        const source = trackRoot(
+            Retree.root({
+                task: {
+                    isCompleted: false,
+                    text: "Write docs",
+                },
+            })
+        );
+        const row = trackRoot(
+            Retree.root(new AutoSelectTaskRowNode(source.task))
+        );
+        const nodeChanged = vi.fn();
+        Retree.on(row, "nodeChanged", nodeChanged);
+
+        source.task.text = "Write better docs";
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        source.task.isCompleted = true;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(row.isVisible).toBe(false);
+    });
+
+    it("narrows trapped object reads to accessed fields while preserving list slot identity", () => {
+        const root = trackRoot(Retree.root(new AutoSelectTaskListNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        root.allTasks[0].text = "Write even better docs";
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.allTasks[0].isCompleted = true;
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.allTasks[0] = {
+            isCompleted: false,
+            text: "Fresh task object",
+        };
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(root.tasks.map((task) => task.text)).toEqual([
+            "Fresh task object",
+            "Ship release",
+        ]);
+
+        root.filters.isCompleted = false;
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
+        expect(root.tasks.map((task) => task.text)).toEqual([
+            "Fresh task object",
+        ]);
+
+        root.allTasks[0].text = "Write best docs";
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
+
+        root.allTasks[0].isCompleted = true;
+        expect(nodeChanged).toHaveBeenCalledTimes(3);
+        expect(root.tasks).toEqual([]);
+
+        root.allTasks[0] = {
+            isCompleted: false,
+            text: "Fresh task object",
+        };
+        expect(nodeChanged).toHaveBeenCalledTimes(4);
+        expect(root.tasks.map((task) => task.text)).toEqual([
+            "Fresh task object",
+        ]);
     });
 });

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -14,7 +14,27 @@ class IgnoredNode extends ReactiveNode {
     }
 }
 
-let root: IgnoredNode | null = null;
+class IgnoredPointerNode extends ReactiveNode {
+    public child = { value: 0 };
+
+    @ignore
+    public selected: { value: number } | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class IgnoredExternalPointerNode extends ReactiveNode {
+    @ignore
+    public selected: { value: number } | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+
+let root: ReactiveNode | null = null;
 
 afterEach(() => {
     if (root) {
@@ -38,5 +58,55 @@ describe("ignore", () => {
 
         expect(nodeChanged).toHaveBeenCalledTimes(1);
         expect(root.ignored.count).toBe(1);
+    });
+
+    it("does not emit when an ignored field is set to a proxied node", () => {
+        const state = Retree.root(new IgnoredPointerNode());
+        root = state;
+        const nodeChanged = vi.fn();
+        Retree.on(state, "nodeChanged", nodeChanged);
+
+        state.selected = state.child;
+
+        expect(nodeChanged).not.toHaveBeenCalled();
+    });
+
+    it("does not reparent a proxied node stored in an ignored field", () => {
+        const source = Retree.root({ child: { value: 0 } });
+        const owner = Retree.root(new IgnoredExternalPointerNode());
+        root = owner;
+
+        owner.selected = source.child;
+
+        if (!owner.selected) {
+            throw new Error(
+                "Expected ignored field to store the selected source child."
+            );
+        }
+        expect(Retree.parent(owner.selected)).toBe(source);
+    });
+
+    it("returns the latest reproxy for a proxied node stored in an ignored field", () => {
+        const state = Retree.root(new IgnoredPointerNode());
+        root = state;
+        state.selected = state.child;
+
+        const selectedBeforeChange = state.selected;
+        if (!selectedBeforeChange) {
+            throw new Error(
+                "Expected ignored field to return the selected child before mutation."
+            );
+        }
+
+        state.child.value = 1;
+
+        const selectedAfterChange = state.selected;
+        if (!selectedAfterChange) {
+            throw new Error(
+                "Expected ignored field to return the selected child after mutation."
+            );
+        }
+        expect(selectedAfterChange).not.toBe(selectedBeforeChange);
+        expect(selectedAfterChange.value).toBe(1);
     });
 });

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -104,6 +104,23 @@ class AttributeViewCustomSelectNode extends ReactiveNode {
     }
 }
 
+class DynamicSelectNode extends ReactiveNode {
+    public includeSecond = false;
+    public first = { value: 0 };
+    public second = { value: 0 };
+
+    @select((self: DynamicSelectNode) =>
+        self.includeSecond ? [self.first, self.second] : [self.first]
+    )
+    get total() {
+        return this.first.value + (this.includeSecond ? this.second.value : 0);
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
 const rootsToCleanup: object[] = [];
 
 function trackRoot<T extends object>(node: T): T {
@@ -264,5 +281,21 @@ describe("select", () => {
 
         expect(nodeChanged).toHaveBeenCalledTimes(1);
         expect(root.attribute?.id).toBe("b");
+    });
+
+    it("allows @select dependency list length changes independently", () => {
+        const root = trackRoot(Retree.root(new DynamicSelectNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        root.second.value = 1;
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.includeSecond = true;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(root.total).toBe(1);
+
+        root.second.value = 2;
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
-import { ignore, link } from "./decorators";
+import { ignore, link, memo, select } from "./decorators";
 import { Transactions } from "./internals/transactions";
 
 class IgnoredNode extends ReactiveNode {
@@ -39,6 +39,65 @@ class LinkedPointerNode extends ReactiveNode {
 
     @link
     public selected: { value: number } | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class AttributeViewNode extends ReactiveNode {
+    public attributeId = "a";
+    public attributes = [
+        { id: "a", value: 0 },
+        { id: "b", value: 0 },
+    ];
+
+    @memo((self: AttributeViewNode) => [self.attributes, self.attributeId])
+    private get _attribute() {
+        return this.attributes.find(
+            (attribute) => attribute.id === this.attributeId
+        );
+    }
+
+    @select((self: AttributeViewNode) => [
+        self.attributes,
+        self.attributeId,
+        self._attribute,
+    ])
+    get attribute() {
+        return this._attribute;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class AttributeViewCustomSelectNode extends ReactiveNode {
+    public attributeId = "a";
+    public attributes = [
+        { id: "a", value: 0 },
+        { id: "b", value: 0 },
+    ];
+
+    @memo((self: AttributeViewCustomSelectNode) => [
+        self.attributes,
+        self.attributeId,
+    ])
+    private get _attribute() {
+        return this.attributes.find(
+            (attribute) => attribute.id === this.attributeId
+        );
+    }
+
+    @select((self: AttributeViewCustomSelectNode) => [
+        self.attributes,
+        self.attributeId,
+        self.dependency(self._attribute, [self._attribute?.id]),
+    ])
+    get attribute() {
+        return this._attribute;
+    }
 
     get dependencies() {
         return [];
@@ -169,5 +228,41 @@ describe("link", () => {
         }
         expect(selectedAfterChange).not.toBe(selectedBeforeChange);
         expect(selectedAfterChange.value).toBe(1);
+    });
+});
+
+describe("select", () => {
+    it("emits the owner node when selected dependencies change", () => {
+        const root = trackRoot(Retree.root(new AttributeViewNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        root.attributes.push({ id: "c", value: 0 });
+        root.attributes[1].value = 1;
+
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.attributes[0].value = 1;
+        root.attributeId = "b";
+
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
+        expect(root.attribute?.id).toBe("b");
+    });
+
+    it("accepts explicit dependency slots for custom @select comparisons", () => {
+        const root = trackRoot(
+            Retree.root(new AttributeViewCustomSelectNode())
+        );
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        root.attributes[0].value = 1;
+
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.attributeId = "b";
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(root.attribute?.id).toBe("b");
     });
 });

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
-import { ignore } from "./decorators";
+import { ignore, link } from "./decorators";
 import { Transactions } from "./internals/transactions";
 
 class IgnoredNode extends ReactiveNode {
@@ -34,13 +34,28 @@ class IgnoredExternalPointerNode extends ReactiveNode {
     }
 }
 
-let root: ReactiveNode | null = null;
+class LinkedPointerNode extends ReactiveNode {
+    public child = { value: 0 };
+
+    @link
+    public selected: { value: number } | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+
+const rootsToCleanup: object[] = [];
+
+function trackRoot<T extends object>(node: T): T {
+    rootsToCleanup.push(node);
+    return node;
+}
 
 afterEach(() => {
-    if (root) {
+    for (const root of rootsToCleanup.splice(0)) {
         Retree.clearListeners(root, false);
     }
-    root = null;
     Transactions.skipEmit = false;
     Transactions.skipReproxy = false;
     Transactions.runningTransaction = false;
@@ -49,7 +64,7 @@ afterEach(() => {
 
 describe("ignore", () => {
     it("skips Retree listener emission for ignored nested objects", () => {
-        root = Retree.root(new IgnoredNode());
+        const root = trackRoot(Retree.root(new IgnoredNode()));
         const nodeChanged = vi.fn();
         Retree.on(root, "nodeChanged", nodeChanged);
 
@@ -61,8 +76,7 @@ describe("ignore", () => {
     });
 
     it("does not emit when an ignored field is set to a proxied node", () => {
-        const state = Retree.root(new IgnoredPointerNode());
-        root = state;
+        const state = trackRoot(Retree.root(new IgnoredPointerNode()));
         const nodeChanged = vi.fn();
         Retree.on(state, "nodeChanged", nodeChanged);
 
@@ -72,9 +86,8 @@ describe("ignore", () => {
     });
 
     it("does not reparent a proxied node stored in an ignored field", () => {
-        const source = Retree.root({ child: { value: 0 } });
-        const owner = Retree.root(new IgnoredExternalPointerNode());
-        root = owner;
+        const source = trackRoot(Retree.root({ child: { value: 0 } }));
+        const owner = trackRoot(Retree.root(new IgnoredExternalPointerNode()));
 
         owner.selected = source.child;
 
@@ -87,8 +100,7 @@ describe("ignore", () => {
     });
 
     it("returns the latest reproxy for a proxied node stored in an ignored field", () => {
-        const state = Retree.root(new IgnoredPointerNode());
-        root = state;
+        const state = trackRoot(Retree.root(new IgnoredPointerNode()));
         state.selected = state.child;
 
         const selectedBeforeChange = state.selected;
@@ -104,6 +116,55 @@ describe("ignore", () => {
         if (!selectedAfterChange) {
             throw new Error(
                 "Expected ignored field to return the selected child after mutation."
+            );
+        }
+        expect(selectedAfterChange).not.toBe(selectedBeforeChange);
+        expect(selectedAfterChange.value).toBe(1);
+    });
+});
+
+describe("link", () => {
+    it("emits when a linked field is set to a proxied node", () => {
+        const state = trackRoot(Retree.root(new LinkedPointerNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(state, "nodeChanged", nodeChanged);
+
+        state.selected = state.child;
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reparent a node stored in a linked field", () => {
+        const source = trackRoot(Retree.root({ child: { value: 0 } }));
+        const owner = trackRoot(Retree.root(new LinkedPointerNode()));
+
+        owner.selected = source.child;
+
+        if (!owner.selected) {
+            throw new Error(
+                "Expected linked field to store the selected source child."
+            );
+        }
+        expect(Retree.parent(owner.selected)).toBe(source);
+    });
+
+    it("returns the latest reproxy for a linked field", () => {
+        const state = trackRoot(Retree.root(new LinkedPointerNode()));
+        state.selected = state.child;
+
+        const selectedBeforeChange = state.selected;
+        if (!selectedBeforeChange) {
+            throw new Error(
+                "Expected linked field to return the selected child before mutation."
+            );
+        }
+
+        state.child.value = 1;
+
+        const selectedAfterChange = state.selected;
+        if (!selectedAfterChange) {
+            throw new Error(
+                "Expected linked field to return the selected child after mutation."
             );
         }
         expect(selectedAfterChange).not.toBe(selectedBeforeChange);

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
 import { ignore, link, memo, select } from "./decorators";
+import { getReproxyNode } from "./internals/reproxy";
 import { Transactions } from "./internals/transactions";
 
 class IgnoredNode extends ReactiveNode {
@@ -121,12 +122,40 @@ class DynamicSelectNode extends ReactiveNode {
     }
 }
 
+class BroadSelectNode extends ReactiveNode {
+    public child = { value: 0, label: "initial" };
+
+    @select((self: BroadSelectNode) => self.child)
+    get selectedChild() {
+        return this.child;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
 class AutoSelectTotalNode extends ReactiveNode {
     public price = { value: 2 };
     public amount = { value: 3 };
     public note = { value: "ignored" };
 
     @select()
+    get total() {
+        return this.price.value * this.amount.value;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class BareAutoSelectTotalNode extends ReactiveNode {
+    public price = { value: 2 };
+    public amount = { value: 3 };
+    public note = { value: "ignored" };
+
+    @select
     get total() {
         return this.price.value * this.amount.value;
     }
@@ -359,8 +388,37 @@ describe("select", () => {
         expect(nodeChanged).toHaveBeenCalledTimes(2);
     });
 
+    it("reproxies the owner when an explicit @select dependency changes", () => {
+        const root = trackRoot(Retree.root(new BroadSelectNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+        const beforeChange = getReproxyNode(root);
+
+        root.child.label = "updated";
+
+        expect(getReproxyNode(root)).not.toBe(beforeChange);
+    });
+
     it("captures accessed Retree nodes when @select is called without a selector", () => {
         const root = trackRoot(Retree.root(new AutoSelectTotalNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+        const beforeChange = getReproxyNode(root);
+
+        root.note.value = "still ignored";
+        expect(nodeChanged).not.toHaveBeenCalled();
+
+        root.price.value = 4;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(getReproxyNode(root)).not.toBe(beforeChange);
+        expect(root.total).toBe(12);
+
+        root.amount.value = 5;
+        expect(nodeChanged).toHaveBeenCalledTimes(2);
+        expect(root.total).toBe(20);
+    });
+
+    it("captures accessed Retree nodes when @select is used without parentheses", () => {
+        const root = trackRoot(Retree.root(new BareAutoSelectTotalNode()));
         const nodeChanged = vi.fn();
         Retree.on(root, "nodeChanged", nodeChanged);
 
@@ -390,12 +448,14 @@ describe("select", () => {
         );
         const nodeChanged = vi.fn();
         Retree.on(row, "nodeChanged", nodeChanged);
+        const beforeChange = getReproxyNode(row);
 
         source.task.text = "Write better docs";
         expect(nodeChanged).not.toHaveBeenCalled();
 
         source.task.isCompleted = true;
         expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(getReproxyNode(row)).not.toBe(beforeChange);
         expect(row.isVisible).toBe(false);
     });
 

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -1,10 +1,13 @@
 import {
     COLLECTED_KEYS_SYMBOL,
     LINKED_KEYS_SYMBOL,
+    IReactiveSelectGetter,
     ReactiveNode,
     SELECT_GETTERS_SYMBOL,
 } from "./ReactiveNode";
+import { collectDependencyAccesses } from "./internals/dependency-tracking";
 import { runFnMemo, runMemo } from "./internals/memo";
+import { Retree } from "./Retree";
 
 /**
  * Field decorator that excludes a property of a {@link ReactiveNode} from Retree's
@@ -169,11 +172,17 @@ export function memo<This extends ReactiveNode, Value>(
  * @remarks
  * `@select` is the class-side companion to {@link Retree.select} and
  * `useSelect`. Use it when a getter exposes a narrow value but depends on
- * broader reactive sources. Reactive dependencies in the returned list are
- * subscribed to; primitive and plain-object dependencies are compared by
- * identity. Wrap a slot with `self.dependency(node, comparisons)` when that
- * slot needs custom comparison cells. When a selected slot changes, Retree
- * reproxies the owning node and emits `nodeChanged` for that owner.
+ * broader reactive sources. When called with no selector, `@select()` runs the
+ * getter under a dependency trapper. Whole Retree-managed values read by the
+ * getter are subscribed to broadly. Property reads subscribe to the owner node
+ * but compare the specific property value, so `task.isCompleted` can update
+ * when the task slot is replaced or `isCompleted` changes without reacting to
+ * unrelated `task.text` changes. Primitive values read by the getter are
+ * compared.
+ * Pass an explicit selector when you want to choose or customize the dependency
+ * slots yourself. Wrap a slot with `self.dependency(node, comparisons)` when
+ * that slot needs custom comparison cells. When a selected slot changes,
+ * Retree reproxies the owning node and emits `nodeChanged` for that owner.
  *
  * The dependency list is ordered and may change length at runtime. Retree
  * treats additions, removals, and reordering as invalidation and refreshes the
@@ -201,9 +210,25 @@ export function memo<This extends ReactiveNode, Value>(
  *     }
  * }
  * ```
+ *
+ * @example
+ * ```ts
+ * class TaskRow extends ReactiveNode {
+ *     @link public task!: Task;
+ *     @link public filter!: TaskFilter;
+ *
+ *     @select()
+ *     get isVisible() {
+ *         return (
+ *             this.filter.isComplete === null ||
+ *             this.task.isCompleted === this.filter.isComplete
+ *         );
+ *     }
+ * }
+ * ```
  */
 export function select<This extends ReactiveNode, Dependencies>(
-    getDependencies: (self: This) => Dependencies
+    getDependencies?: (self: This) => Dependencies
 ) {
     return function <Value>(
         target: (this: This) => Value,
@@ -219,11 +244,20 @@ export function select<This extends ReactiveNode, Dependencies>(
             if (!(this instanceof ReactiveNode)) {
                 return;
             }
-            this[SELECT_GETTERS_SYMBOL].set(context.name, {
-                getDependencies: getDependencies as (
-                    self: ReactiveNode
-                ) => unknown,
-            });
+            const selectGetter: IReactiveSelectGetter =
+                getDependencies === undefined
+                    ? {
+                          getDependencies: (self: ReactiveNode) =>
+                              collectDependencyAccesses(() =>
+                                  target.call(self as This)
+                              ),
+                      }
+                    : {
+                          getDependencies: getDependencies as (
+                              self: ReactiveNode
+                          ) => unknown,
+                      };
+            this[SELECT_GETTERS_SYMBOL].set(context.name, selectGetter);
         });
         return function selectedGetter(this: This): Value {
             return target.call(this);

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -20,6 +20,10 @@ import { runFnMemo, runMemo } from "./internals/memo";
  * the tree — caches, scratch buffers, framework handles, references to objects
  * already managed elsewhere, etc.
  *
+ * Do not use `@ignore` when you want a reactive pointer to another node. Use
+ * {@link link} or {@link Retree.link} for that. Writes to ignored fields do
+ * not emit Retree listeners or React re-renders.
+ *
  * @example
  ```ts
  import { Retree, ReactiveNode, ignore } from "@retreejs/core";
@@ -57,6 +61,32 @@ export function ignore(
  * Replacing the linked field emits a normal `nodeChanged` event for the owning
  * {@link ReactiveNode}, but the assigned node keeps its existing parent. Reads
  * return the latest reproxy for the linked node.
+ *
+ * Use this for selected items and cross-references. Do not use it when the
+ * target should become a structural child; use {@link Retree.move} /
+ * {@link ReactiveNode.moveTo}. Do not use it when two places need independent
+ * state; use {@link Retree.clone}.
+ *
+ * @example
+ * ```ts
+ * import { ReactiveNode, Retree, link } from "@retreejs/core";
+ *
+ * class EditorState extends ReactiveNode {
+ *     @link public selectedTask: Task | null = null;
+ *
+ *     get dependencies() {
+ *         return [];
+ *     }
+ * }
+ *
+ * const root = Retree.root({
+ *     tasks: [new Task()],
+ *     editor: new EditorState(),
+ * });
+ *
+ * root.editor.selectedTask = root.tasks[0]; // ✅ emits on editor
+ * Retree.parent(root.editor.selectedTask) === root.tasks; // true
+ * ```
  */
 export function link(
     _value: undefined,
@@ -82,6 +112,13 @@ export function link(
  *
  * The cache key is the getter's property name, so each `@memo`-decorated getter has
  * its own cell automatically.
+ *
+ * `@memo` is a cache, not a subscription. It does not emit Retree events or
+ * trigger React renders by itself. Use `ReactiveNode.dependencies`,
+ * `Retree.select`, or `useSelect` when you also need notification behavior.
+ *
+ * Do not use `@memo` on methods; use {@link fnMemo}. Do not use it for values
+ * with side effects.
  *
  * @example
  ```ts
@@ -149,6 +186,13 @@ type FnMemoComparisonArgs<Args extends unknown[]> = Args extends []
  *
  * Each decorated method stores one cache cell per instance, containing the last
  * argument list and return value.
+ *
+ * `@fnMemo` is a cache, not a subscription. It does not emit Retree events or
+ * trigger React renders by itself. Keep decorated methods deterministic for
+ * the same arguments and dependency values.
+ *
+ * Do not apply `@fnMemo` to static methods or methods that intentionally
+ * perform side effects.
  *
  * @example
  ```ts

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -175,10 +175,11 @@ export function memo<This extends ReactiveNode, Value>(
  * slot needs custom comparison cells. When a selected slot changes, Retree
  * reproxies the owning node and emits `nodeChanged` for that owner.
  *
- * The dependency list is ordered and should keep a stable length while the
- * node is observed. Put every value that can change the getter result in the
- * list. Use {@link memo} for expensive intermediate getters, then select the
- * memoized value here.
+ * The dependency list is ordered and may change length at runtime. Retree
+ * treats additions, removals, and reordering as invalidation and refreshes the
+ * underlying subscriptions. Put every value that can change the getter result
+ * in the list. Use {@link memo} for expensive intermediate getters, then
+ * select the memoized value here.
  *
  * @example
  * ```ts

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -172,13 +172,13 @@ export function memo<This extends ReactiveNode, Value>(
  * @remarks
  * `@select` is the class-side companion to {@link Retree.select} and
  * `useSelect`. Use it when a getter exposes a narrow value but depends on
- * broader reactive sources. When called with no selector, `@select()` runs the
- * getter under a dependency trapper. Whole Retree-managed values read by the
- * getter are subscribed to broadly. Property reads subscribe to the owner node
- * but compare the specific property value, so `task.isCompleted` can update
- * when the task slot is replaced or `isCompleted` changes without reacting to
- * unrelated `task.text` changes. Primitive values read by the getter are
- * compared.
+ * broader reactive sources. When called with no selector, `@select` and
+ * `@select()` are interchangeable. Both run the getter under a dependency
+ * trapper. Whole Retree-managed values read by the getter are subscribed to
+ * broadly. Property reads subscribe to the owner node but compare the specific
+ * property value, so `task.isCompleted` can update when the task slot is
+ * replaced or `isCompleted` changes without reacting to unrelated `task.text`
+ * changes. Primitive values read by the getter are compared.
  * Pass an explicit selector when you want to choose or customize the dependency
  * slots yourself. Wrap a slot with `self.dependency(node, comparisons)` when
  * that slot needs custom comparison cells. When a selected slot changes,
@@ -217,7 +217,7 @@ export function memo<This extends ReactiveNode, Value>(
  *     @link public task!: Task;
  *     @link public filter!: TaskFilter;
  *
- *     @select()
+ *     @select
  *     get isVisible() {
  *         return (
  *             this.filter.isComplete === null ||
@@ -227,41 +227,103 @@ export function memo<This extends ReactiveNode, Value>(
  * }
  * ```
  */
+
+export function select<This extends ReactiveNode, Value>(
+    target: (this: This) => Value,
+    context: ClassGetterDecoratorContext<This, Value>
+): (this: This) => Value;
+// eslint-disable-next-line no-redeclare
 export function select<This extends ReactiveNode, Dependencies>(
     getDependencies?: (self: This) => Dependencies
+): <Value>(
+    target: (this: This) => Value,
+    context: ClassGetterDecoratorContext<This, Value>
+) => (this: This) => Value;
+// eslint-disable-next-line no-redeclare
+export function select(
+    targetOrGetDependencies?: unknown,
+    context?: ClassGetterDecoratorContext<ReactiveNode, unknown>
 ) {
-    return function <Value>(
-        target: (this: This) => Value,
-        context: ClassGetterDecoratorContext<This, Value>
-    ): (this: This) => Value {
-        if (context.kind !== "getter") {
+    if (context !== undefined) {
+        if (!isDecoratorFunction(targetOrGetDependencies)) {
             // @retree-throws
             throw new Error(
-                "@select can only be applied to a getter on a ReactiveNode subclass. This is expected when @select is placed on a field, method, setter, or non-ReactiveNode class. Fix: move @select to a getter on a class that extends ReactiveNode."
+                "@select could not find the decorated getter function. This is unexpected and is likely a Retree bug. Fix: report this error with the decorated getter name and TypeScript version."
             );
         }
-        context.addInitializer(function () {
-            if (!(this instanceof ReactiveNode)) {
-                return;
-            }
-            const selectGetter: IReactiveSelectGetter =
-                getDependencies === undefined
-                    ? {
-                          getDependencies: (self: ReactiveNode) =>
-                              collectDependencyAccesses(() =>
-                                  target.call(self as This)
-                              ),
-                      }
-                    : {
-                          getDependencies: getDependencies as (
-                              self: ReactiveNode
-                          ) => unknown,
-                      };
-            this[SELECT_GETTERS_SYMBOL].set(context.name, selectGetter);
-        });
-        return function selectedGetter(this: This): Value {
-            return target.call(this);
-        };
+        return decorateSelectGetter(targetOrGetDependencies, context);
+    }
+    return function selectedGetterDecorator(
+        target: (this: ReactiveNode) => unknown,
+        decoratorContext: ClassGetterDecoratorContext<ReactiveNode, unknown>
+    ): (this: ReactiveNode) => unknown {
+        if (targetOrGetDependencies === undefined) {
+            return decorateSelectGetter(target, decoratorContext);
+        }
+        if (!isDependencyFunction(targetOrGetDependencies)) {
+            // @retree-throws
+            throw new Error(
+                "@select dependencies must be a function when @select is called as @select(...). This is expected when a non-function value is passed to @select. Fix: pass a selector like @select((self) => [self.items]) or use @select with no arguments for automatic dependency trapping."
+            );
+        }
+        return decorateSelectGetter(
+            target,
+            decoratorContext,
+            targetOrGetDependencies
+        );
+    };
+}
+
+function isDecoratorFunction(
+    value: unknown
+): value is (this: ReactiveNode) => unknown {
+    return typeof value === "function";
+}
+
+function isDependencyFunction(
+    value: unknown
+): value is (self: ReactiveNode) => unknown {
+    return typeof value === "function";
+}
+
+function decorateSelectGetter<This extends ReactiveNode, Value, Dependencies>(
+    target: ((this: This) => Value) | undefined,
+    context: ClassGetterDecoratorContext<This, Value>,
+    getDependencies?: (self: This) => Dependencies
+): (this: This) => Value {
+    if (target === undefined) {
+        // @retree-throws
+        throw new Error(
+            "@select could not find the decorated getter function. This is unexpected and is likely a Retree bug. Fix: report this error with the decorated getter name and TypeScript version."
+        );
+    }
+    if (context.kind !== "getter") {
+        // @retree-throws
+        throw new Error(
+            "@select can only be applied to a getter on a ReactiveNode subclass. This is expected when @select is placed on a field, method, setter, or non-ReactiveNode class. Fix: move @select to a getter on a class that extends ReactiveNode."
+        );
+    }
+    context.addInitializer(function () {
+        if (!(this instanceof ReactiveNode)) {
+            return;
+        }
+        const selectGetter: IReactiveSelectGetter =
+            getDependencies === undefined
+                ? {
+                      getDependencies: (self: ReactiveNode) =>
+                          collectDependencyAccesses(() =>
+                              target.call(self as This)
+                          ),
+                  }
+                : {
+                      getDependencies: getDependencies as (
+                          self: ReactiveNode
+                      ) => unknown,
+                  };
+        this[SELECT_GETTERS_SYMBOL].set(context.name, selectGetter);
+    });
+    return function selectedGetter(this: This): Value {
+        return target.call(this);
     };
 }
 

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -6,7 +6,12 @@ import {
     SELECT_GETTERS_SYMBOL,
 } from "./ReactiveNode";
 import { collectDependencyAccesses } from "./internals/dependency-tracking";
-import { runFnMemo, runMemo } from "./internals/memo";
+import {
+    runFnMemo,
+    runMemo,
+    runTrappedFnMemo,
+    runTrappedMemo,
+} from "./internals/memo";
 import { Retree } from "./Retree";
 
 /**
@@ -106,11 +111,15 @@ export function link(
 /**
  * Decorator that memoizes a getter on a {@link ReactiveNode}.
  * @remarks
- * Pass a function that returns the comparisons array — the function captures `this`
+ * Use `@memo` or `@memo()` for automatic dependency trapping. Pass a function
+ * only when you want finer cache-key control; the function captures `this`
  * lazily, so the values are read fresh each time the getter is accessed.
  *
  * Cache semantics (matches {@link ReactiveNode.memo}):
- * - No argument or returns `undefined`: recompute on every reproxy of the ReactiveNode.
+ * - No argument: `@memo` and `@memo()` are interchangeable. Both run the
+ *   getter under automatic dependency trapping and recompute when one of the
+ *   trapped reads changes.
+ * - Returns `undefined`: recompute on every reproxy of the ReactiveNode.
  * - Returns `[]`: compute once, cache forever for this instance.
  * - Returns `[a, b, ...]`: recompute on shallow-change.
  *
@@ -130,7 +139,7 @@ export function link(
     list: Card[] = [];
     searchText = "";
 
-    @memo((self: ListFilter) => [self.list, self.searchText])
+    @memo
     get filteredList() {
         return this.list.filter((c) => c.text === this.searchText);
     }
@@ -138,30 +147,80 @@ export function link(
     get dependencies() { return [this.dependency(this.list)]; }
  }
  ```
+ *
+ * Pass explicit comparisons when the automatic trapper is broader than you want:
+ *
+ ```ts
+    @memo((self: ListFilter) => [self.list, self.searchText])
+    get filteredListWithExplicitComparisons() {
+        return this.list.filter((c) => c.text === this.searchText);
+    }
+ ```
  */
 export function memo<This extends ReactiveNode, Value>(
+    target: (this: This) => Value,
+    context: ClassGetterDecoratorContext<This, Value>
+): (this: This) => Value;
+// eslint-disable-next-line no-redeclare
+export function memo<This extends ReactiveNode>(
     getComparisons?: (self: This) => unknown[] | undefined
+): <Value>(
+    target: (this: This) => Value,
+    context: ClassGetterDecoratorContext<This, Value>
+) => (this: This) => Value;
+// eslint-disable-next-line no-redeclare
+export function memo(
+    targetOrGetComparisons?: unknown,
+    context?: ClassGetterDecoratorContext<ReactiveNode, unknown>
 ) {
-    return function (
-        target: (this: This) => Value,
-        context: ClassGetterDecoratorContext<This, Value>
-    ): (this: This) => Value {
-        if (context.kind !== "getter") {
+    if (context !== undefined) {
+        if (!isDecoratorFunction(targetOrGetComparisons)) {
             // @retree-throws
             throw new Error(
-                "@memo can only be applied to a getter on a ReactiveNode subclass. This is expected when @memo is placed on a field, method, setter, or non-ReactiveNode class. Fix: move @memo to a getter on a class that extends ReactiveNode, or use this.memo('key', fn, deps) for method-local caching."
+                "@memo could not find the decorated getter function. This is unexpected and is likely a Retree bug. Fix: report this error with the decorated getter name and TypeScript version."
             );
         }
-        const cacheKey = context.name;
-        return function memoizedGetter(this: This): Value {
-            const comparisons = getComparisons?.(this);
-            return runMemo(
-                this,
-                cacheKey,
-                () => target.call(this),
-                comparisons
+        return decorateMemoGetter(targetOrGetComparisons, context);
+    }
+    return function (
+        target: (this: ReactiveNode) => unknown,
+        decoratorContext: ClassGetterDecoratorContext<ReactiveNode, unknown>
+    ): (this: ReactiveNode) => unknown {
+        if (targetOrGetComparisons === undefined) {
+            return decorateMemoGetter(target, decoratorContext);
+        }
+        if (!isComparisonFunction(targetOrGetComparisons)) {
+            // @retree-throws
+            throw new Error(
+                "@memo dependencies must be a function when @memo is called as @memo(...). This is expected when a non-function value is passed to @memo. Fix: pass a selector like @memo((self) => [self.items]) or use @memo with no arguments for automatic dependency trapping."
             );
-        };
+        }
+        return decorateMemoGetter(
+            target,
+            decoratorContext,
+            targetOrGetComparisons
+        );
+    };
+}
+
+function decorateMemoGetter<This extends ReactiveNode, Value>(
+    target: (this: This) => Value,
+    context: ClassGetterDecoratorContext<This, Value>,
+    getComparisons?: (self: This) => unknown[] | undefined
+): (this: This) => Value {
+    if (context.kind !== "getter") {
+        // @retree-throws
+        throw new Error(
+            "@memo can only be applied to a getter on a ReactiveNode subclass. This is expected when @memo is placed on a field, method, setter, or non-ReactiveNode class. Fix: move @memo to a getter on a class that extends ReactiveNode, or use this.memo('key', fn, deps) for method-local caching."
+        );
+    }
+    const cacheKey = context.name;
+    return function memoizedGetter(this: This): Value {
+        if (getComparisons === undefined) {
+            return runTrappedMemo(this, cacheKey, () => target.call(this));
+        }
+        const comparisons = getComparisons(this);
+        return runMemo(this, cacheKey, () => target.call(this), comparisons);
     };
 }
 
@@ -195,7 +254,7 @@ export function memo<This extends ReactiveNode, Value>(
  * class AttributeView extends ReactiveNode {
  *     public attributeId!: string;
  *
- *     @memo((self: AttributeView) => [self.attributes, self.attributeId])
+ *     @memo
  *     private get _attribute() {
  *         return this.attributes.find((check) => check.id === this.attributeId);
  *     }
@@ -286,6 +345,12 @@ function isDependencyFunction(
     return typeof value === "function";
 }
 
+function isComparisonFunction(
+    value: unknown
+): value is (self: ReactiveNode, ...args: unknown[]) => unknown[] | undefined {
+    return typeof value === "function";
+}
+
 function decorateSelectGetter<This extends ReactiveNode, Value, Dependencies>(
     target: ((this: This) => Value) | undefined,
     context: ClassGetterDecoratorContext<This, Value>,
@@ -339,14 +404,17 @@ type FnMemoComparisonArgs<Args extends unknown[]> = Args extends []
 /**
  * Decorator that memoizes a method return value on a {@link ReactiveNode}.
  * @remarks
- * Pass a function that returns the comparisons array — the function receives the
- * current instance and method arguments, so the values are read fresh each time
- * the method is called. The method arguments are always shallow-compared in
- * addition to the dependency comparisons.
+ * Use `@fnMemo` or `@fnMemo()` for automatic dependency trapping. Pass a
+ * function only when you want finer cache-key control; the function receives
+ * the current instance and method arguments, so the values are read fresh each
+ * time the method is called. The method arguments are always shallow-compared.
  *
  * Cache semantics:
- * - No argument or returns `undefined`: recompute when the arguments change, or on
- *   every reproxy of the ReactiveNode.
+ * - No argument: `@fnMemo` and `@fnMemo()` are interchangeable. Both run the
+ *   method under automatic dependency trapping and recompute when the arguments
+ *   or one of the trapped reads changes.
+ * - Returns `undefined`: recompute when the arguments change, or on every
+ *   reproxy of the ReactiveNode.
  * - Returns `[]`: recompute only when the arguments change.
  * - Returns `[a, b, ...]`: recompute when the arguments or comparisons shallow-change.
  *
@@ -366,7 +434,7 @@ type FnMemoComparisonArgs<Args extends unknown[]> = Args extends []
     list: Card[] = [];
     searchText = "";
 
-    @fnMemo((self: ListFilter) => [self.searchText])
+    @fnMemo
     filterBy(limit: number) {
         return this.list
             .filter((c) => c.text === this.searchText)
@@ -376,7 +444,34 @@ type FnMemoComparisonArgs<Args extends unknown[]> = Args extends []
     get dependencies() { return [this.dependency(this.list)]; }
  }
  ```
+ *
+ * Pass explicit comparisons when the automatic trapper is broader than you want:
+ *
+ ```ts
+    @fnMemo((self: ListFilter, limit: number) => [
+        self.list,
+        self.searchText,
+        limit,
+    ])
+    filterByWithExplicitComparisons(limit: number) {
+        return this.list
+            .filter((c) => c.text === this.searchText)
+            .slice(0, limit);
+    }
+ ```
  */
+export function fnMemo<
+    This extends ReactiveNode,
+    MethodArgs extends unknown[],
+    Value
+>(
+    target: FnMemoMethod<This, MethodArgs, Value>,
+    context: ClassMethodDecoratorContext<
+        This,
+        FnMemoMethod<This, MethodArgs, Value>
+    >
+): FnMemoMethod<This, MethodArgs, Value>;
+// eslint-disable-next-line no-redeclare
 export function fnMemo<
     This extends ReactiveNode,
     ComparisonArgs extends unknown[] = []
@@ -385,39 +480,91 @@ export function fnMemo<
         self: This,
         ...args: FnMemoComparisonArgs<ComparisonArgs>
     ) => unknown[] | undefined
+): <MethodArgs extends FnMemoComparisonArgs<ComparisonArgs>, Value>(
+    target: FnMemoMethod<This, MethodArgs, Value>,
+    context: ClassMethodDecoratorContext<
+        This,
+        FnMemoMethod<This, MethodArgs, Value>
+    >
+) => FnMemoMethod<This, MethodArgs, Value>;
+// eslint-disable-next-line no-redeclare
+export function fnMemo(
+    targetOrGetComparisons?: unknown,
+    context?: ClassMethodDecoratorContext<
+        ReactiveNode,
+        FnMemoMethod<ReactiveNode, unknown[], unknown>
+    >
 ) {
-    return function <
-        MethodArgs extends FnMemoComparisonArgs<ComparisonArgs>,
-        Value
-    >(
-        target: FnMemoMethod<This, MethodArgs, Value>,
+    if (context !== undefined) {
+        if (!isDecoratorFunction(targetOrGetComparisons)) {
+            // @retree-throws
+            throw new Error(
+                "@fnMemo could not find the decorated method function. This is unexpected and is likely a Retree bug. Fix: report this error with the decorated method name and TypeScript version."
+            );
+        }
+        return decorateFnMemoMethod(targetOrGetComparisons, context);
+    }
+    return function <MethodArgs extends unknown[], Value>(
+        target: FnMemoMethod<ReactiveNode, MethodArgs, Value>,
         context: ClassMethodDecoratorContext<
-            This,
-            FnMemoMethod<This, MethodArgs, Value>
+            ReactiveNode,
+            FnMemoMethod<ReactiveNode, MethodArgs, Value>
         >
-    ): FnMemoMethod<This, MethodArgs, Value> {
-        if (context.kind !== "method") {
+    ): FnMemoMethod<ReactiveNode, MethodArgs, Value> {
+        if (targetOrGetComparisons === undefined) {
+            return decorateFnMemoMethod(target, context);
+        }
+        if (!isComparisonFunction(targetOrGetComparisons)) {
             // @retree-throws
             throw new Error(
-                "@fnMemo can only be applied to a method on a ReactiveNode subclass. This is expected when @fnMemo is placed on a field, getter, setter, or non-ReactiveNode class. Fix: move @fnMemo to an instance method on a class that extends ReactiveNode."
+                "@fnMemo dependencies must be a function when @fnMemo is called as @fnMemo(...). This is expected when a non-function value is passed to @fnMemo. Fix: pass a selector like @fnMemo((self, arg) => [self.items, arg]) or use @fnMemo with no arguments for automatic dependency trapping."
             );
         }
-        if (context.static) {
-            // @retree-throws
-            throw new Error(
-                "@fnMemo cannot be applied to a static method. This is a decorator usage error because @fnMemo memoizes return values per ReactiveNode instance. Fix: make the method an instance method, or use your own static cache outside Retree."
-            );
-        }
-        const cacheKey = Symbol(`fnMemo:${String(context.name)}`);
-        return function memoizedMethod(this: This, ...args: MethodArgs): Value {
-            const comparisons = getComparisons?.(this, ...args);
-            return runFnMemo(
+        return decorateFnMemoMethod(target, context, targetOrGetComparisons);
+    };
+}
+
+function decorateFnMemoMethod<
+    This extends ReactiveNode,
+    MethodArgs extends unknown[],
+    Value
+>(
+    target: FnMemoMethod<This, MethodArgs, Value>,
+    context: ClassMethodDecoratorContext<
+        This,
+        FnMemoMethod<This, MethodArgs, Value>
+    >,
+    getComparisons?: (self: This, ...args: MethodArgs) => unknown[] | undefined
+): FnMemoMethod<This, MethodArgs, Value> {
+    if (context.kind !== "method") {
+        // @retree-throws
+        throw new Error(
+            "@fnMemo can only be applied to a method on a ReactiveNode subclass. This is expected when @fnMemo is placed on a field, getter, setter, or non-ReactiveNode class. Fix: move @fnMemo to an instance method on a class that extends ReactiveNode."
+        );
+    }
+    if (context.static) {
+        // @retree-throws
+        throw new Error(
+            "@fnMemo cannot be applied to a static method. This is a decorator usage error because @fnMemo memoizes return values per ReactiveNode instance. Fix: make the method an instance method, or use your own static cache outside Retree."
+        );
+    }
+    const cacheKey = Symbol(`fnMemo:${String(context.name)}`);
+    return function memoizedMethod(this: This, ...args: MethodArgs): Value {
+        if (getComparisons === undefined) {
+            return runTrappedFnMemo(
                 this,
                 cacheKey,
                 () => target.call(this, ...args),
-                args,
-                comparisons
+                args
             );
-        };
+        }
+        const comparisons = getComparisons(this, ...args);
+        return runFnMemo(
+            this,
+            cacheKey,
+            () => target.call(this, ...args),
+            args,
+            comparisons
+        );
     };
 }

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -2,6 +2,7 @@ import {
     COLLECTED_KEYS_SYMBOL,
     LINKED_KEYS_SYMBOL,
     ReactiveNode,
+    SELECT_GETTERS_SYMBOL,
 } from "./ReactiveNode";
 import { runFnMemo, runMemo } from "./internals/memo";
 
@@ -157,6 +158,74 @@ export function memo<This extends ReactiveNode, Value>(
                 () => target.call(this),
                 comparisons
             );
+        };
+    };
+}
+
+/**
+ * Decorator that makes a getter's owning {@link ReactiveNode} react to an
+ * ordered dependency list.
+ *
+ * @remarks
+ * `@select` is the class-side companion to {@link Retree.select} and
+ * `useSelect`. Use it when a getter exposes a narrow value but depends on
+ * broader reactive sources. Reactive dependencies in the returned list are
+ * subscribed to; primitive and plain-object dependencies are compared by
+ * identity. Wrap a slot with `self.dependency(node, comparisons)` when that
+ * slot needs custom comparison cells. When a selected slot changes, Retree
+ * reproxies the owning node and emits `nodeChanged` for that owner.
+ *
+ * The dependency list is ordered and should keep a stable length while the
+ * node is observed. Put every value that can change the getter result in the
+ * list. Use {@link memo} for expensive intermediate getters, then select the
+ * memoized value here.
+ *
+ * @example
+ * ```ts
+ * class AttributeView extends ReactiveNode {
+ *     public attributeId!: string;
+ *
+ *     @memo((self: AttributeView) => [self.attributes, self.attributeId])
+ *     private get _attribute() {
+ *         return this.attributes.find((check) => check.id === this.attributeId);
+ *     }
+ *
+ *     @select((self) => [
+ *         self.attributes,
+ *         self.attributeId,
+ *         self.dependency(self._attribute, [self._attribute?.id]),
+ *     ])
+ *     get attribute() {
+ *         return this._attribute;
+ *     }
+ * }
+ * ```
+ */
+export function select<This extends ReactiveNode, Dependencies>(
+    getDependencies: (self: This) => Dependencies
+) {
+    return function <Value>(
+        target: (this: This) => Value,
+        context: ClassGetterDecoratorContext<This, Value>
+    ): (this: This) => Value {
+        if (context.kind !== "getter") {
+            // @retree-throws
+            throw new Error(
+                "@select can only be applied to a getter on a ReactiveNode subclass. This is expected when @select is placed on a field, method, setter, or non-ReactiveNode class. Fix: move @select to a getter on a class that extends ReactiveNode."
+            );
+        }
+        context.addInitializer(function () {
+            if (!(this instanceof ReactiveNode)) {
+                return;
+            }
+            this[SELECT_GETTERS_SYMBOL].set(context.name, {
+                getDependencies: getDependencies as (
+                    self: ReactiveNode
+                ) => unknown,
+            });
+        });
+        return function selectedGetter(this: This): Value {
+            return target.call(this);
         };
     };
 }

--- a/packages/retree-core/src/decorators.ts
+++ b/packages/retree-core/src/decorators.ts
@@ -1,4 +1,8 @@
-import { COLLECTED_KEYS_SYMBOL, ReactiveNode } from "./ReactiveNode";
+import {
+    COLLECTED_KEYS_SYMBOL,
+    LINKED_KEYS_SYMBOL,
+    ReactiveNode,
+} from "./ReactiveNode";
 import { runFnMemo, runMemo } from "./internals/memo";
 
 /**
@@ -46,6 +50,26 @@ export function ignore(
 }
 
 /**
+ * Field decorator that stores a reactive pointer to another Retree-managed node
+ * without making that node a structural child.
+ *
+ * @remarks
+ * Replacing the linked field emits a normal `nodeChanged` event for the owning
+ * {@link ReactiveNode}, but the assigned node keeps its existing parent. Reads
+ * return the latest reproxy for the linked node.
+ */
+export function link(
+    _value: undefined,
+    context: ClassFieldDecoratorContext
+): void | ((this: ReactiveNode, value: any) => any) {
+    context.addInitializer(function () {
+        if (!(this instanceof ReactiveNode)) return;
+        this[LINKED_KEYS_SYMBOL].add(context.name);
+    });
+    return;
+}
+
+/**
  * Decorator that memoizes a getter on a {@link ReactiveNode}.
  * @remarks
  * Pass a function that returns the comparisons array — the function captures `this`
@@ -82,8 +106,9 @@ export function memo<This extends ReactiveNode, Value>(
         context: ClassGetterDecoratorContext<This, Value>
     ): (this: This) => Value {
         if (context.kind !== "getter") {
+            // @retree-throws
             throw new Error(
-                "@memo can only be applied to a getter on a ReactiveNode subclass."
+                "@memo can only be applied to a getter on a ReactiveNode subclass. This is expected when @memo is placed on a field, method, setter, or non-ReactiveNode class. Fix: move @memo to a getter on a class that extends ReactiveNode, or use this.memo('key', fn, deps) for method-local caching."
             );
         }
         const cacheKey = context.name;
@@ -162,13 +187,15 @@ export function fnMemo<
         >
     ): FnMemoMethod<This, MethodArgs, Value> {
         if (context.kind !== "method") {
+            // @retree-throws
             throw new Error(
-                "@fnMemo can only be applied to a method on a ReactiveNode subclass."
+                "@fnMemo can only be applied to a method on a ReactiveNode subclass. This is expected when @fnMemo is placed on a field, getter, setter, or non-ReactiveNode class. Fix: move @fnMemo to an instance method on a class that extends ReactiveNode."
             );
         }
         if (context.static) {
+            // @retree-throws
             throw new Error(
-                "@fnMemo cannot be applied to a static method. It memoizes return values per ReactiveNode instance."
+                "@fnMemo cannot be applied to a static method. This is a decorator usage error because @fnMemo memoizes return values per ReactiveNode instance. Fix: make the method an instance method, or use your own static cache outside Retree."
             );
         }
         const cacheKey = Symbol(`fnMemo:${String(context.name)}`);

--- a/packages/retree-core/src/internals/dependencies.ts
+++ b/packages/retree-core/src/internals/dependencies.ts
@@ -1,0 +1,129 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IReactiveDependency } from "../ReactiveNode";
+import { TreeNode } from "../types";
+import { getCustomProxyHandler, getUnproxiedNode } from "./proxy";
+import { TCustomProxy } from "./proxy-types";
+
+export interface NormalizedDependencySlot {
+    node: TCustomProxy<TreeNode> | undefined;
+    comparisons: unknown[] | undefined;
+    comparisonValues: unknown[];
+    explicit: boolean;
+}
+
+export function isRetreeManagedDependency(
+    value: unknown
+): value is TCustomProxy<TreeNode> {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        getCustomProxyHandler(value) !== undefined
+    );
+}
+
+export function normalizeDependencyEntry(
+    dependency: unknown
+): NormalizedDependencySlot {
+    if (isExplicitReactiveDependency(dependency)) {
+        if (isRetreeManagedDependency(dependency.node)) {
+            const comparisons = dependency.comparisons;
+            return {
+                node: dependency.node,
+                comparisons,
+                comparisonValues: [dependency.node, ...(comparisons ?? [])],
+                explicit: true,
+            };
+        }
+        const comparisons =
+            dependency.comparisons === undefined
+                ? [dependency.node]
+                : dependency.comparisons;
+        return {
+            node: undefined,
+            comparisons,
+            comparisonValues: [...comparisons],
+            explicit: true,
+        };
+    }
+    if (isRetreeManagedDependency(dependency)) {
+        return {
+            node: dependency,
+            comparisons: undefined,
+            comparisonValues: [dependency],
+            explicit: false,
+        };
+    }
+    return {
+        node: undefined,
+        comparisons: [dependency],
+        comparisonValues: [dependency],
+        explicit: false,
+    };
+}
+
+export function getDependencyComparisonValues(
+    dependencies: readonly unknown[]
+) {
+    const comparisonValues: unknown[] = [];
+    for (const dependency of dependencies) {
+        comparisonValues.push(
+            ...normalizeDependencyEntry(dependency).comparisonValues
+        );
+    }
+    return comparisonValues;
+}
+
+export function areDependencyComparisonValuesEqual(
+    previous: readonly unknown[],
+    next: readonly unknown[]
+) {
+    if (previous.length !== next.length) {
+        return false;
+    }
+    for (let index = 0; index < previous.length; index++) {
+        if (!areDependencyValuesEqual(previous[index], next[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function areDependencyValuesEqual(previous: unknown, next: unknown) {
+    if (
+        isRetreeManagedDependency(previous) &&
+        isRetreeManagedDependency(next)
+    ) {
+        return getUnproxiedNode(previous) === getUnproxiedNode(next);
+    }
+    return Object.is(previous, next);
+}
+
+function isExplicitReactiveDependency(
+    dependency: unknown
+): dependency is IReactiveDependency {
+    if (
+        dependency === null ||
+        typeof dependency !== "object" ||
+        isRetreeManagedDependency(dependency)
+    ) {
+        return false;
+    }
+    if (!("node" in dependency)) {
+        return false;
+    }
+    if (!hasComparisonsProperty(dependency)) {
+        return true;
+    }
+    const comparisons = dependency.comparisons;
+    return comparisons === undefined || Array.isArray(comparisons);
+}
+
+function hasComparisonsProperty(
+    dependency: object
+): dependency is { comparisons: unknown } {
+    return "comparisons" in dependency;
+}

--- a/packages/retree-core/src/internals/dependency-tracking.ts
+++ b/packages/retree-core/src/internals/dependency-tracking.ts
@@ -8,12 +8,28 @@ import {
 
 interface DependencyAccessFrame {
     entries: DependencyAccessEntry[];
+    mode: "dependencies" | "comparisons";
+    writes: DependencyPropertyWrite[];
+}
+
+interface DependencyPropertyWrite {
+    ownerUnproxiedNode: TreeNode;
+    propertyKey: string | symbol;
+}
+
+export interface DependencyComparisonAccessor {
+    readonly kind: "retree-dependency-comparison-accessor";
+    getValues(): unknown[];
 }
 
 type DependencyAccessEntry =
     | {
           kind: "dependency";
           value: unknown;
+          comparisonAccessor?: DependencyComparisonAccessor;
+          ownerUnproxiedNode?: TreeNode;
+          propertyKey?: string | symbol;
+          valueUnproxiedNode?: TreeNode;
       }
     | {
           kind: "managed-value";
@@ -22,9 +38,35 @@ type DependencyAccessEntry =
       };
 
 const dependencyAccessStack: DependencyAccessFrame[] = [];
+let pauseDependencyTrackingDepth = 0;
+
+export function runWithoutDependencyTracking<T>(callback: () => T): T {
+    pauseDependencyTrackingDepth++;
+    try {
+        return callback();
+    } finally {
+        pauseDependencyTrackingDepth--;
+    }
+}
+
+export function runWithIsolatedDependencyTracking<T>(callback: () => T): T {
+    const outerFrames = dependencyAccessStack.splice(
+        0,
+        dependencyAccessStack.length
+    );
+    try {
+        return callback();
+    } finally {
+        dependencyAccessStack.splice(0, 0, ...outerFrames);
+    }
+}
 
 export function collectDependencyAccesses<T>(callback: () => T): unknown[] {
-    const frame: DependencyAccessFrame = { entries: [] };
+    const frame: DependencyAccessFrame = {
+        entries: [],
+        mode: "dependencies",
+        writes: [],
+    };
     dependencyAccessStack.push(frame);
     try {
         callback();
@@ -34,7 +76,43 @@ export function collectDependencyAccesses<T>(callback: () => T): unknown[] {
     return frame.entries.map((entry) => entry.value);
 }
 
+export function collectDependencyComparisonAccesses<T>(callback: () => T): {
+    value: T;
+    comparisons: unknown[];
+} {
+    let value: T | undefined;
+    const frame: DependencyAccessFrame = {
+        entries: [],
+        mode: "comparisons",
+        writes: [],
+    };
+    dependencyAccessStack.push(frame);
+    try {
+        value = callback();
+    } finally {
+        dependencyAccessStack.pop();
+    }
+    return {
+        value: value as T,
+        comparisons: frame.entries.flatMap((entry) => {
+            if (isWrittenPropertyEntry(frame, entry)) {
+                return [];
+            }
+            if (entry.kind === "managed-value") {
+                return [createComparisonAccessor(() => [entry.value])];
+            }
+            if (entry.comparisonAccessor !== undefined) {
+                return [entry.comparisonAccessor];
+            }
+            return [entry.value];
+        }),
+    };
+}
+
 export function trackDependencyAccess<T>(value: T): T {
+    if (pauseDependencyTrackingDepth > 0) {
+        return value;
+    }
     const currentFrame =
         dependencyAccessStack[dependencyAccessStack.length - 1];
     if (currentFrame === undefined) {
@@ -56,6 +134,9 @@ export function trackDependencyAccess<T>(value: T): T {
 }
 
 export function trackDependencyOwnerAccess(value: unknown): void {
+    if (pauseDependencyTrackingDepth > 0) {
+        return;
+    }
     const currentFrame =
         dependencyAccessStack[dependencyAccessStack.length - 1];
     if (currentFrame === undefined) {
@@ -72,6 +153,12 @@ export function trackDependencyPropertyAccess<T>(
     propertyKey: string | symbol,
     value: T
 ): T {
+    if (pauseDependencyTrackingDepth > 0) {
+        return value;
+    }
+    if (isRetreeInternalProperty(propertyKey)) {
+        return value;
+    }
     const currentFrame =
         dependencyAccessStack[dependencyAccessStack.length - 1];
     if (currentFrame === undefined) {
@@ -85,17 +172,128 @@ export function trackDependencyPropertyAccess<T>(
     }
     const ownerUnproxiedNode = owner["[[Handler]]"][unproxiedBaseNodeKey];
     removePendingManagedValueAccess(currentFrame, ownerUnproxiedNode);
+    if (currentFrame.mode === "comparisons") {
+        removePendingPropertyValueAccess(currentFrame, ownerUnproxiedNode);
+    }
+    const valueUnproxiedNode = isCustomProxy(value)
+        ? value["[[Handler]]"][unproxiedBaseNodeKey]
+        : undefined;
     currentFrame.entries.push({
         kind: "dependency",
         value: {
             node: owner,
             comparisons: [value],
         } satisfies IReactiveDependency,
+        comparisonAccessor: createComparisonAccessor(() => [
+            Reflect.get(owner, propertyKey),
+        ]),
+        ownerUnproxiedNode,
+        propertyKey,
+        valueUnproxiedNode,
     });
     if (isArrayElementRead(ownerUnproxiedNode, propertyKey)) {
         return value;
     }
+    if (currentFrame.mode === "comparisons") {
+        return value;
+    }
     return trackDependencyAccess(value);
+}
+
+export function trackDependencyPropertyWrite(
+    owner: unknown,
+    propertyKey: string | symbol
+): void {
+    if (pauseDependencyTrackingDepth > 0) {
+        return;
+    }
+    if (isRetreeInternalProperty(propertyKey)) {
+        return;
+    }
+    const currentFrame =
+        dependencyAccessStack[dependencyAccessStack.length - 1];
+    if (currentFrame === undefined) {
+        return;
+    }
+    if (!isCustomProxy(owner)) {
+        return;
+    }
+    const ownerUnproxiedNode = owner["[[Handler]]"][unproxiedBaseNodeKey];
+    currentFrame.writes.push({ ownerUnproxiedNode, propertyKey });
+    removePendingPropertyAccess(currentFrame, ownerUnproxiedNode, propertyKey);
+}
+
+function isRetreeInternalProperty(propertyKey: string | symbol): boolean {
+    if (typeof propertyKey !== "string") {
+        return false;
+    }
+    return propertyKey.startsWith("RETREE_");
+}
+
+function createComparisonAccessor(
+    getValues: () => unknown[]
+): DependencyComparisonAccessor {
+    return {
+        kind: "retree-dependency-comparison-accessor",
+        getValues,
+    };
+}
+
+function removePendingPropertyAccess(
+    frame: DependencyAccessFrame,
+    ownerUnproxiedNode: TreeNode,
+    propertyKey: string | symbol
+) {
+    for (let index = frame.entries.length - 1; index >= 0; index--) {
+        const entry = frame.entries[index];
+        if (entry.kind !== "dependency") {
+            continue;
+        }
+        if (entry.ownerUnproxiedNode !== ownerUnproxiedNode) {
+            continue;
+        }
+        if (entry.propertyKey !== propertyKey) {
+            continue;
+        }
+        frame.entries.splice(index, 1);
+    }
+}
+
+function isWrittenPropertyEntry(
+    frame: DependencyAccessFrame,
+    entry: DependencyAccessEntry
+): boolean {
+    if (entry.kind !== "dependency") {
+        return false;
+    }
+    if (entry.ownerUnproxiedNode === undefined) {
+        return false;
+    }
+    if (entry.propertyKey === undefined) {
+        return false;
+    }
+    return frame.writes.some((write) => {
+        if (write.ownerUnproxiedNode !== entry.ownerUnproxiedNode) {
+            return false;
+        }
+        return write.propertyKey === entry.propertyKey;
+    });
+}
+
+function removePendingPropertyValueAccess(
+    frame: DependencyAccessFrame,
+    valueUnproxiedNode: TreeNode
+) {
+    for (let index = frame.entries.length - 1; index >= 0; index--) {
+        const entry = frame.entries[index];
+        if (entry.kind !== "dependency") {
+            continue;
+        }
+        if (entry.valueUnproxiedNode !== valueUnproxiedNode) {
+            continue;
+        }
+        frame.entries.splice(index, 1);
+    }
 }
 
 function isArrayElementRead(

--- a/packages/retree-core/src/internals/dependency-tracking.ts
+++ b/packages/retree-core/src/internals/dependency-tracking.ts
@@ -1,0 +1,132 @@
+import { IReactiveDependency } from "../ReactiveNode";
+import { TreeNode } from "../types";
+import {
+    isCustomProxy,
+    TCustomProxy,
+    unproxiedBaseNodeKey,
+} from "./proxy-types";
+
+interface DependencyAccessFrame {
+    entries: DependencyAccessEntry[];
+}
+
+type DependencyAccessEntry =
+    | {
+          kind: "dependency";
+          value: unknown;
+      }
+    | {
+          kind: "managed-value";
+          value: TCustomProxy<TreeNode>;
+          unproxiedNode: TreeNode;
+      };
+
+const dependencyAccessStack: DependencyAccessFrame[] = [];
+
+export function collectDependencyAccesses<T>(callback: () => T): unknown[] {
+    const frame: DependencyAccessFrame = { entries: [] };
+    dependencyAccessStack.push(frame);
+    try {
+        callback();
+    } finally {
+        dependencyAccessStack.pop();
+    }
+    return frame.entries.map((entry) => entry.value);
+}
+
+export function trackDependencyAccess<T>(value: T): T {
+    const currentFrame =
+        dependencyAccessStack[dependencyAccessStack.length - 1];
+    if (currentFrame === undefined) {
+        return value;
+    }
+    if (typeof value === "function") {
+        return value;
+    }
+    if (isCustomProxy(value)) {
+        currentFrame.entries.push({
+            kind: "managed-value",
+            value,
+            unproxiedNode: value["[[Handler]]"][unproxiedBaseNodeKey],
+        });
+        return value;
+    }
+    currentFrame.entries.push({ kind: "dependency", value });
+    return value;
+}
+
+export function trackDependencyOwnerAccess(value: unknown): void {
+    const currentFrame =
+        dependencyAccessStack[dependencyAccessStack.length - 1];
+    if (currentFrame === undefined) {
+        return;
+    }
+    if (value === null || typeof value !== "object") {
+        return;
+    }
+    currentFrame.entries.push({ kind: "dependency", value });
+}
+
+export function trackDependencyPropertyAccess<T>(
+    owner: unknown,
+    propertyKey: string | symbol,
+    value: T
+): T {
+    const currentFrame =
+        dependencyAccessStack[dependencyAccessStack.length - 1];
+    if (currentFrame === undefined) {
+        return value;
+    }
+    if (typeof value === "function") {
+        return value;
+    }
+    if (!isCustomProxy(owner)) {
+        return trackDependencyAccess(value);
+    }
+    const ownerUnproxiedNode = owner["[[Handler]]"][unproxiedBaseNodeKey];
+    removePendingManagedValueAccess(currentFrame, ownerUnproxiedNode);
+    currentFrame.entries.push({
+        kind: "dependency",
+        value: {
+            node: owner,
+            comparisons: [value],
+        } satisfies IReactiveDependency,
+    });
+    if (isArrayElementRead(ownerUnproxiedNode, propertyKey)) {
+        return value;
+    }
+    return trackDependencyAccess(value);
+}
+
+function isArrayElementRead(
+    ownerUnproxiedNode: TreeNode,
+    propertyKey: string | symbol
+) {
+    if (!Array.isArray(ownerUnproxiedNode)) {
+        return false;
+    }
+    if (typeof propertyKey !== "string") {
+        return false;
+    }
+    const index = Number(propertyKey);
+    if (!Number.isInteger(index)) {
+        return false;
+    }
+    return index >= 0;
+}
+
+function removePendingManagedValueAccess(
+    frame: DependencyAccessFrame,
+    unproxiedNode: TreeNode
+) {
+    for (let index = frame.entries.length - 1; index >= 0; index--) {
+        const entry = frame.entries[index];
+        if (entry.kind !== "managed-value") {
+            continue;
+        }
+        if (entry.unproxiedNode !== unproxiedNode) {
+            continue;
+        }
+        frame.entries.splice(index, 1);
+    }
+}

--- a/packages/retree-core/src/internals/index.ts
+++ b/packages/retree-core/src/internals/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./TypedEventEmitter";
 export * from "./dependencies";
+export * from "./dependency-tracking";
 export * from "./proxy";
 export * from "./reproxy";
 export * from "./select";

--- a/packages/retree-core/src/internals/index.ts
+++ b/packages/retree-core/src/internals/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./TypedEventEmitter";
+export * from "./dependencies";
 export * from "./proxy";
 export * from "./reproxy";
 export * from "./select";

--- a/packages/retree-core/src/internals/index.ts
+++ b/packages/retree-core/src/internals/index.ts
@@ -6,3 +6,4 @@
 export * from "./TypedEventEmitter";
 export * from "./proxy";
 export * from "./reproxy";
+export * from "./select";

--- a/packages/retree-core/src/internals/memo.ts
+++ b/packages/retree-core/src/internals/memo.ts
@@ -261,17 +261,19 @@ export function consumeCurrentMemoGetter(
     const stack = memoGetterStackMap.get(owner);
     const top = stack && stack.length > 0 ? stack[stack.length - 1] : undefined;
     if (!top) {
+        // @retree-throws
         throw new Error(
             "memo() was called without a key outside of a ReactiveNode getter. " +
-                "Either call memo from a getter, or pass an explicit key as the first " +
-                "argument: `this.memo('myKey', fn, deps)`."
+                "This is expected when keyless memo is used from a method, callback, constructor, or async continuation after the getter has returned. " +
+                "Fix: call keyless memo directly inside a ReactiveNode getter, or pass an explicit key as the first argument: `this.memo('myKey', fn, deps)`."
         );
     }
     if (top.memoCalled) {
+        // @retree-throws
         throw new Error(
             `memo() was called more than once in getter '${String(
                 top.getterName
-            )}' without an explicit key. Pass a unique string key as the first ` +
+            )}' without an explicit key. This is expected when one getter needs multiple memo cells. Pass a unique string key as the first ` +
                 "argument: `this.memo('myKey', fn, deps)`."
         );
     }

--- a/packages/retree-core/src/internals/memo.ts
+++ b/packages/retree-core/src/internals/memo.ts
@@ -5,6 +5,11 @@
 
 import { ReactiveNode } from "../ReactiveNode";
 import { TreeNode } from "../types";
+import {
+    DependencyComparisonAccessor,
+    collectDependencyComparisonAccesses,
+} from "./dependency-tracking";
+import { getDependencyComparisonValues } from "./dependencies";
 import { getUnproxiedNode } from "./proxy";
 import { getReproxyNodeForUnproxiedNode } from "./reproxy";
 
@@ -20,6 +25,12 @@ interface IMemoCacheEntry {
      * `undefined` means "no comparisons; invalidate when the ReactiveNode reproxies."
      */
     comparisons: unknown[] | undefined;
+    /**
+     * Original comparison cells used for automatic dependency trapping. These
+     * cells can refresh their current comparison values without recomputing the
+     * memoized getter or method body.
+     */
+    comparisonAccessors: unknown[] | undefined;
     /**
      * Reproxy reference at the time of caching. Used to detect "the ReactiveNode
      * has reproxied since this entry was made" for the `undefined` comparisons case.
@@ -113,10 +124,46 @@ export function runMemo<T>(
     cache.set(key, {
         value,
         comparisons: normalized,
+        comparisonAccessors: undefined,
         reproxy: getReproxyNodeForUnproxiedNode(unproxied) ?? currentReproxy,
         args: undefined,
     });
     return value;
+}
+
+export function runTrappedMemo<T>(
+    instance: ReactiveNode,
+    key: string | symbol,
+    fn: () => T
+): T {
+    const unproxied = getUnproxiedNode(instance) as ReactiveNode | undefined;
+    if (!unproxied) {
+        return fn();
+    }
+    const cache = getOrCreateMemoCache(unproxied);
+    const prev = cache.get(key);
+    if (
+        prev !== undefined &&
+        prev.args === undefined &&
+        prev.comparisonAccessors !== undefined
+    ) {
+        const latestComparisons = normalizeComparisons(
+            prev.comparisonAccessors
+        );
+        if (shallowEqualArrays(prev.comparisons ?? [], latestComparisons)) {
+            return prev.value as T;
+        }
+    }
+
+    const result = collectDependencyComparisonAccesses(fn);
+    cache.set(key, {
+        value: result.value,
+        comparisons: normalizeComparisons(result.comparisons),
+        comparisonAccessors: result.comparisons,
+        reproxy: getReproxyNodeForUnproxiedNode(unproxied),
+        args: undefined,
+    });
+    return result.value;
 }
 
 /**
@@ -167,10 +214,49 @@ export function runFnMemo<T>(
     cache.set(key, {
         value,
         comparisons: normalizedComparisons,
+        comparisonAccessors: undefined,
         reproxy: getReproxyNodeForUnproxiedNode(unproxied) ?? currentReproxy,
         args: normalizedArgs,
     });
     return value;
+}
+
+export function runTrappedFnMemo<T>(
+    instance: ReactiveNode,
+    key: string | symbol,
+    fn: () => T,
+    args: unknown[]
+): T {
+    const unproxied = getUnproxiedNode(instance) as ReactiveNode | undefined;
+    if (!unproxied) {
+        return fn();
+    }
+    const cache = getOrCreateMemoCache(unproxied);
+    const normalizedArgs = normalizeComparisons(args);
+    const prev = cache.get(key);
+    if (
+        prev !== undefined &&
+        prev.args !== undefined &&
+        prev.comparisonAccessors !== undefined &&
+        shallowEqualArrays(prev.args, normalizedArgs)
+    ) {
+        const latestComparisons = normalizeComparisons(
+            prev.comparisonAccessors
+        );
+        if (shallowEqualArrays(prev.comparisons ?? [], latestComparisons)) {
+            return prev.value as T;
+        }
+    }
+
+    const result = collectDependencyComparisonAccesses(fn);
+    cache.set(key, {
+        value: result.value,
+        comparisons: normalizeComparisons(result.comparisons),
+        comparisonAccessors: result.comparisons,
+        reproxy: getReproxyNodeForUnproxiedNode(unproxied),
+        args: normalizedArgs,
+    });
+    return result.value;
 }
 
 /**
@@ -179,22 +265,46 @@ export function runFnMemo<T>(
  * never change identity, but the reproxy bumps every time the node mutates.
  */
 function normalizeComparisons(comparisons: unknown[]): unknown[] {
-    const out = new Array(comparisons.length);
+    const out: unknown[] = [];
     for (let i = 0; i < comparisons.length; i++) {
-        const cell = comparisons[i];
-        if (cell !== null && typeof cell === "object") {
-            const unproxy = getUnproxiedNode(cell as TreeNode);
-            if (unproxy) {
-                const reproxy = getReproxyNodeForUnproxiedNode(unproxy);
-                if (reproxy) {
-                    out[i] = reproxy;
-                    continue;
-                }
-            }
+        const comparison = comparisons[i];
+        const cells = getComparisonCells(comparison);
+        for (const cell of cells) {
+            out.push(normalizeComparisonCell(cell));
         }
-        out[i] = cell;
     }
     return out;
+}
+
+function getComparisonCells(comparison: unknown): unknown[] {
+    if (!isDependencyComparisonAccessor(comparison)) {
+        return [comparison];
+    }
+    return getDependencyComparisonValues(comparison.getValues());
+}
+
+function normalizeComparisonCell(cell: unknown): unknown {
+    if (cell !== null && typeof cell === "object") {
+        const unproxy = getUnproxiedNode(cell as TreeNode);
+        if (unproxy) {
+            const reproxy = getReproxyNodeForUnproxiedNode(unproxy);
+            if (reproxy) {
+                return reproxy;
+            }
+        }
+    }
+    return cell;
+}
+
+function isDependencyComparisonAccessor(
+    value: unknown
+): value is DependencyComparisonAccessor {
+    if (value === null || typeof value !== "object") {
+        return false;
+    }
+    return (
+        Reflect.get(value, "kind") === "retree-dependency-comparison-accessor"
+    );
 }
 
 /**

--- a/packages/retree-core/src/internals/proxy.spec.ts
+++ b/packages/retree-core/src/internals/proxy.spec.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { ReactiveNode } from "../ReactiveNode";
 import { Retree } from "../Retree";
 import { getBaseProxy, getCustomProxyHandler, getUnproxiedNode } from "./proxy";
+
+class MethodNode extends ReactiveNode {
+    public value = 0;
+
+    public increment() {
+        this.value += 1;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
 
 describe("proxy internals", () => {
     it("exposes proxy metadata for managed nodes", () => {
@@ -11,5 +24,16 @@ describe("proxy internals", () => {
         expect(getBaseProxy(root.child)).toBe(root.child);
         expect(getUnproxiedNode(root.child)).not.toBe(root.child);
         expect(handler?.["[[Target]]" as never]).toBeUndefined();
+    });
+
+    it("returns stable bound methods from the same base proxy", () => {
+        const root = Retree.root(new MethodNode());
+        const increment = root.increment;
+
+        expect(root.increment).toBe(increment);
+
+        increment();
+
+        expect(root.value).toBe(1);
     });
 });

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { COLLECTED_KEYS_SYMBOL, ReactiveNode } from "../ReactiveNode";
+import {
+    COLLECTED_KEYS_SYMBOL,
+    LINKED_KEYS_SYMBOL,
+    ReactiveNode,
+} from "../ReactiveNode";
 import { TreeNode } from "../types";
 import { TreeChangeEmitter } from "./NodeChangeEmitter";
 import {
@@ -94,6 +98,24 @@ function getLatestIgnoredValue(value: unknown) {
     return value;
 }
 
+function assertValidLinkedValue(prop: string | symbol, value: unknown) {
+    if (value === null || value === undefined) {
+        return;
+    }
+    if (typeof value !== "object") {
+        return;
+    }
+    if (isCustomProxy(value)) {
+        return;
+    }
+    // @retree-throws
+    throw new Error(
+        `@link field ${String(
+            prop
+        )} can only store a Retree-managed node, null, undefined, or a non-object leaf value. This is expected when assigning a plain object to @link. Fix: pass the object through Retree.root(...) or read it from an existing Retree tree first; use @ignore for non-reactive objects that should not be managed by Retree.`
+    );
+}
+
 /**
  * @internal
  * Builds a proxied object that emits changes when any value changes.
@@ -130,6 +152,11 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     propString === COLLECTED_KEYS_SYMBOL ||
                     target[COLLECTED_KEYS_SYMBOL].has(propString)
                 ) {
+                    return getLatestIgnoredValue(
+                        Reflect.get(target, prop, target)
+                    );
+                }
+                if (target[LINKED_KEYS_SYMBOL].has(prop)) {
                     return getLatestIgnoredValue(
                         Reflect.get(target, prop, target)
                     );
@@ -249,6 +276,36 @@ export function buildProxy<T extends TreeNode = TreeNode>(
         set(target, prop, newValue, receiver) {
             if (target instanceof ReactiveNode) {
                 const propString = String(prop);
+                if (target[LINKED_KEYS_SYMBOL].has(prop)) {
+                    assertValidLinkedValue(prop, newValue);
+                    const prev = Reflect.get(target, prop, target);
+                    if (prev === newValue) {
+                        return true;
+                    }
+                    const baseProxy = getBaseProxy<T>(receiver);
+                    let returnValue: boolean;
+                    isApplyingSet = true;
+                    try {
+                        returnValue = Reflect.set(
+                            target,
+                            prop,
+                            newValue,
+                            target
+                        );
+                    } finally {
+                        isApplyingSet = false;
+                    }
+                    if (!Transactions.skipReproxy) {
+                        const reproxy = updateReproxyNode(baseProxy);
+                        emitter.emit(
+                            "nodeChanged",
+                            proxyHandler[unproxiedBaseNodeKey],
+                            baseProxy,
+                            reproxy
+                        );
+                    }
+                    return returnValue;
+                }
                 // Check for ignore keys
                 if (
                     propString === COLLECTED_KEYS_SYMBOL ||
@@ -513,7 +570,8 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 value === null ||
                 (object instanceof ReactiveNode &&
                     (propString === COLLECTED_KEYS_SYMBOL ||
-                        object[COLLECTED_KEYS_SYMBOL].has(propString)))
+                        object[COLLECTED_KEYS_SYMBOL].has(propString) ||
+                        object[LINKED_KEYS_SYMBOL].has(prop)))
             ) {
                 proxyHandler[proxiedChildrenKey][prop] = value;
             } else if (typeof value === "object") {
@@ -896,7 +954,10 @@ function wrapMapMutation(
             emitCollectionChange(target, baseProxy, emitter, removedNodes);
         };
     }
-    throw new Error(`Unsupported Map mutation: ${prop}`);
+    // @retree-throws
+    throw new Error(
+        `Retree internal invariant failed: unsupported Map mutation '${prop}'. This is unexpected and likely a Retree bug because this wrapper should only receive set, delete, or clear. Please file a Retree issue with the Map operation that triggered this.`
+    );
 }
 
 function wrapSetRead(
@@ -1050,7 +1111,10 @@ function wrapSetMutation(
             emitCollectionChange(target, baseProxy, emitter, removedNodes);
         };
     }
-    throw new Error(`Unsupported Set mutation: ${prop}`);
+    // @retree-throws
+    throw new Error(
+        `Retree internal invariant failed: unsupported Set mutation '${prop}'. This is unexpected and likely a Retree bug because this wrapper should only receive add, delete, or clear. Please file a Retree issue with the Set operation that triggered this.`
+    );
 }
 
 function wrapSetHas(target: Set<any>) {
@@ -1168,14 +1232,41 @@ function reparentProxy<T extends TreeNode = TreeNode>(
             // Such a case is usually temporary, but it doesn't have to be.
             currentParent.proxyNode !== newParent.proxyNode
         ) {
+            // @retree-throws
             throw new Error(
-                "A node can only have a single parent. To move the node to a new parent, first remove it from the previous parent and then set it to the new object."
+                [
+                    "Retree cannot assign this node because it already has a structural parent.",
+                    "This is expected when the same object is inserted into two different places in the tree.",
+                    `Current parent: ${describeParentEdge(currentParent)}.`,
+                    `Requested parent: ${describeParentEdge(newParent)}.`,
+                    "Fix: choose one explicit ownership operation: move it with Retree.move(node, destination, key), store a reactive pointer with Retree.link(node) or @link, ignore it via @ignore, or duplicate it with Retree.clone(node).",
+                ].join(" ")
             );
         }
         currentParent.propName = newParent.propName;
         currentParent.proxyNode = newParent.proxyNode;
+    } else {
+        proxy["[[Handler]]"][proxiedParentKey] = newParent;
     }
     return proxy;
+}
+
+function describeParentEdge(parent: IProxyParent<any>) {
+    const parentNode =
+        parent.proxyNode === null ? null : getUnproxiedNode(parent.proxyNode);
+    const parentKind =
+        parent.proxyNode === null
+            ? "none"
+            : Array.isArray(parent.proxyNode)
+            ? "Array"
+            : parent.proxyNode instanceof Map
+            ? "Map"
+            : parent.proxyNode instanceof Set
+            ? "Set"
+            : parentNode?.constructor?.name || "Object";
+    const propName =
+        parent.propName === null ? "unknown" : String(parent.propName);
+    return `${parentKind} at key ${propName}`;
 }
 
 /**
@@ -1260,5 +1351,8 @@ export function getBaseProxy<T extends TreeNode = TreeNode>(
         }
         return node;
     }
-    throw new Error("Unproxied object");
+    // @retree-throws
+    throw new Error(
+        "Retree internal invariant failed: expected a Retree-managed proxy but received an unproxied object. This is unexpected if it came from a public Retree API. Fix: pass objects returned by Retree.root(...) or children read from a Retree tree; if that is already true, file a Retree issue with the operation that triggered this."
+    );
 }

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -30,6 +30,7 @@ import {
 import {
     trackDependencyAccess,
     trackDependencyPropertyAccess,
+    trackDependencyPropertyWrite,
 } from "./dependency-tracking";
 import { Transactions } from "./transactions";
 
@@ -117,9 +118,9 @@ function isDateMutatingMethod(prop: string): prop is DateMutatingMethodName {
 
 function getLatestIgnoredValue(value: unknown) {
     if (isCustomProxy(value)) {
-        return trackDependencyAccess(getReproxyNode(value));
+        return getReproxyNode(value);
     }
-    return trackDependencyAccess(value);
+    return value;
 }
 
 function assertValidLinkedValue(prop: string | symbol, value: unknown) {
@@ -176,17 +177,21 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             if (target instanceof ReactiveNode) {
                 const propString = String(prop);
                 // Check for ignore keys
-                if (
-                    propString === COLLECTED_KEYS_SYMBOL ||
-                    target[COLLECTED_KEYS_SYMBOL].has(propString)
-                ) {
-                    return getLatestIgnoredValue(
-                        Reflect.get(target, prop, target)
+                if (propString.startsWith("RETREE_")) {
+                    return Reflect.get(target, prop, target);
+                }
+                if (target[COLLECTED_KEYS_SYMBOL].has(propString)) {
+                    return trackDependencyPropertyAccess(
+                        getBaseProxy(receiver),
+                        prop,
+                        getLatestIgnoredValue(Reflect.get(target, prop, target))
                     );
                 }
                 if (target[LINKED_KEYS_SYMBOL].has(prop)) {
-                    return getLatestIgnoredValue(
-                        Reflect.get(target, prop, target)
+                    return trackDependencyPropertyAccess(
+                        getBaseProxy(receiver),
+                        prop,
+                        getLatestIgnoredValue(Reflect.get(target, prop, target))
                     );
                 }
             }
@@ -336,6 +341,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             return trackDependencyPropertyAccess(baseProxy, prop, value);
         },
         set(target, prop, newValue, receiver) {
+            trackDependencyPropertyWrite(getBaseProxy<T>(receiver), prop);
             if (target instanceof ReactiveNode) {
                 const propString = String(prop);
                 if (target[LINKED_KEYS_SYMBOL].has(prop)) {
@@ -443,6 +449,15 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             return true;
         },
         defineProperty(target, prop, descriptor) {
+            const currentProxyForWrite = isCustomProxy(target)
+                ? target
+                : getReproxyNodeForUnproxiedNode(target);
+            const baseProxyForWrite = currentProxyForWrite
+                ? getBaseProxy(currentProxyForWrite)
+                : undefined;
+            if (baseProxyForWrite !== undefined) {
+                trackDependencyPropertyWrite(baseProxyForWrite, prop);
+            }
             if (target instanceof ReactiveNode) {
                 const propString = String(prop);
                 // Check for ignore keys
@@ -456,9 +471,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             if (isApplyingSet) {
                 return Reflect.defineProperty(target, prop, descriptor);
             }
-            const currentProxy = isCustomProxy(target)
-                ? target
-                : getReproxyNodeForUnproxiedNode(target);
+            const currentProxy = currentProxyForWrite;
             const baseProxy = currentProxy
                 ? getBaseProxy(currentProxy)
                 : currentProxy;

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -27,6 +27,10 @@ import {
     getReproxyNodeForUnproxiedNode,
     updateReproxyNode,
 } from "./reproxy";
+import {
+    trackDependencyAccess,
+    trackDependencyPropertyAccess,
+} from "./dependency-tracking";
 import { Transactions } from "./transactions";
 
 export const FUNCTION_NAMES_BIND_TO_RAW: (string | symbol)[] = [
@@ -74,6 +78,26 @@ const DATE_MUTATING_METHODS: Record<
     setUTCSeconds: Date.prototype.setUTCSeconds,
 };
 
+interface BoundFunctionCacheEntry {
+    source: Function;
+    bound: Function;
+}
+
+export function getCachedBoundFunction<TFunction extends Function>(
+    cache: Map<string | symbol, BoundFunctionCacheEntry>,
+    prop: string | symbol,
+    source: TFunction,
+    thisArg: unknown
+): TFunction {
+    const cached = cache.get(prop);
+    if (cached !== undefined && cached.source === source) {
+        return cached.bound as TFunction;
+    }
+    const bound = source.bind(thisArg);
+    cache.set(prop, { source, bound });
+    return bound as TFunction;
+}
+
 /**
  * Built-ins like {@link Date}, {@link Map}, and {@link Set} rely on internal slots, so calling their methods
  * with a Proxy as the `this` value throws "incompatible receiver". For those instances we bind
@@ -93,9 +117,9 @@ function isDateMutatingMethod(prop: string): prop is DateMutatingMethodName {
 
 function getLatestIgnoredValue(value: unknown) {
     if (isCustomProxy(value)) {
-        return getReproxyNode(value);
+        return trackDependencyAccess(getReproxyNode(value));
     }
-    return value;
+    return trackDependencyAccess(value);
 }
 
 function assertValidLinkedValue(prop: string | symbol, value: unknown) {
@@ -132,6 +156,10 @@ export function buildProxy<T extends TreeNode = TreeNode>(
     parent?: IProxyParent<any>
 ): T {
     let isApplyingSet = false;
+    const boundFunctionCache = new Map<
+        string | symbol,
+        BoundFunctionCacheEntry
+    >();
     const proxyHandler: ProxyHandler<T> & ICustomProxyHandler<T> = {
         // Add some extra stuff into the handler so we can store the original TreeNode and access it later
         // Without overriding the rest of the getters in the object.
@@ -168,7 +196,12 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             ) {
                 const value = proxyHandler[proxiedChildrenKey][prop];
                 if (typeof value !== "function") {
-                    return value;
+                    const baseProxy = getBaseProxy(receiver);
+                    return trackDependencyPropertyAccess(
+                        baseProxy,
+                        prop,
+                        value
+                    );
                 }
             }
             const baseProxy = getBaseProxy(receiver);
@@ -226,9 +259,16 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                             emitter
                         );
                     }
-                    return value.bind(target);
+                    return trackDependencyAccess(
+                        getCachedBoundFunction(
+                            boundFunctionCache,
+                            prop,
+                            value,
+                            target
+                        )
+                    );
                 }
-                return value;
+                return trackDependencyPropertyAccess(baseProxy, prop, value);
             }
             let value: any;
             if (
@@ -249,9 +289,23 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             }
             if (typeof value === "function") {
                 if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
-                    return value.bind(target);
+                    return trackDependencyAccess(
+                        getCachedBoundFunction(
+                            boundFunctionCache,
+                            prop,
+                            value,
+                            target
+                        )
+                    );
                 }
-                return value.bind(baseProxy);
+                return trackDependencyAccess(
+                    getCachedBoundFunction(
+                        boundFunctionCache,
+                        prop,
+                        value,
+                        baseProxy
+                    )
+                );
             }
             if (shouldLazilyProxyProperty(target, prop, value)) {
                 const descriptor = Reflect.getOwnPropertyDescriptor(
@@ -259,19 +313,27 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     prop
                 );
                 if (!descriptor || !descriptorHasValue(descriptor)) {
-                    return value;
+                    return trackDependencyPropertyAccess(
+                        baseProxy,
+                        prop,
+                        value
+                    );
                 }
                 if (!shouldKeepRawPropertyValue(descriptor, value)) {
-                    return getOrCreateProxiedChild(
-                        proxyHandler,
-                        prop,
-                        value,
+                    return trackDependencyPropertyAccess(
                         baseProxy,
-                        emitter
+                        prop,
+                        getOrCreateProxiedChild(
+                            proxyHandler,
+                            prop,
+                            value,
+                            baseProxy,
+                            emitter
+                        )
                     );
                 }
             }
-            return value;
+            return trackDependencyPropertyAccess(baseProxy, prop, value);
         },
         set(target, prop, newValue, receiver) {
             if (target instanceof ReactiveNode) {

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -18,7 +18,11 @@ import {
     unproxiedBaseNodeKey,
 } from "./proxy-types";
 import { getReactiveNodeGetter, popMemoGetter, pushMemoGetter } from "./memo";
-import { getReproxyNodeForUnproxiedNode, updateReproxyNode } from "./reproxy";
+import {
+    getReproxyNode,
+    getReproxyNodeForUnproxiedNode,
+    updateReproxyNode,
+} from "./reproxy";
 import { Transactions } from "./transactions";
 
 export const FUNCTION_NAMES_BIND_TO_RAW: (string | symbol)[] = [
@@ -83,6 +87,13 @@ function isDateMutatingMethod(prop: string): prop is DateMutatingMethodName {
     return Object.prototype.hasOwnProperty.call(DATE_MUTATING_METHODS, prop);
 }
 
+function getLatestIgnoredValue(value: unknown) {
+    if (isCustomProxy(value)) {
+        return getReproxyNode(value);
+    }
+    return value;
+}
+
 /**
  * @internal
  * Builds a proxied object that emits changes when any value changes.
@@ -119,7 +130,9 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     propString === COLLECTED_KEYS_SYMBOL ||
                     target[COLLECTED_KEYS_SYMBOL].has(propString)
                 ) {
-                    return Reflect.get(target, prop, target);
+                    return getLatestIgnoredValue(
+                        Reflect.get(target, prop, target)
+                    );
                 }
             }
             if (

--- a/packages/retree-core/src/internals/reactive-node-utils.ts
+++ b/packages/retree-core/src/internals/reactive-node-utils.ts
@@ -2,6 +2,7 @@ import { IReactiveDependency, ReactiveNode } from "../ReactiveNode";
 import { TreeNode } from "../types";
 
 export interface IActiveReactiveDependency extends IReactiveDependency {
+    key: string;
     unsubscribeListener: (() => void) | undefined;
     unproxiedNode: TreeNode | undefined;
 }
@@ -10,7 +11,7 @@ export interface IPreviousReactiveDependent {
     reactiveNode: ReactiveNode;
     unproxiedReactiveNode: TreeNode;
     comparisons?: any[];
-    index: number;
+    key: string;
 }
 
 let reactiveDependentMap:
@@ -83,7 +84,7 @@ export function setReactiveDependents(
         if (
             existingDependent.unproxiedReactiveNode ===
                 dependent.unproxiedReactiveNode &&
-            existingDependent.index === dependent.index
+            existingDependent.key === dependent.key
         ) {
             existingDependent.reactiveNode = dependent.reactiveNode;
             existingDependent.comparisons = dependent.comparisons;
@@ -97,7 +98,7 @@ export function setReactiveDependents(
 export function deleteReactiveDependent(
     unproxiedDependentNode: TreeNode,
     unproxiedDependencyNode: TreeNode,
-    dependencyIndex?: number
+    dependencyKey?: string
 ) {
     if (!reactiveDependentMap) {
         reactiveDependentMap = new WeakMap();
@@ -111,10 +112,10 @@ export function deleteReactiveDependent(
         if (dep.unproxiedReactiveNode !== unproxiedDependencyNode) {
             return true;
         }
-        if (dependencyIndex === undefined) {
+        if (dependencyKey === undefined) {
             return false;
         }
-        return dep.index !== dependencyIndex;
+        return dep.key !== dependencyKey;
     });
     if (newDependents.length === 0) {
         reactiveDependentMap?.delete(unproxiedDependentNode);

--- a/packages/retree-core/src/internals/reproxy.spec.ts
+++ b/packages/retree-core/src/internals/reproxy.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Retree } from "../Retree";
 import { getBaseProxy } from "./proxy";
+import { isCustomProxy } from "./proxy-types";
 import { getReproxyNode, updateReproxyNode } from "./reproxy";
 
 describe("reproxy internals", () => {
@@ -14,6 +15,11 @@ describe("reproxy internals", () => {
         expect(updated).not.toBe(original);
         expect(getBaseProxy(updated)).toBe(root.child);
 
+        if (!isCustomProxy<{ value: number }>(root.child)) {
+            throw new Error(
+                "Expected root.child to be a custom proxy before manually updating its reproxy."
+            );
+        }
         const manual = updateReproxyNode(root.child);
         expect(manual).not.toBe(updated);
         expect(manual.value).toBe(2);

--- a/packages/retree-core/src/internals/reproxy.spec.ts
+++ b/packages/retree-core/src/internals/reproxy.spec.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
+import { ReactiveNode } from "../ReactiveNode";
 import { Retree } from "../Retree";
 import { getBaseProxy } from "./proxy";
 import { isCustomProxy } from "./proxy-types";
 import { getReproxyNode, updateReproxyNode } from "./reproxy";
+
+class MethodNode extends ReactiveNode {
+    public value = 0;
+
+    public increment() {
+        this.value += 1;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
 
 describe("reproxy internals", () => {
     it("creates a fresh snapshot and preserves access to the base proxy", () => {
@@ -23,5 +36,17 @@ describe("reproxy internals", () => {
         const manual = updateReproxyNode(root.child);
         expect(manual).not.toBe(updated);
         expect(manual.value).toBe(2);
+    });
+
+    it("returns stable bound methods from the same reproxy", () => {
+        const root = Retree.root(new MethodNode());
+        const reproxy = getReproxyNode(root);
+        const increment = reproxy.increment;
+
+        expect(reproxy.increment).toBe(increment);
+
+        increment();
+
+        expect(root.value).toBe(1);
     });
 });

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -79,7 +79,9 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                     prop === COLLECTED_KEYS_SYMBOL ||
                     target[COLLECTED_KEYS_SYMBOL].has(prop)
                 ) {
-                    return Reflect.get(target, prop, target);
+                    return getLatestIgnoredValue(
+                        Reflect.get(target, prop, target)
+                    );
                 }
             }
             if (
@@ -147,4 +149,11 @@ function buildReproxy<T extends TreeNode = TreeNode>(
     };
     const proxy = new Proxy(object, proxyHandler);
     return proxy as TCustomProxy<T>;
+}
+
+function getLatestIgnoredValue(value: unknown) {
+    if (isCustomProxy(value)) {
+        return getReproxyNode(value);
+    }
+    return value;
 }

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -14,8 +14,13 @@ import {
     getBaseProxy,
     getUnproxiedNode,
     FUNCTION_NAMES_BIND_TO_RAW,
+    getCachedBoundFunction,
     isInternalSlotInstance,
 } from "./proxy";
+import {
+    trackDependencyAccess,
+    trackDependencyPropertyAccess,
+} from "./dependency-tracking";
 import { getReactiveNodeGetter, popMemoGetter, pushMemoGetter } from "./memo";
 import {
     ICustomProxyHandler,
@@ -73,6 +78,10 @@ function buildReproxy<T extends TreeNode = TreeNode>(
             "Retree internal invariant failed: cannot build a reproxy for an unproxied node. This is unexpected and likely a Retree bug if it came from a public Retree API. Fix: make sure callers pass Retree-managed proxies from Retree.root(...) or tree children; otherwise file a Retree issue with the operation that triggered this."
         );
     }
+    const boundFunctionCache = new Map<
+        string | symbol,
+        { source: Function; bound: Function }
+    >();
     const proxyHandler: ProxyHandler<T> &
         Omit<ICustomProxyHandler<T>, typeof proxiedChildrenKey> = {
         // Add some extra stuff into the handler so we can store the original TreeNode and access it later
@@ -110,7 +119,12 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 const childProxy = handler[proxiedChildrenKey][prop];
                 if (typeof childProxy !== "function") {
                     const reproxy = getReproxyNode(childProxy);
-                    return reproxy ?? childProxy;
+                    const baseProxy: TCustomProxy<T> = getBaseProxy(receiver);
+                    return trackDependencyPropertyAccess(
+                        baseProxy,
+                        prop,
+                        reproxy ?? childProxy
+                    );
                 }
             }
             const baseProxy: TCustomProxy<T> = getBaseProxy(receiver);
@@ -118,7 +132,11 @@ function buildReproxy<T extends TreeNode = TreeNode>(
             // Some built-in methods need internal slots on `this`. Delegate property access to the
             // base proxy so the bind/wrap logic in buildProxy is reused (and mutations emit).
             if (isInternalSlotInstance(rawNode)) {
-                return Reflect.get(baseProxy, prop, baseProxy);
+                return trackDependencyPropertyAccess(
+                    baseProxy,
+                    prop,
+                    Reflect.get(baseProxy, prop, baseProxy)
+                );
             }
             const reproxy = getReproxyNode(baseProxy);
             const evalTarget = rawNode ?? target;
@@ -141,17 +159,35 @@ function buildReproxy<T extends TreeNode = TreeNode>(
 
             if (typeof value === "function") {
                 if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
-                    return value.bind(rawNode);
+                    return trackDependencyAccess(
+                        getCachedBoundFunction(
+                            boundFunctionCache,
+                            prop,
+                            value,
+                            rawNode
+                        )
+                    );
                 }
-                return value.bind(reproxy);
+                return trackDependencyAccess(
+                    getCachedBoundFunction(
+                        boundFunctionCache,
+                        prop,
+                        value,
+                        reproxy
+                    )
+                );
             }
             if (value !== null && typeof value === "object") {
                 const baseValue = Reflect.get(baseProxy, prop, baseProxy);
                 if (isCustomProxy(baseValue)) {
-                    return getReproxyNode(baseValue) ?? baseValue;
+                    return trackDependencyPropertyAccess(
+                        baseProxy,
+                        prop,
+                        getReproxyNode(baseValue) ?? baseValue
+                    );
                 }
             }
-            return value;
+            return trackDependencyPropertyAccess(baseProxy, prop, value);
         },
         set(target, prop, newValue, receiver) {
             if (target instanceof ReactiveNode) {
@@ -171,7 +207,7 @@ function buildReproxy<T extends TreeNode = TreeNode>(
 
 function getLatestIgnoredValue(value: unknown) {
     if (isCustomProxy(value)) {
-        return getReproxyNode(value);
+        return trackDependencyAccess(getReproxyNode(value));
     }
-    return value;
+    return trackDependencyAccess(value);
 }

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { COLLECTED_KEYS_SYMBOL, ReactiveNode } from "../ReactiveNode";
+import {
+    COLLECTED_KEYS_SYMBOL,
+    LINKED_KEYS_SYMBOL,
+    ReactiveNode,
+} from "../ReactiveNode";
 import { TreeNode } from "../types";
 import {
     getCustomProxyHandler,
@@ -29,7 +33,10 @@ export function updateReproxyNode<T extends TreeNode = TreeNode>(
 ): TCustomProxy<T> {
     const handler = getCustomProxyHandler(node);
     if (!handler) {
-        throw new Error("Cannot reproxy a root unproxied node");
+        // @retree-throws
+        throw new Error(
+            "Retree internal invariant failed: cannot update a reproxy for an unproxied node. This is unexpected and likely a Retree bug if it came from a public Retree API. Fix: make sure callers pass Retree-managed proxies from Retree.root(...) or tree children; otherwise file a Retree issue with the operation that triggered this."
+        );
     }
     const unproxiedNode = handler[unproxiedBaseNodeKey];
     const reproxy = buildReproxy<T>(node);
@@ -40,7 +47,10 @@ export function updateReproxyNode<T extends TreeNode = TreeNode>(
 export function getReproxyNode<T extends TreeNode = TreeNode>(node: T): T {
     const handler = getCustomProxyHandler<T>(node);
     if (!handler) {
-        throw new Error("Cannot get a reproxy for a root unproxied node");
+        // @retree-throws
+        throw new Error(
+            "Retree internal invariant failed: cannot get a reproxy for an unproxied node. This is unexpected and likely a Retree bug if it came from a public Retree API. Fix: make sure callers pass Retree-managed proxies from Retree.root(...) or tree children; otherwise file a Retree issue with the operation that triggered this."
+        );
     }
     const unproxiedNode = handler[unproxiedBaseNodeKey];
     // If we haven't reproxied, we return the original TreeNode
@@ -58,7 +68,10 @@ function buildReproxy<T extends TreeNode = TreeNode>(
 ): TCustomProxy<T> {
     const handler = getCustomProxyHandler(object);
     if (!handler) {
-        throw new Error("Cannot reproxy a root unproxied node");
+        // @retree-throws
+        throw new Error(
+            "Retree internal invariant failed: cannot build a reproxy for an unproxied node. This is unexpected and likely a Retree bug if it came from a public Retree API. Fix: make sure callers pass Retree-managed proxies from Retree.root(...) or tree children; otherwise file a Retree issue with the operation that triggered this."
+        );
     }
     const proxyHandler: ProxyHandler<T> &
         Omit<ICustomProxyHandler<T>, typeof proxiedChildrenKey> = {
@@ -79,6 +92,11 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                     prop === COLLECTED_KEYS_SYMBOL ||
                     target[COLLECTED_KEYS_SYMBOL].has(prop)
                 ) {
+                    return getLatestIgnoredValue(
+                        Reflect.get(target, prop, target)
+                    );
+                }
+                if (target[LINKED_KEYS_SYMBOL].has(prop)) {
                     return getLatestIgnoredValue(
                         Reflect.get(target, prop, target)
                     );

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -97,10 +97,10 @@ function buildReproxy<T extends TreeNode = TreeNode>(
             }
             if (target instanceof ReactiveNode) {
                 // Check for ignore keys
-                if (
-                    prop === COLLECTED_KEYS_SYMBOL ||
-                    target[COLLECTED_KEYS_SYMBOL].has(prop)
-                ) {
+                if (typeof prop === "string" && prop.startsWith("RETREE_")) {
+                    return Reflect.get(target, prop, target);
+                }
+                if (target[COLLECTED_KEYS_SYMBOL].has(prop)) {
                     return getLatestIgnoredValue(
                         Reflect.get(target, prop, target)
                     );

--- a/packages/retree-core/src/internals/select.ts
+++ b/packages/retree-core/src/internals/select.ts
@@ -4,8 +4,12 @@
  */
 
 import { TRetreeChangedEvents, TreeNode } from "../types";
-import { getBaseProxy, getCustomProxyHandler, getUnproxiedNode } from "./proxy";
-import { TCustomProxy } from "./proxy-types";
+import {
+    areDependencyComparisonValuesEqual,
+    getDependencyComparisonValues,
+    normalizeDependencyEntry,
+} from "./dependencies";
+import { getBaseProxy, getUnproxiedNode } from "./proxy";
 import { getReproxyNode } from "./reproxy";
 
 export type RetreeSelectSelector<TNode extends TreeNode, TSelected> = (
@@ -54,16 +58,6 @@ export function defaultSelectEquals<TSelected>(
     return Object.is(previous, next);
 }
 
-function areSelectSlotsEqual(previous: unknown, next: unknown): boolean {
-    if (
-        isRetreeManagedDependency(previous) &&
-        isRetreeManagedDependency(next)
-    ) {
-        return getUnproxiedNode(previous) === getUnproxiedNode(next);
-    }
-    return Object.is(previous, next);
-}
-
 export function defaultSelectShouldNotify<TSelected>(
     previous: TSelected,
     next: TSelected,
@@ -76,35 +70,33 @@ export function defaultSelectShouldNotify<TSelected>(
         return true;
     }
     if (changedDependencyIndex !== undefined) {
+        const currentSlot = normalizeDependencyEntry(
+            next[changedDependencyIndex]
+        );
+        if (currentSlot.explicit) {
+            const previousSlot = normalizeDependencyEntry(
+                previous[changedDependencyIndex]
+            );
+            return !areDependencyComparisonValuesEqual(
+                previousSlot.comparisonValues,
+                currentSlot.comparisonValues
+            );
+        }
         if (changedDependencyIndex >= next.length - 1) {
             return true;
         }
-        for (
-            let index = changedDependencyIndex + 1;
-            index < next.length;
-            index++
-        ) {
-            if (!areSelectSlotsEqual(previous[index], next[index])) {
-                return true;
-            }
-        }
-        return false;
+        return !areDependencyComparisonValuesEqual(
+            getDependencyComparisonValues(
+                previous.slice(changedDependencyIndex + 1)
+            ),
+            getDependencyComparisonValues(
+                next.slice(changedDependencyIndex + 1)
+            )
+        );
     }
-    for (let index = 0; index < previous.length; index++) {
-        if (!areSelectSlotsEqual(previous[index], next[index])) {
-            return true;
-        }
-    }
-    return false;
-}
-
-export function isRetreeManagedDependency(
-    value: unknown
-): value is TCustomProxy<TreeNode> {
-    return (
-        value !== null &&
-        typeof value === "object" &&
-        getCustomProxyHandler(value) !== undefined
+    return !areDependencyComparisonValuesEqual(
+        getDependencyComparisonValues(previous),
+        getDependencyComparisonValues(next)
     );
 }
 
@@ -134,10 +126,11 @@ export function createRetreeSelectionObserver<
 
         for (let index = 0; index < dependencies.length; index++) {
             const dependency = dependencies[index];
-            if (!isRetreeManagedDependency(dependency)) {
+            const normalizedDependency = normalizeDependencyEntry(dependency);
+            if (normalizedDependency.node === undefined) {
                 continue;
             }
-            const dependencyBaseProxy = getBaseProxy(dependency);
+            const dependencyBaseProxy = getBaseProxy(normalizedDependency.node);
             const rawNode = getUnproxiedNode(dependencyBaseProxy);
             if (rawNode === undefined || rawNode === baseRawNode) {
                 continue;

--- a/packages/retree-core/src/internals/select.ts
+++ b/packages/retree-core/src/internals/select.ts
@@ -1,0 +1,231 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TRetreeChangedEvents, TreeNode } from "../types";
+import { getBaseProxy, getCustomProxyHandler, getUnproxiedNode } from "./proxy";
+import { TCustomProxy } from "./proxy-types";
+import { getReproxyNode } from "./reproxy";
+
+export type RetreeSelectSelector<TNode extends TreeNode, TSelected> = (
+    node: TNode
+) => TSelected;
+
+export type RetreeSelectEquals<TSelected> = (
+    previous: TSelected,
+    next: TSelected
+) => boolean;
+
+type SelectionListener<TNode extends TreeNode> = (node: TNode) => void;
+type SubscribeToNode = <TNode extends TreeNode>(
+    node: TNode,
+    listenerType: TRetreeChangedEvents,
+    listener: SelectionListener<TNode>
+) => () => void;
+
+interface ActiveSelectDependency {
+    rawNode: TreeNode;
+    indices: number[];
+    unsubscribe: () => void;
+}
+
+export function normalizeSelectDependencies<TSelected>(
+    selected: TSelected
+): readonly unknown[] {
+    return Array.isArray(selected) ? selected : [selected];
+}
+
+export function defaultSelectEquals<TSelected>(
+    previous: TSelected,
+    next: TSelected
+): boolean {
+    if (Array.isArray(previous) && Array.isArray(next)) {
+        if (previous.length !== next.length) {
+            return false;
+        }
+        for (let index = 0; index < previous.length; index++) {
+            if (!Object.is(previous[index], next[index])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return Object.is(previous, next);
+}
+
+function areSelectSlotsEqual(previous: unknown, next: unknown): boolean {
+    if (
+        isRetreeManagedDependency(previous) &&
+        isRetreeManagedDependency(next)
+    ) {
+        return getUnproxiedNode(previous) === getUnproxiedNode(next);
+    }
+    return Object.is(previous, next);
+}
+
+export function defaultSelectShouldNotify<TSelected>(
+    previous: TSelected,
+    next: TSelected,
+    changedDependencyIndex?: number
+): boolean {
+    if (!Array.isArray(previous) || !Array.isArray(next)) {
+        return !defaultSelectEquals(previous, next);
+    }
+    if (previous.length !== next.length) {
+        return true;
+    }
+    if (changedDependencyIndex !== undefined) {
+        if (changedDependencyIndex >= next.length - 1) {
+            return true;
+        }
+        for (
+            let index = changedDependencyIndex + 1;
+            index < next.length;
+            index++
+        ) {
+            if (!areSelectSlotsEqual(previous[index], next[index])) {
+                return true;
+            }
+        }
+        return false;
+    }
+    for (let index = 0; index < previous.length; index++) {
+        if (!areSelectSlotsEqual(previous[index], next[index])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function isRetreeManagedDependency(
+    value: unknown
+): value is TCustomProxy<TreeNode> {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        getCustomProxyHandler(value) !== undefined
+    );
+}
+
+export function createRetreeSelectionObserver<
+    TNode extends TreeNode,
+    TSelected
+>(options: {
+    node: TNode;
+    selector: RetreeSelectSelector<TNode, TSelected>;
+    equals?: RetreeSelectEquals<TSelected>;
+    listenerType: TRetreeChangedEvents;
+    subscribeToNode: SubscribeToNode;
+    onChange: (next: TSelected, previous: TSelected) => void;
+}): () => void {
+    const baseProxy = getBaseProxy(options.node);
+    const baseRawNode = getUnproxiedNode(baseProxy);
+    let activeDependencies: ActiveSelectDependency[] = [];
+    let previous = options.selector(getReproxyNode(baseProxy));
+
+    const updateDependencySubscriptions = (selected: TSelected) => {
+        const nextDependencies: ActiveSelectDependency[] = [];
+        const nextDependencySlots = new Map<
+            TreeNode,
+            { baseProxy: TreeNode; indices: number[] }
+        >();
+        const dependencies = normalizeSelectDependencies(selected);
+
+        for (let index = 0; index < dependencies.length; index++) {
+            const dependency = dependencies[index];
+            if (!isRetreeManagedDependency(dependency)) {
+                continue;
+            }
+            const dependencyBaseProxy = getBaseProxy(dependency);
+            const rawNode = getUnproxiedNode(dependencyBaseProxy);
+            if (rawNode === undefined || rawNode === baseRawNode) {
+                continue;
+            }
+            const existingSlot = nextDependencySlots.get(rawNode);
+            if (existingSlot !== undefined) {
+                existingSlot.indices.push(index);
+                continue;
+            }
+            nextDependencySlots.set(rawNode, {
+                baseProxy: dependencyBaseProxy,
+                indices: [index],
+            });
+        }
+
+        for (const [rawNode, dependencySlot] of nextDependencySlots.entries()) {
+            const existing = activeDependencies.find(
+                (active) => active.rawNode === rawNode
+            );
+            if (existing !== undefined) {
+                existing.indices = dependencySlot.indices;
+                nextDependencies.push(existing);
+                continue;
+            }
+
+            nextDependencies.push({
+                rawNode,
+                indices: dependencySlot.indices,
+                unsubscribe: options.subscribeToNode(
+                    dependencySlot.baseProxy,
+                    "nodeChanged",
+                    () => evaluate(rawNode)
+                ),
+            });
+        }
+
+        for (const activeDependency of activeDependencies) {
+            if (
+                !nextDependencies.some(
+                    (dependency) =>
+                        dependency.rawNode === activeDependency.rawNode
+                )
+            ) {
+                activeDependency.unsubscribe();
+            }
+        }
+        activeDependencies = nextDependencies;
+    };
+
+    const evaluate = (changedDependencyRawNode?: TreeNode) => {
+        const changedDependencyIndex =
+            changedDependencyRawNode === undefined
+                ? undefined
+                : activeDependencies.find(
+                      (dependency) =>
+                          dependency.rawNode === changedDependencyRawNode
+                  )?.indices;
+        const next = options.selector(getReproxyNode(baseProxy));
+        updateDependencySubscriptions(next);
+        const shouldNotify =
+            options.equals !== undefined
+                ? !options.equals(previous, next)
+                : Array.isArray(changedDependencyIndex)
+                ? changedDependencyIndex.some((index) =>
+                      defaultSelectShouldNotify(previous, next, index)
+                  )
+                : defaultSelectShouldNotify(previous, next);
+        if (!shouldNotify) {
+            previous = next;
+            return;
+        }
+        const previousToEmit = previous;
+        previous = next;
+        options.onChange(next, previousToEmit);
+    };
+
+    updateDependencySubscriptions(previous);
+    const unsubscribeRoot = options.subscribeToNode(
+        baseProxy,
+        options.listenerType,
+        evaluate
+    );
+
+    return () => {
+        unsubscribeRoot();
+        for (const activeDependency of activeDependencies) {
+            activeDependency.unsubscribe();
+        }
+        activeDependencies = [];
+    };
+}

--- a/packages/retree-core/src/internals/select.ts
+++ b/packages/retree-core/src/internals/select.ts
@@ -6,15 +6,19 @@
 import { TRetreeChangedEvents, TreeNode } from "../types";
 import {
     areDependencyComparisonValuesEqual,
+    areDependencyValuesEqual,
     getDependencyComparisonValues,
     normalizeDependencyEntry,
 } from "./dependencies";
+import { collectDependencyAccesses } from "./dependency-tracking";
 import { getBaseProxy, getUnproxiedNode } from "./proxy";
 import { getReproxyNode } from "./reproxy";
 
 export type RetreeSelectSelector<TNode extends TreeNode, TSelected> = (
     node: TNode
 ) => TSelected;
+
+export type RetreeTrackedSelectSelector<TSelected> = () => TSelected;
 
 export type RetreeSelectEquals<TSelected> = (
     previous: TSelected,
@@ -34,6 +38,94 @@ interface ActiveSelectDependency {
     unsubscribe: () => void;
 }
 
+interface TrackedSelection<TSelected> {
+    selected: TSelected;
+    dependencies: readonly unknown[];
+}
+
+function getTrackedDependencyComparisonValue(dependency: unknown): unknown {
+    const normalizedDependency = normalizeDependencyEntry(dependency);
+    if (
+        normalizedDependency.node !== undefined &&
+        normalizedDependency.node !== null
+    ) {
+        return getUnproxiedNode(getBaseProxy(normalizedDependency.node));
+    }
+    return dependency;
+}
+
+function getTrackedDependencyComparisonValues(
+    dependencies: readonly unknown[]
+) {
+    const comparisonValues: unknown[] = [];
+    for (const dependency of dependencies) {
+        const comparisonValue = getTrackedDependencyComparisonValue(dependency);
+        const previousValue = comparisonValues[comparisonValues.length - 1];
+        if (Object.is(previousValue, comparisonValue)) {
+            continue;
+        }
+        comparisonValues.push(comparisonValue);
+    }
+    return comparisonValues;
+}
+
+function defaultTrackedDependenciesChanged(
+    previous: readonly unknown[],
+    next: readonly unknown[]
+): boolean {
+    const previousComparisonValues =
+        getTrackedDependencyComparisonValues(previous);
+    const nextComparisonValues = getTrackedDependencyComparisonValues(next);
+    if (previousComparisonValues.length !== nextComparisonValues.length) {
+        return true;
+    }
+    for (let index = 0; index < previousComparisonValues.length; index++) {
+        if (
+            !Object.is(
+                previousComparisonValues[index],
+                nextComparisonValues[index]
+            )
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function defaultTrackedSelectedChanged<TSelected>(
+    previous: TSelected,
+    next: TSelected
+): boolean {
+    return !Object.is(previous, next);
+}
+
+function stabilizeSelectedRetreeReferences<TSelected>(
+    previous: TSelected,
+    next: TSelected
+): TSelected {
+    if (!Array.isArray(previous) || !Array.isArray(next)) {
+        if (areDependencyValuesEqual(previous, next)) {
+            return previous;
+        }
+        return next;
+    }
+    if (previous.length !== next.length) {
+        return next;
+    }
+    let didStabilizeSlot = false;
+    const stabilized = next.map((nextValue, index) => {
+        const previousValue = previous[index];
+        if (!areDependencyValuesEqual(previousValue, nextValue)) {
+            return nextValue;
+        }
+        if (previousValue !== nextValue) {
+            didStabilizeSlot = true;
+        }
+        return previousValue;
+    });
+    return (didStabilizeSlot ? stabilized : next) as TSelected;
+}
+
 export function normalizeSelectDependencies<TSelected>(
     selected: TSelected
 ): readonly unknown[] {
@@ -49,13 +141,13 @@ export function defaultSelectEquals<TSelected>(
             return false;
         }
         for (let index = 0; index < previous.length; index++) {
-            if (!Object.is(previous[index], next[index])) {
+            if (!areDependencyValuesEqual(previous[index], next[index])) {
                 return false;
             }
         }
         return true;
     }
-    return Object.is(previous, next);
+    return areDependencyValuesEqual(previous, next);
 }
 
 export function defaultSelectShouldNotify<TSelected>(
@@ -220,5 +312,139 @@ export function createRetreeSelectionObserver<
             activeDependency.unsubscribe();
         }
         activeDependencies = [];
+    };
+}
+
+export function createRetreeTrackedSelectionObserver<TSelected>(options: {
+    selector: RetreeTrackedSelectSelector<TSelected>;
+    equals?: RetreeSelectEquals<TSelected>;
+    subscribeToNode: SubscribeToNode;
+    onChange: (next: TSelected, previous: TSelected) => void;
+}): () => void {
+    let activeDependencies: ActiveSelectDependency[] = [];
+    let previous = runTrackedSelection(options.selector);
+
+    const updateDependencySubscriptions = (
+        trackedSelection: TrackedSelection<TSelected>
+    ) => {
+        const nextDependencies: ActiveSelectDependency[] = [];
+        const nextDependencySlots = new Map<
+            TreeNode,
+            { baseProxy: TreeNode; indices: number[] }
+        >();
+
+        for (
+            let index = 0;
+            index < trackedSelection.dependencies.length;
+            index++
+        ) {
+            const dependency = trackedSelection.dependencies[index];
+            const normalizedDependency = normalizeDependencyEntry(dependency);
+            if (normalizedDependency.node === undefined) {
+                continue;
+            }
+            const dependencyBaseProxy = getBaseProxy(normalizedDependency.node);
+            const rawNode = getUnproxiedNode(dependencyBaseProxy);
+            if (rawNode === undefined) {
+                continue;
+            }
+            const existingSlot = nextDependencySlots.get(rawNode);
+            if (existingSlot !== undefined) {
+                existingSlot.indices.push(index);
+                continue;
+            }
+            nextDependencySlots.set(rawNode, {
+                baseProxy: dependencyBaseProxy,
+                indices: [index],
+            });
+        }
+
+        for (const [rawNode, dependencySlot] of nextDependencySlots.entries()) {
+            const existing = activeDependencies.find(
+                (active) => active.rawNode === rawNode
+            );
+            if (existing !== undefined) {
+                existing.indices = dependencySlot.indices;
+                nextDependencies.push(existing);
+                continue;
+            }
+
+            nextDependencies.push({
+                rawNode,
+                indices: dependencySlot.indices,
+                unsubscribe: options.subscribeToNode(
+                    dependencySlot.baseProxy,
+                    "nodeChanged",
+                    evaluate
+                ),
+            });
+        }
+
+        for (const activeDependency of activeDependencies) {
+            if (
+                !nextDependencies.some(
+                    (dependency) =>
+                        dependency.rawNode === activeDependency.rawNode
+                )
+            ) {
+                activeDependency.unsubscribe();
+            }
+        }
+        activeDependencies = nextDependencies;
+    };
+
+    const evaluate = () => {
+        const next = runTrackedSelection(options.selector);
+        const nextSelected = stabilizeSelectedRetreeReferences(
+            previous.selected,
+            next.selected
+        );
+        updateDependencySubscriptions(next);
+        const selectedChanged =
+            options.equals !== undefined
+                ? !options.equals(previous.selected, nextSelected)
+                : defaultTrackedSelectedChanged(
+                      previous.selected,
+                      nextSelected
+                  );
+        const dependenciesChanged = defaultTrackedDependenciesChanged(
+            previous.dependencies,
+            next.dependencies
+        );
+        if (!selectedChanged && !dependenciesChanged) {
+            previous = {
+                selected: nextSelected,
+                dependencies: next.dependencies,
+            };
+            return;
+        }
+        const previousToEmit = previous;
+        previous = {
+            selected: nextSelected,
+            dependencies: next.dependencies,
+        };
+        options.onChange(nextSelected, previousToEmit.selected);
+    };
+
+    updateDependencySubscriptions(previous);
+
+    return () => {
+        for (const activeDependency of activeDependencies) {
+            activeDependency.unsubscribe();
+        }
+        activeDependencies = [];
+    };
+}
+
+export function runTrackedSelection<TSelected>(
+    selector: RetreeTrackedSelectSelector<TSelected>
+): TrackedSelection<TSelected> {
+    let selected: TSelected | undefined;
+    const dependencies = collectDependencyAccesses(() => {
+        selected = selector();
+    });
+    return {
+        selected: selected as TSelected,
+        dependencies,
     };
 }

--- a/packages/retree-core/src/memo.spec.ts
+++ b/packages/retree-core/src/memo.spec.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
-import { fnMemo, memo } from "./decorators";
+import { fnMemo, ignore, memo } from "./decorators";
+import { getReproxyNode } from "./internals/reproxy";
 import { Transactions } from "./internals/transactions";
 
 const rootsToCleanup: object[] = [];
@@ -130,9 +131,10 @@ describe("memo (method form)", () => {
         expect(root.computeCount).toBe(1);
     });
 
-    it("with undefined comparisons, recomputes once per reproxy", () => {
+    it("with omitted comparisons, traps getter reads as comparisons", () => {
         class UndefinedDepsNode extends ReactiveNode {
             public counter = 0;
+            public unrelated = 0;
             public computeCount = 0;
 
             get cached(): number {
@@ -156,12 +158,11 @@ describe("memo (method form)", () => {
         expect(root.cached).toBe(0);
         expect(root.computeCount).toBe(1);
 
-        // A property set reproxies the ReactiveNode → next read recomputes.
         root.counter = 1;
         expect(root.cached).toBe(1);
         expect(root.computeCount).toBe(2);
 
-        // Repeated reads are cached again until the next reproxy.
+        root.unrelated = 1;
         expect(root.cached).toBe(1);
         expect(root.computeCount).toBe(2);
     });
@@ -349,9 +350,10 @@ describe("@memo decorator", () => {
         expect(root.computeCount).toBe(2);
     });
 
-    it("with no deps function (undefined comparisons), recomputes once per reproxy", () => {
+    it("with no deps function, traps getter reads as comparisons", () => {
         class UndefDeps extends ReactiveNode {
             public counter = 0;
+            public unrelated = 0;
             public computeCount = 0;
 
             @memo()
@@ -375,6 +377,103 @@ describe("@memo decorator", () => {
         root.counter = 1;
         expect(root.cached).toBe(1);
         expect(root.computeCount).toBe(2);
+
+        root.unrelated = 1;
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("supports @memo without parentheses as automatic dependency trapping", () => {
+        class BareMemoNode extends ReactiveNode {
+            public counter = 0;
+            public unrelated = 0;
+            public computeCount = 0;
+
+            @memo
+            get cached(): number {
+                this.computeCount += 1;
+                return this.counter;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new BareMemoNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.cached).toBe(0);
+        expect(root.cached).toBe(0);
+        expect(root.computeCount).toBe(1);
+
+        root.unrelated = 1;
+        expect(root.cached).toBe(0);
+        expect(root.computeCount).toBe(1);
+
+        root.counter = 1;
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("with no deps function, narrows trapped child property reads", () => {
+        class ChildPropertyNode extends ReactiveNode {
+            public child = { value: 1, label: "initial" };
+            public computeCount = 0;
+
+            @memo()
+            get doubled(): number {
+                this.computeCount += 1;
+                return this.child.value * 2;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new ChildPropertyNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.doubled).toBe(2);
+        expect(root.doubled).toBe(2);
+        expect(root.computeCount).toBe(1);
+
+        root.child.label = "updated";
+        expect(root.doubled).toBe(2);
+        expect(root.computeCount).toBe(1);
+
+        root.child.value = 2;
+        expect(root.doubled).toBe(4);
+        expect(root.computeCount).toBe(2);
+    });
+
+    it("still emits and reproxies when a @memo getter writes a non-ignored field", () => {
+        class SideEffectMemoNode extends ReactiveNode {
+            public source = 1;
+            public sideEffectCount = 0;
+
+            @memo()
+            get doubled(): number {
+                this.sideEffectCount += 1;
+                return this.source * 2;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new SideEffectMemoNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+        const beforeRead = getReproxyNode(root);
+
+        expect(root.doubled).toBe(2);
+
+        expect(root.sideEffectCount).toBe(1);
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(getReproxyNode(root)).not.toBe(beforeRead);
     });
 
     it("returns []-style 'cache forever' when the deps function returns []", () => {
@@ -530,9 +629,10 @@ describe("@fnMemo decorator", () => {
         expect(root.computeCount).toBe(3);
     });
 
-    it("with undefined comparisons, reuses same-argument calls until the node reproxies", () => {
+    it("with no deps function, traps method reads and method arguments as comparisons", () => {
         class Formatter extends ReactiveNode {
             public suffix = "a";
+            public unrelated = 0;
             public computeCount = 0;
 
             @fnMemo()
@@ -558,9 +658,182 @@ describe("@fnMemo decorator", () => {
         expect(root.format(2)).toBe("2:a");
         expect(root.computeCount).toBe(2);
 
+        root.unrelated = 1;
+        expect(root.format(2)).toBe("2:a");
+        expect(root.computeCount).toBe(2);
+
         root.suffix = "b";
         expect(root.format(2)).toBe("2:b");
         expect(root.computeCount).toBe(3);
+    });
+
+    it("supports @fnMemo without parentheses as automatic dependency trapping", () => {
+        class BareFnMemoNode extends ReactiveNode {
+            public suffix = "a";
+            public unrelated = 0;
+            public computeCount = 0;
+
+            @fnMemo
+            public format(value: number): string {
+                this.computeCount += 1;
+                return `${value}:${this.suffix}`;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new BareFnMemoNode()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.format(1)).toBe("1:a");
+        expect(root.format(1)).toBe("1:a");
+        expect(root.computeCount).toBe(1);
+
+        root.unrelated = 1;
+        expect(root.format(1)).toBe("1:a");
+        expect(root.computeCount).toBe(1);
+
+        expect(root.format(2)).toBe("2:a");
+        expect(root.computeCount).toBe(2);
+
+        root.suffix = "b";
+        expect(root.format(2)).toBe("2:b");
+        expect(root.computeCount).toBe(3);
+    });
+
+    it("with no deps function, narrows trapped method child property reads", () => {
+        class ChildFormatter extends ReactiveNode {
+            public child = { suffix: "a", label: "initial" };
+            public computeCount = 0;
+
+            @fnMemo()
+            public format(value: number): string {
+                this.computeCount += 1;
+                return `${value}:${this.child.suffix}`;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new ChildFormatter()));
+        Retree.on(root, "nodeChanged", vi.fn());
+
+        expect(root.format(1)).toBe("1:a");
+        expect(root.format(1)).toBe("1:a");
+        expect(root.computeCount).toBe(1);
+
+        root.child.label = "updated";
+        expect(root.format(1)).toBe("1:a");
+        expect(root.computeCount).toBe(1);
+
+        expect(root.format(2)).toBe("2:a");
+        expect(root.computeCount).toBe(2);
+
+        root.child.suffix = "b";
+        expect(root.format(2)).toBe("2:b");
+        expect(root.computeCount).toBe(3);
+    });
+
+    it("still emits and reproxies when a @fnMemo method writes a non-ignored field", () => {
+        class SideEffectFnMemoNode extends ReactiveNode {
+            public suffix = "a";
+            public sideEffectCount = 0;
+
+            @fnMemo()
+            public format(value: number): string {
+                this.sideEffectCount += 1;
+                return `${value}:${this.suffix}`;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new SideEffectFnMemoNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+        const beforeCall = getReproxyNode(root);
+
+        expect(root.format(1)).toBe("1:a");
+
+        expect(root.sideEffectCount).toBe(1);
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        expect(getReproxyNode(root)).not.toBe(beforeCall);
+    });
+
+    it("traps nested memo reads while keeping fnMemo writes out of the cache dependencies", () => {
+        class MixedSideEffectNode extends ReactiveNode {
+            public count1 = 0;
+            @ignore
+            public count2 = 0;
+            @ignore
+            public count3ComputeCount = 0;
+            @ignore
+            public incrementComputeCount = 0;
+
+            @memo()
+            get count3(): number {
+                this.count3ComputeCount += 1;
+                return this.count1 + this.count2;
+            }
+
+            @fnMemo()
+            public increment(label: string): number {
+                this.incrementComputeCount += 1;
+                this.count1 += 1;
+                this.count2 += 1;
+                return this.count3;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new MixedSideEffectNode()));
+        const nodeChanged = vi.fn();
+        Retree.on(root, "nodeChanged", nodeChanged);
+
+        expect(root.increment("same")).toBe(2);
+        expect(root.count1).toBe(1);
+        expect(root.count2).toBe(1);
+        expect(root.incrementComputeCount).toBe(1);
+        expect(root.count3ComputeCount).toBe(1);
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+
+        expect(root.increment("same")).toBe(2);
+        expect(root.count1).toBe(1);
+        expect(root.count2).toBe(1);
+        expect(root.incrementComputeCount).toBe(1);
+        expect(root.count3ComputeCount).toBe(1);
+
+        root.count1 = 10;
+        expect(root.increment("same")).toBe(13);
+        expect(root.count1).toBe(11);
+        expect(root.count2).toBe(2);
+        expect(root.incrementComputeCount).toBe(2);
+        expect(root.count3ComputeCount).toBe(3);
+        expect(nodeChanged).toHaveBeenCalledTimes(3);
+
+        root.count2 = 20;
+        expect(root.increment("same")).toBe(33);
+        expect(root.count1).toBe(12);
+        expect(root.count2).toBe(21);
+        expect(root.incrementComputeCount).toBe(3);
+        expect(root.count3ComputeCount).toBe(5);
+        expect(nodeChanged).toHaveBeenCalledTimes(4);
+
+        expect(root.increment("other")).toBe(35);
+        expect(root.count1).toBe(13);
+        expect(root.count2).toBe(22);
+        expect(root.incrementComputeCount).toBe(4);
+        expect(root.count3ComputeCount).toBe(6);
+        expect(nodeChanged).toHaveBeenCalledTimes(5);
     });
 
     it("with empty comparisons, recomputes only when arguments change", () => {
@@ -689,9 +962,10 @@ describe("memo (keyless method form)", () => {
         expect(root.computeCount).toBe(3);
     });
 
-    it("supports the undefined-deps form (recompute once per reproxy)", () => {
+    it("supports omitted comparisons by trapping getter reads", () => {
         class Undef extends ReactiveNode {
             public counter = 0;
+            public unrelated = 0;
             public computeCount = 0;
 
             get cached(): number {
@@ -715,6 +989,10 @@ describe("memo (keyless method form)", () => {
         expect(root.computeCount).toBe(1);
 
         root.counter = 1;
+        expect(root.cached).toBe(1);
+        expect(root.computeCount).toBe(2);
+
+        root.unrelated = 1;
         expect(root.cached).toBe(1);
         expect(root.computeCount).toBe(2);
     });

--- a/packages/retree-core/src/types.ts
+++ b/packages/retree-core/src/types.ts
@@ -10,6 +10,13 @@ export type OptionalNode<T extends TreeNode = TreeNode> =
     | (undefined | T)
     | (null | T);
 
+export type RetreeObjectMoveKey<
+    TDestination extends TreeNode,
+    TNode extends TreeNode
+> = {
+    [K in keyof TDestination]-?: TNode extends TDestination[K] ? K : never;
+}[keyof TDestination];
+
 /**
  * Listener types for {@link Retree.on} that return a reproxied node.
  */

--- a/packages/retree-react/README.md
+++ b/packages/retree-react/README.md
@@ -111,6 +111,8 @@ function AttributeLabel({ row }: { row: AttributeRow }) {
 
 `useSelect` listens with `nodeChanged` by default. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes.
 
+Dependency-list subscriptions in `useSelect` are observational. If `self.attributes` or `self.attribute` changes in the example above, the component can re-render, but the `row` node passed to `useSelect` is not forced to receive a fresh reproxy. Use `@select` on a `ReactiveNode` getter when the owner node itself should emit `nodeChanged`.
+
 `useSelect` is a subscription primitive, not a memo cache. Use `memo` or `fnMemo` to cache expensive computation, and use `useSelect` to narrow React updates. If your selector returns a fresh object or array, pass `equals` to avoid re-rendering when the selected value is logically unchanged.
 
 ### useNode hook
@@ -397,7 +399,7 @@ function TodoCount({ todos }: { todos: Todo[] }) {
 
 `useTree` maps to broad descendant invalidation. It is still useful, especially for small local subtrees, but it should not be the default for large app-level roots. If a `useTree` component reads deeply on every render, the render itself becomes part of the benchmark cost.
 
-`ReactiveNode.dependencies` and `@select` are often better bridges than `useTree` when one node needs to update from another node. Keep dependency lists stable in length and order. Return raw reactive nodes/primitives directly for simple slots, and use `this.dependency(node, comparisons)` when one slot needs custom comparison values. Keep setup work in `onObserved()` instead of inside the `dependencies` getter.
+`ReactiveNode.dependencies` and `@select` are often better bridges than `useTree` when one node needs to update from another node. Dependency lists can change length/order; Retree treats shape changes as invalidation and refreshes subscriptions. Return raw reactive nodes/primitives directly for simple slots, and use `this.dependency(node, comparisons)` when one slot needs custom comparison values. Prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when the selected items or selected order changes. Keep setup work in `onObserved()` instead of inside the `dependencies` getter.
 
 Plain object and array fields on `ReactiveNode` are prepared lazily. This reduces initial proxy/setup time, but the first nested read pays the preparation cost. If you want to pay that cost during a loading state, call `node.prepareTree({ depth })` or opt into `super({ prepare: { autoPrepare: true, depth } })`.
 

--- a/packages/retree-react/README.md
+++ b/packages/retree-react/README.md
@@ -18,9 +18,36 @@ Install with `yarn`:
 yarn add @retreejs/core @retreejs/react
 ```
 
+## Feature glossary
+
+-   [`useRoot`](#useroot-hook) creates one Retree root for a component lifetime. Use it when state belongs to a React subtree.
+-   [`useNode`](#usenode-hook) subscribes to direct `nodeChanged` events. Use it for focused components that own one node.
+-   [`useTree`](#usetree-hook) subscribes to `treeChanged` events from a node and descendants. Use it for small subtrees that should re-render together.
+-   [`useSelect`](#useselect-hook) subscribes to a derived value and re-renders only when that selected value changes. Use it for counts, totals, booleans, labels, and other narrow projections.
+-   [`ReactiveNode.dependencies`](#reactivenode) can make a node emit `nodeChanged` from a narrow dependency. Use it when a view model should update from child or external nodes without making components subscribe broadly.
+-   [`memo`, `@memo`, and `@fnMemo`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#memoize-computed-getters) cache expensive computed values. They do not trigger renders by themselves.
+-   [`@ignore`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#opt-fields-out-of-reactivity-with-ignore) stores non-rendered state on a `ReactiveNode`. Writes do not emit and therefore do not re-render React subscribers.
+
 ## How to use
 
 It's extremely easy to get started with Retree. The main React hooks are `useNode`, `useTree`, and `useSelect`. Each has specific advantages while leveraging the same simple interface.
+
+### useRoot hook
+
+Use `useRoot` when a component should create and retain its own Retree root. The factory runs once for the component lifetime.
+
+```tsx
+import { useNode, useRoot } from "@retreejs/react";
+
+function CounterPanel() {
+    const counter = useRoot(() => ({ count: 0 }));
+    const state = useNode(counter);
+
+    return <button onClick={() => (state.count += 1)}>{state.count}</button>;
+}
+```
+
+`useRoot` creates the root; `useNode`, `useTree`, or `useSelect` decide what causes the component to re-render.
 
 ### useSelect hook
 
@@ -43,6 +70,28 @@ function TotalRow() {
 
     return <td>{total}</td>;
 }
+```
+
+```tsx
+const project = Retree.root({
+    tasks: [
+        { title: "Docs", done: false },
+        { title: "Tests", done: true },
+    ],
+});
+
+function DoneCount() {
+    const doneCount = useSelect(
+        project.tasks,
+        (tasks) => tasks.filter((task) => task.done).length,
+        { listenerType: "treeChanged" }
+    );
+
+    return <span>{doneCount}</span>;
+}
+
+project.tasks[0].done = true; // ✅ re-renders DoneCount: 1 -> 2
+project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
 ```
 
 `useSelect` listens with `nodeChanged` by default. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes.
@@ -80,7 +129,7 @@ class Todo {
     }
 }
 
-// Todo React component that acceps a Todo object as a prop
+// Todo React component that accepts a Todo object as a prop
 function _ViewTodo({ todo }) {
     // Make todo stateful. Changes to todo will only re-render this component.
     const _todo = useNode(todo);
@@ -210,7 +259,7 @@ function Headers({ headers }) {
 }
 
 function Row({ row }) {
-    // In this simple case, `useNode` and `useTree` can be used interchangably.
+    // In this simple case, `useNode` and `useTree` can be used interchangeably.
     const rowState = useNode(row);
     return (
         <tr>
@@ -345,43 +394,37 @@ Plain object and array fields on `ReactiveNode` are prepared lazily. This reduce
 
 The `ReactiveNode` class allows nodes in your tree to reactively update when their declared dependencies change. This offers a middleground between `useTree` and `useNode` that can be extremely powerful for minimizing re-renders in your application.
 
-```ts
-import { Retree, ReactiveNode } from "@retree/core";
-import { useNode } from "@retree/core";
-// Declare a class that extends `ReactiveNode`
-class Node extends ReactiveNode {
-    numbers: number[] = [];
-    constructor() {
-        super();
-    }
-    // Get count of even numbers in the list
+```tsx
+import { Retree, ReactiveNode } from "@retreejs/core";
+import { useNode } from "@retreejs/react";
+
+class EvenCounter extends ReactiveNode {
+    public numbers: number[] = [];
+
     get evenNumberCount(): number {
         return this.numbers.filter((number) => number % 2 === 0).length;
     }
-    // Implement abstract `dependencies` getter with list of dependencies
+
     get dependencies() {
         return [
-            // Similar to React, dependencies cannot change in length or order between updates.
             this.dependency(
-                // The dependency node to listen to changes for.
                 this.numbers,
-                // Optional comparison dependencies so that only specific changes cause `Node` instances to updates.
-                // If not provided, all changes to `this.numbers` would cause `Node` instances to update.
+                // Only emit when the derived value changes.
                 [this.evenNumberCount]
             ),
         ];
     }
 }
-// Create root `ReactiveNode` instance and listen for changes in `useNode`
-const node = Retree.root(new Node());
-const nodeState = useNode(node);
 
-// ✅ Will re-render
-node.list.push(2);
-node.list.push(100);
-// ❌ Will not re-render
-node.list.push(3);
-node.list.push(99);
+const counter = Retree.root(new EvenCounter());
+
+function EvenBadge() {
+    const state = useNode(counter);
+    return <span>{state.evenNumberCount}</span>;
+}
+
+counter.numbers.push(2); // ✅ re-renders: evenNumberCount 0 -> 1
+counter.numbers.push(3); // ❌ no re-render: evenNumberCount stayed 1
 ```
 
 ### Transactions
@@ -391,7 +434,7 @@ If you are making multiple changes to one or many nodes at once, you can use `Re
 ```ts
 const _counter = Retree.root({ count: 0 });
 const counter = useNode(_counter);
-// Will only emit "valueChanged" once
+// Will only emit "nodeChanged" once
 Retree.runTransaction(() => {
     counter.count = counter.count + 1;
     counter.count = counter.count * 2;
@@ -406,7 +449,7 @@ If you want to skip re-rendering on a change, you can use the `Retree.runSilent`
 const counter = Retree.root({ count: 0, multiplier: 1 });
 const counterState = useNode(counter);
 // Skip re-render on setting the multiplier
-function onClickIncrementMultipler() {
+function onClickIncrementMultiplier() {
     Retree.runSilent(() => {
         counterState.multiplier += 1;
     });

--- a/packages/retree-react/README.md
+++ b/packages/retree-react/README.md
@@ -95,6 +95,21 @@ project.tasks[0].done = true; // ✅ re-renders DoneCount: 1 -> 2
 project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
 ```
 
+`useSelect` can also infer dependencies when you pass only a selector function. Whole Retree-managed values read by the selector subscribe automatically. Property reads subscribe to the owner node but compare the specific property value, so `task.done` reacts to task replacement or `done` changes without reacting to unrelated task fields. Primitive reads compare.
+
+```tsx
+function DoneCount() {
+    const doneCount = useSelect(
+        () => project.tasks.filter((task) => task.done).length
+    );
+
+    return <span>{doneCount}</span>;
+}
+
+project.tasks[0].done = true; // ✅ re-renders DoneCount
+project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
+```
+
 Selectors can return an ordered dependency list. Reactive entries are subscribed to; primitive entries are compared. This lets a component listen broadly enough to stay fresh without re-rendering for unrelated changes.
 
 ```tsx
@@ -111,7 +126,7 @@ function AttributeLabel({ row }: { row: AttributeRow }) {
 
 `useSelect` listens with `nodeChanged` by default. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes.
 
-Dependency-list subscriptions in `useSelect` are observational. If `self.attributes` or `self.attribute` changes in the example above, the component can re-render, but the `row` node passed to `useSelect` is not forced to receive a fresh reproxy. Use `@select` on a `ReactiveNode` getter when the owner node itself should emit `nodeChanged`.
+Dependency-list subscriptions in `useSelect` are observational. If `self.attributes` or `self.attribute` changes in the example above, the component can re-render, but the `row` node passed to `useSelect` is not forced to receive a fresh reproxy. Use `@select` on a `ReactiveNode` getter when the owner node itself should emit `nodeChanged`. Use `@select()` with no selector when the getter should trap reads automatically, including property-level reads like `task.done`.
 
 `useSelect` is a subscription primitive, not a memo cache. Use `memo` or `fnMemo` to cache expensive computation, and use `useSelect` to narrow React updates. If your selector returns a fresh object or array, pass `equals` to avoid re-rendering when the selected value is logically unchanged.
 

--- a/packages/retree-react/README.md
+++ b/packages/retree-react/README.md
@@ -23,8 +23,9 @@ yarn add @retreejs/core @retreejs/react
 -   [`useRoot`](#useroot-hook) creates one Retree root for a component lifetime. Use it when state belongs to a React subtree.
 -   [`useNode`](#usenode-hook) subscribes to direct `nodeChanged` events. Use it for focused components that own one node.
 -   [`useTree`](#usetree-hook) subscribes to `treeChanged` events from a node and descendants. Use it for small subtrees that should re-render together.
--   [`useSelect`](#useselect-hook) subscribes to a derived value and re-renders only when that selected value changes. Use it for counts, totals, booleans, labels, and other narrow projections.
--   [`ReactiveNode.dependencies`](#reactivenode) can make a node emit `nodeChanged` from a narrow dependency. Use it when a view model should update from child or external nodes without making components subscribe broadly.
+-   [`useSelect`](#useselect-hook) subscribes to a selected value or ordered dependency list and re-renders only when it changes. Use it for counts, totals, booleans, labels, and other narrow projections.
+-   [`@select`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#reactive-dependencies) decorates a getter with an ordered dependency list. Use it when VM logic should stay in the `ReactiveNode` while `useNode(node)` stays selective.
+-   [`ReactiveNode.dependencies`](#reactivenode) can make a node emit `nodeChanged` from narrow dependencies. Return raw reactive nodes/primitives directly, or wrap one slot with `this.dependency(node, comparisons)`.
 -   [`memo`, `@memo`, and `@fnMemo`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#memoize-computed-getters) cache expensive computed values. They do not trigger renders by themselves.
 -   [`@ignore`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#opt-fields-out-of-reactivity-with-ignore) stores non-rendered state on a `ReactiveNode`. Writes do not emit and therefore do not re-render React subscribers.
 
@@ -51,7 +52,7 @@ function CounterPanel() {
 
 ### useSelect hook
 
-Use `useSelect` when a component needs a derived value from a Retree node but should only re-render when that derived value changes. It accepts any Retree-managed node, not only a root.
+Use `useSelect` when a component needs a selected value or dependency list from a Retree node but should only re-render when that selection changes. It accepts any Retree-managed node, not only a root.
 
 ```tsx
 import { Retree } from "@retreejs/core";
@@ -92,6 +93,20 @@ function DoneCount() {
 
 project.tasks[0].done = true; // ✅ re-renders DoneCount: 1 -> 2
 project.tasks[0].title = "Better docs"; // ❌ no re-render: doneCount stayed 2
+```
+
+Selectors can return an ordered dependency list. Reactive entries are subscribed to; primitive entries are compared. This lets a component listen broadly enough to stay fresh without re-rendering for unrelated changes.
+
+```tsx
+function AttributeLabel({ row }: { row: AttributeRow }) {
+    const [, , attribute] = useSelect(row, (self) => [
+        self.attributes,
+        self.attributeId,
+        self.attribute,
+    ]);
+
+    return <span>{attribute?.label}</span>;
+}
 ```
 
 `useSelect` listens with `nodeChanged` by default. This is best for selecting direct values owned by that exact node, including `ReactiveNode` values that emit when their dependencies change. Pass `listenerType: "treeChanged"` when the selector intentionally reads descendant nodes.
@@ -382,7 +397,7 @@ function TodoCount({ todos }: { todos: Todo[] }) {
 
 `useTree` maps to broad descendant invalidation. It is still useful, especially for small local subtrees, but it should not be the default for large app-level roots. If a `useTree` component reads deeply on every render, the render itself becomes part of the benchmark cost.
 
-`ReactiveNode.dependencies` is often a better bridge than `useTree` when one node needs to update from another node. Keep dependency lists stable in length and order, use comparison values to suppress irrelevant changes, and keep setup work in `onObserved()` instead of inside the `dependencies` getter.
+`ReactiveNode.dependencies` and `@select` are often better bridges than `useTree` when one node needs to update from another node. Keep dependency lists stable in length and order. Return raw reactive nodes/primitives directly for simple slots, and use `this.dependency(node, comparisons)` when one slot needs custom comparison values. Keep setup work in `onObserved()` instead of inside the `dependencies` getter.
 
 Plain object and array fields on `ReactiveNode` are prepared lazily. This reduces initial proxy/setup time, but the first nested read pays the preparation cost. If you want to pay that cost during a loading state, call `node.prepareTree({ depth })` or opt into `super({ prepare: { autoPrepare: true, depth } })`.
 
@@ -406,13 +421,7 @@ class EvenCounter extends ReactiveNode {
     }
 
     get dependencies() {
-        return [
-            this.dependency(
-                this.numbers,
-                // Only emit when the derived value changes.
-                [this.evenNumberCount]
-            ),
-        ];
+        return [this.dependency(this.numbers, [this.evenNumberCount])];
     }
 }
 

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.3.1",
+        "@retreejs/core": "0.4.0",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.3.1",
+        "@retreejs/core": "0.4.0",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.3.0",
+        "@retreejs/core": "0.3.1",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.3.0",
+        "@retreejs/core": "0.3.1",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/src/useNode.spec.tsx
+++ b/packages/retree-react/src/useNode.spec.tsx
@@ -1,8 +1,21 @@
 import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { Retree } from "@retreejs/core";
+import { ReactiveNode, Retree, select } from "@retreejs/core";
 import { useNode } from "./useNode";
+
+class SelectedOwnerNode extends ReactiveNode {
+    public child = { value: 1 };
+
+    @select
+    get selectedValue() {
+        return this.child.value;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
 
 const rootsToCleanup: object[] = [];
 
@@ -69,6 +82,27 @@ describe("useNode", () => {
 
         expect(screen.getByTestId("value").textContent).toBe("1");
         expect(renderCount).toBe(1);
+    });
+
+    it("rerenders the attached node when @select dependencies change", () => {
+        const root = trackRoot(Retree.root(new SelectedOwnerNode()));
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const state = useNode(root);
+            return <div data-testid="value">{state.selectedValue}</div>;
+        }
+
+        render(<Probe />);
+        expect(screen.getByTestId("value").textContent).toBe("1");
+
+        act(() => {
+            root.child.value = 2;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("2");
+        expect(renderCount).toBe(2);
     });
 
     it("supports the node factory form and switches immediately when the node prop changes", () => {

--- a/packages/retree-react/src/useNode.ts
+++ b/packages/retree-react/src/useNode.ts
@@ -14,14 +14,21 @@ const LISTENER_TYPE = "nodeChanged";
  * Stateful version of an object and its leafs.
  *
  * @remarks
- * Changes to child leafs (e.g., `node.text`) will cause this to re-render.
- * Changes to child nodes (e.g., `node.someObject.text`) will not cause this to re-render.
- * If the `nodeState` response is used in a comparison check, the old `nodeState` will not equal the new `nodeState`.
+ * `useNode` subscribes to direct `nodeChanged` events for the node you pass.
+ * Changes to fields owned by that node (for example `todo.text`) re-render
+ * the component. Changes inside child nodes (for example
+ * `project.tasks[0].text` when subscribed to `project`) do not re-render the
+ * component.
+ *
+ * Use `useNode` for focused components such as list rows, panels, and forms.
+ * Prefer it over `useTree` for hot paths. If the component only needs a
+ * derived value, prefer `useSelect`.
  *
  * @param node object to make stateful
  * @returns a stateful version of the node provided.
  * 
  * @example
+ * ```tsx
 import React from "react";
 import { Retree } from "@retreejs/core";
 import { useNode } from "@retreejs/react";
@@ -38,7 +45,7 @@ class Todo {
     }
 }
 
-// Todo React component that acceps a Todo object as a prop
+// Todo React component that accepts a Todo object as a prop
 function _ViewTodo({ todo }) {
     // Make todo stateful. Changes to todo will only re-render this component.
     const _todo = useNode(todo);
@@ -80,6 +87,7 @@ function App() {
     );
 }
 export default App;
+ * ```
  */
 export function useNode<T extends TreeNode = TreeNode>(
     node: T | NodeFactory<T>

--- a/packages/retree-react/src/useRoot.ts
+++ b/packages/retree-react/src/useRoot.ts
@@ -26,8 +26,25 @@ import { useRef } from "react";
  * across the function body's StrictMode re-renders within a single mount,
  * so a `useRef + null check` guard ensures the factory runs exactly once.
  *
+ * Use `useRoot` when the Retree state belongs to this React subtree. Do not
+ * use it for shared module-level state that should outlive the component;
+ * create that root once outside React instead. Do not create a new Retree root
+ * directly during render.
+ *
  * @param factory function that returns a node wrapped in `Retree.root`.
  * @returns a root proxied node.
+ *
+ * @example
+ * ```tsx
+ * import { useNode, useRoot } from "@retreejs/react";
+ *
+ * function CounterPanel() {
+ *     const counter = useRoot(() => ({ count: 0 }));
+ *     const state = useNode(counter);
+ *
+ *     return <button onClick={() => (state.count += 1)}>{state.count}</button>;
+ * }
+ * ```
  */
 export function useRoot<T extends TreeNode>(factory: () => T): T {
     const ref = useRef<T | null>(null);

--- a/packages/retree-react/src/useSelect.spec.tsx
+++ b/packages/retree-react/src/useSelect.spec.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { Retree } from "@retreejs/core";
 import { useSelect } from "./useSelect";
 
@@ -155,6 +155,87 @@ describe("useSelect", () => {
         });
 
         expect(screen.getByTestId("value").textContent).toBe("1");
+    });
+
+    it("selects dependency tuples without rerendering for broad source churn", () => {
+        const root = trackRoot(
+            Retree.root({
+                attributeId: "a",
+                attributes: [
+                    { id: "a", value: 0 },
+                    { id: "b", value: 0 },
+                ],
+            })
+        );
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const selection = useSelect(
+                root,
+                (node) =>
+                    [
+                        node.attributes,
+                        node.attributeId,
+                        node.attributes.find(
+                            (attribute) => attribute.id === node.attributeId
+                        ),
+                    ] as const
+            );
+            return (
+                <div data-testid="value">{selection[2]?.value ?? "none"}</div>
+            );
+        }
+
+        render(<Probe />);
+
+        act(() => {
+            root.attributes.push({ id: "c", value: 0 });
+            root.attributes[1].value = 1;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("0");
+        expect(renderCount).toBe(1);
+
+        act(() => {
+            root.attributes[0].value = 2;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("2");
+        expect(renderCount).toBe(2);
+    });
+
+    it("infers tuple select values for equality", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 1,
+                label: "one",
+            })
+        );
+
+        function Probe() {
+            const selection = useSelect(
+                root,
+                (node) => [node.count, node.label] as const,
+                {
+                    equals: (previous, next) => {
+                        expectTypeOf(previous).toEqualTypeOf<
+                            readonly [number, string]
+                        >();
+                        expectTypeOf(next).toEqualTypeOf<
+                            readonly [number, string]
+                        >();
+                        return (
+                            previous[0] === next[0] && previous[1] === next[1]
+                        );
+                    },
+                }
+            );
+            return <div data-testid="value">{selection[1]}</div>;
+        }
+
+        render(<Probe />);
+        expect(screen.getByTestId("value").textContent).toBe("one");
     });
 
     it("shares one Retree listener for multiple selectors on the same node", () => {

--- a/packages/retree-react/src/useSelect.spec.tsx
+++ b/packages/retree-react/src/useSelect.spec.tsx
@@ -1,7 +1,10 @@
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
-import { Retree } from "@retreejs/core";
+import { ReactiveNode, Retree, link, select } from "@retreejs/core";
 import { getReproxyNode } from "@retreejs/core/internal";
+import { memo } from "react";
+import { useNode } from "./useNode";
+import { useRoot } from "./useRoot";
 import { useSelect } from "./useSelect";
 
 const rootsToCleanup: object[] = [];
@@ -25,6 +28,47 @@ function clearListenersRecursively(node: unknown, seen = new Set<object>()) {
     Retree.clearListeners(node as never);
     for (const child of Object.values(node)) {
         clearListenersRecursively(child, seen);
+    }
+}
+
+interface RenderTask {
+    id: string;
+    isCompleted: boolean;
+    text: string;
+}
+
+class RenderTaskListState extends ReactiveNode {
+    public filter = { isCompleted: null as boolean | null };
+    public tasks: RenderTask[] = [
+        { id: "a", isCompleted: false, text: "First" },
+        { id: "b", isCompleted: false, text: "Second" },
+    ];
+
+    @select()
+    public get visibleTasks() {
+        return this.tasks.filter(
+            (task) =>
+                this.filter.isCompleted === null ||
+                task.isCompleted === this.filter.isCompleted
+        );
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class RenderTaskRowState extends ReactiveNode {
+    @link
+    public task: RenderTask;
+
+    constructor(task: RenderTask) {
+        super();
+        this.task = task;
+    }
+
+    get dependencies() {
+        return [];
     }
 }
 
@@ -156,6 +200,323 @@ describe("useSelect", () => {
         });
 
         expect(screen.getByTestId("value").textContent).toBe("1");
+    });
+
+    it("selects with trapped dependencies when only a selector function is passed", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 1,
+                label: "one",
+            })
+        );
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const count = useSelect(() => root.count);
+            expectTypeOf(count).toEqualTypeOf<number>();
+            return <div data-testid="value">{count}</div>;
+        }
+
+        render(<Probe />);
+
+        act(() => {
+            root.label = "two";
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("1");
+        expect(renderCount).toBe(1);
+
+        act(() => {
+            root.count = 2;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("2");
+        expect(renderCount).toBe(2);
+    });
+
+    it("infers selector-only tuple outputs independently from trapped node dependencies", () => {
+        type Task = {
+            id: string;
+            text: string;
+        };
+        type QueryStatus = "pending" | "success";
+        const root = trackRoot(
+            Retree.root({
+                tasks: {
+                    state: undefined as Task[] | undefined,
+                    result: {
+                        status: "pending" as QueryStatus,
+                    },
+                },
+                filter: {
+                    isComplete: null as boolean | null,
+                },
+            })
+        );
+
+        function Probe() {
+            const [tasks, filter, queryStatus] = useSelect(() => {
+                const tasks = root.tasks.state ?? [];
+                return [tasks, root.filter, root.tasks.result.status] as const;
+            });
+
+            expectTypeOf(tasks).toEqualTypeOf<Task[]>();
+            expectTypeOf(filter).toEqualTypeOf<typeof root.filter>();
+            expectTypeOf(queryStatus).toEqualTypeOf<QueryStatus>();
+
+            return (
+                <div data-testid="value">
+                    {queryStatus}:{tasks.length}:{String(filter.isComplete)}
+                </div>
+            );
+        }
+
+        render(<Probe />);
+        expect(screen.getByTestId("value").textContent).toBe("pending:0:null");
+    });
+
+    it("lets row selectors update without rerendering a trapped parent task list", () => {
+        const root = trackRoot(Retree.root(new RenderTaskListState()));
+        const rowRenderCounts = new Map<string, number>();
+        let parentRenderCount = 0;
+
+        function Row({ task }: { task: RenderTask }) {
+            const taskId = task.id;
+            rowRenderCounts.set(taskId, (rowRenderCounts.get(taskId) ?? 0) + 1);
+            const row = useRoot(() => new RenderTaskRowState(task));
+            const isCompleted = useSelect(() => row.task.isCompleted);
+
+            return (
+                <div data-testid={`task-${taskId}`}>{String(isCompleted)}</div>
+            );
+        }
+
+        function Parent() {
+            parentRenderCount += 1;
+            const tasks = useSelect(() => root.visibleTasks);
+            return (
+                <>
+                    {tasks.map((task) => (
+                        <Row key={task.id} task={task} />
+                    ))}
+                </>
+            );
+        }
+
+        render(<Parent />);
+
+        expect(parentRenderCount).toBe(1);
+        expect(rowRenderCounts.get("a")).toBe(1);
+        expect(rowRenderCounts.get("b")).toBe(1);
+
+        act(() => {
+            root.tasks[0].isCompleted = true;
+        });
+
+        expect(screen.getByTestId("task-a").textContent).toBe("true");
+        expect(screen.getByTestId("task-b").textContent).toBe("false");
+        expect(parentRenderCount).toBe(1);
+        expect(rowRenderCounts.get("a")).toBe(2);
+        expect(rowRenderCounts.get("b")).toBe(1);
+    });
+
+    it("does not rerender memoized child consumers for stable selected child nodes", () => {
+        const root = trackRoot(Retree.root(new RenderTaskListState()));
+        let parentRenderCount = 0;
+        let filterRenderCount = 0;
+
+        const FilterProbe = memo(function FilterProbe({
+            filter,
+        }: {
+            filter: RenderTaskListState["filter"];
+        }) {
+            filterRenderCount += 1;
+            const state = useNode(filter);
+            return <div data-testid="filter">{String(state.isCompleted)}</div>;
+        });
+
+        function Parent() {
+            parentRenderCount += 1;
+            const [tasks, filter] = useSelect(() => [
+                root.visibleTasks,
+                root.filter,
+            ]);
+            return (
+                <>
+                    <FilterProbe filter={filter} />
+                    <div data-testid="task-count">{tasks.length}</div>
+                </>
+            );
+        }
+
+        render(<Parent />);
+
+        expect(parentRenderCount).toBe(1);
+        expect(filterRenderCount).toBe(1);
+
+        act(() => {
+            root.tasks[0].text = "First draft";
+        });
+
+        expect(screen.getByTestId("task-count").textContent).toBe("2");
+        expect(parentRenderCount).toBe(1);
+        expect(filterRenderCount).toBe(1);
+
+        act(() => {
+            root.tasks.push({
+                id: "c",
+                isCompleted: false,
+                text: "Third",
+            });
+        });
+
+        expect(screen.getByTestId("task-count").textContent).toBe("3");
+        expect(parentRenderCount).toBe(2);
+        expect(filterRenderCount).toBe(1);
+    });
+
+    it("treats fresh selected arrays as changed while stabilizing managed slots", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 0,
+                filter: {
+                    isCompleted: null as boolean | null,
+                },
+            })
+        );
+        let parentRenderCount = 0;
+        let filterRenderCount = 0;
+
+        const FilterProbe = memo(function FilterProbe({
+            filter,
+        }: {
+            filter: typeof root.filter;
+        }) {
+            filterRenderCount += 1;
+            const state = useNode(filter);
+            return <div data-testid="filter">{String(state.isCompleted)}</div>;
+        });
+
+        function Parent() {
+            parentRenderCount += 1;
+            const [filter] = useSelect(() => {
+                root.count;
+                return [root.filter];
+            });
+            return <FilterProbe filter={filter} />;
+        }
+
+        render(<Parent />);
+
+        act(() => {
+            root.count = 1;
+        });
+
+        expect(parentRenderCount).toBe(2);
+        expect(filterRenderCount).toBe(1);
+    });
+
+    it("trapped useSelect subscriptions follow reproxy child reads", () => {
+        const root = trackRoot(
+            Retree.root({
+                child: {
+                    count: 1,
+                    label: "one",
+                },
+            })
+        );
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const count = useSelect(() => root.child.count);
+            return <div data-testid="value">{count}</div>;
+        }
+
+        render(<Probe />);
+
+        act(() => {
+            root.child.label = "two";
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("1");
+        expect(renderCount).toBe(1);
+
+        act(() => {
+            root.child.count = 2;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("2");
+        expect(renderCount).toBe(2);
+    });
+
+    it("trapped useSelect compares primitive reads even when the selected value is equal", () => {
+        const root = trackRoot(
+            Retree.root({
+                count: 1,
+            })
+        );
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const isPositive = useSelect(() => root.count > 0);
+            return <div data-testid="value">{String(isPositive)}</div>;
+        }
+
+        render(<Probe />);
+
+        act(() => {
+            root.count = 2;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("true");
+        expect(renderCount).toBe(2);
+    });
+
+    it("returns primitive ReactiveNode getter outputs from trapped selectors", () => {
+        class PrimitiveGetterNode extends ReactiveNode {
+            public child = {
+                count: 1,
+                label: "one",
+            };
+
+            @select()
+            get isPositive() {
+                return this.child.count > 0;
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+
+        const root = trackRoot(Retree.root(new PrimitiveGetterNode()));
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const isPositive = useSelect(() => root.isPositive);
+            expectTypeOf(isPositive).toEqualTypeOf<boolean>();
+            return <div data-testid="value">{String(isPositive)}</div>;
+        }
+
+        render(<Probe />);
+
+        act(() => {
+            root.child.label = "two";
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("true");
+        expect(renderCount).toBe(1);
+
+        act(() => {
+            root.child.count = 2;
+        });
+
+        expect(screen.getByTestId("value").textContent).toBe("true");
+        expect(renderCount).toBe(2);
     });
 
     it("selects dependency tuples without rerendering for broad source churn", () => {

--- a/packages/retree-react/src/useSelect.spec.tsx
+++ b/packages/retree-react/src/useSelect.spec.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { Retree } from "@retreejs/core";
+import { getReproxyNode } from "@retreejs/core/internal";
 import { useSelect } from "./useSelect";
 
 const rootsToCleanup: object[] = [];
@@ -188,6 +189,7 @@ describe("useSelect", () => {
         }
 
         render(<Probe />);
+        const rootReproxyBeforeSelectedAttributeChange = getReproxyNode(root);
 
         act(() => {
             root.attributes.push({ id: "c", value: 0 });
@@ -203,6 +205,73 @@ describe("useSelect", () => {
 
         expect(screen.getByTestId("value").textContent).toBe("2");
         expect(renderCount).toBe(2);
+        expect(getReproxyNode(root)).toBe(
+            rootReproxyBeforeSelectedAttributeChange
+        );
+    });
+
+    it("supports explicit dependency slots without reproxying the selected root", () => {
+        const root = trackRoot(
+            Retree.root({
+                attributeId: "a",
+                attributes: [
+                    { id: "a", value: 0 },
+                    { id: "b", value: 0 },
+                ],
+                dependency(node: unknown, comparisons?: unknown[]) {
+                    return { node, comparisons };
+                },
+            })
+        );
+        let renderCount = 0;
+
+        function Probe() {
+            renderCount += 1;
+            const selected = useSelect(
+                root,
+                (node) =>
+                    [
+                        node.attributes,
+                        node.attributeId,
+                        node.dependency(
+                            node.attributes.find(
+                                (attribute) => attribute.id === node.attributeId
+                            ),
+                            [
+                                node.attributes.find(
+                                    (attribute) =>
+                                        attribute.id === node.attributeId
+                                )?.id,
+                            ]
+                        ),
+                    ] as const
+            );
+            return (
+                <div data-testid="explicit-value">
+                    {selected[2].comparisons?.[0] ?? "none"}
+                </div>
+            );
+        }
+
+        render(<Probe />);
+        const rootReproxyBeforeDependencyChange = getReproxyNode(root);
+
+        act(() => {
+            root.attributes[0].value = 1;
+        });
+
+        expect(screen.getByTestId("explicit-value").textContent).toBe("a");
+        expect(renderCount).toBe(1);
+
+        act(() => {
+            root.attributeId = "b";
+        });
+
+        expect(screen.getByTestId("explicit-value").textContent).toBe("b");
+        expect(renderCount).toBe(2);
+        expect(getReproxyNode(root)).not.toBe(
+            rootReproxyBeforeDependencyChange
+        );
     });
 
     it("infers tuple select values for equality", () => {

--- a/packages/retree-react/src/useSelect.ts
+++ b/packages/retree-react/src/useSelect.ts
@@ -26,6 +26,47 @@ function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
  * `useSelect` narrows React updates to changes in the selected value. It is
  * a subscription primitive, not a memo cache: use `memo` / `fnMemo` for
  * caching computation and `useSelect` for reducing re-renders.
+ *
+ * By default `useSelect` listens to `nodeChanged`, which is best when the
+ * selector reads fields directly owned by the node. Pass
+ * `listenerType: "treeChanged"` when the selector reads descendants. Pass
+ * `equals` when the selector returns a new object or array that should be
+ * compared structurally.
+ *
+ * Do not use `useSelect` to cache expensive computation for reuse elsewhere.
+ * Put that work behind `memo`, `@memo`, or `@fnMemo`, then select the cached
+ * value.
+ *
+ * @param node Retree-managed node or node factory to observe.
+ * @param selector Function that reads a selected value from the latest reproxy.
+ * @param options Optional listener type and equality comparison.
+ * @returns The latest selected value.
+ *
+ * @example
+ * ```tsx
+ * import { Retree } from "@retreejs/core";
+ * import { useSelect } from "@retreejs/react";
+ *
+ * const project = Retree.root({
+ *     tasks: [
+ *         { title: "Docs", done: false },
+ *         { title: "Tests", done: true },
+ *     ],
+ * });
+ *
+ * function DoneCount() {
+ *     const doneCount = useSelect(
+ *         project.tasks,
+ *         (tasks) => tasks.filter((task) => task.done).length,
+ *         { listenerType: "treeChanged" }
+ *     );
+ *
+ *     return <span>{doneCount}</span>;
+ * }
+ *
+ * project.tasks[0].done = true; // ✅ re-renders DoneCount
+ * project.tasks[0].title = "Better docs"; // ❌ no re-render
+ * ```
  */
 export function useSelect<TNode extends TreeNode, TSelected>(
     node: TNode | NodeFactory<TNode>,

--- a/packages/retree-react/src/useSelect.ts
+++ b/packages/retree-react/src/useSelect.ts
@@ -5,7 +5,11 @@
 "use no memo";
 
 import { RetreeSelectOptions, TreeNode } from "@retreejs/core";
-import { getBaseProxy, getReproxyNode } from "@retreejs/core/internal";
+import {
+    createRetreeSelectionObserver,
+    getBaseProxy,
+    getReproxyNode,
+} from "@retreejs/core/internal";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { subscribeToNode } from "./internals/subscriptionHub";
 import { NodeFactory } from "./types";
@@ -23,22 +27,25 @@ function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
  * Subscribe to a selected value from any Retree-managed node.
  *
  * @remarks
- * `useSelect` narrows React updates to changes in the selected value. It is
- * a subscription primitive, not a memo cache: use `memo` / `fnMemo` for
- * caching computation and `useSelect` for reducing re-renders.
+ * `useSelect` narrows React updates to changes in the selected value or
+ * ordered dependency list. Reactive entries in a dependency list are
+ * subscribed to; primitive and plain entries are compared by identity. It is a
+ * subscription primitive, not a memo cache: use `memo` / `fnMemo` for caching
+ * computation and `useSelect` for reducing re-renders.
  *
  * By default `useSelect` listens to `nodeChanged`, which is best when the
  * selector reads fields directly owned by the node. Pass
- * `listenerType: "treeChanged"` when the selector reads descendants. Pass
- * `equals` when the selector returns a new object or array that should be
- * compared structurally.
+ * `listenerType: "treeChanged"` when the selector reads descendants that are
+ * not included as reactive entries in a dependency list. Pass `equals` when
+ * the selected value or tuple should be compared structurally.
  *
  * Do not use `useSelect` to cache expensive computation for reuse elsewhere.
  * Put that work behind `memo`, `@memo`, or `@fnMemo`, then select the cached
  * value.
  *
  * @param node Retree-managed node or node factory to observe.
- * @param selector Function that reads a selected value from the latest reproxy.
+ * @param selector Function that reads a selected value or dependency list from
+ * the latest reproxy.
  * @param options Optional listener type and equality comparison.
  * @returns The latest selected value.
  *
@@ -67,6 +74,15 @@ function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
  * project.tasks[0].done = true; // ✅ re-renders DoneCount
  * project.tasks[0].title = "Better docs"; // ❌ no re-render
  * ```
+ *
+ * @example
+ * ```tsx
+ * const [, , attribute] = useSelect(row, (self) => [
+ *     self.attributes,
+ *     self.attributeId,
+ *     self.attribute,
+ * ]);
+ * ```
  */
 export function useSelect<TNode extends TreeNode, TSelected>(
     node: TNode | NodeFactory<TNode>,
@@ -78,7 +94,7 @@ export function useSelect<TNode extends TreeNode, TSelected>(
     }, [node]);
     const baseProxy = getBaseProxy<TNode>(memoNode);
     const listenerType = options?.listenerType ?? "nodeChanged";
-    const equals = options?.equals ?? Object.is;
+    const equals = options?.equals;
     const selectorRef = useRef(selector);
     const equalsRef = useRef(equals);
     selectorRef.current = selector;
@@ -98,22 +114,20 @@ export function useSelect<TNode extends TreeNode, TSelected>(
     }
 
     useEffect(() => {
-        let previous = selectorRef.current(getReproxyNode(baseProxy));
-        return subscribeToNode<TNode>(baseProxy, listenerType, (reproxy) => {
-            const next = selectorRef.current(reproxy);
-            if (equalsRef.current(previous, next)) {
-                return;
-            }
-            previous = next;
-            setSelectedState((previousState) => {
-                if (equalsRef.current(previousState.selected, next)) {
-                    return previousState;
-                }
-                return {
-                    baseProxy,
-                    selected: next,
-                };
-            });
+        return createRetreeSelectionObserver({
+            node: baseProxy,
+            selector: (reproxy) => selectorRef.current(reproxy),
+            equals: equalsRef.current,
+            listenerType,
+            subscribeToNode,
+            onChange: (next) => {
+                setSelectedState(() => {
+                    return {
+                        baseProxy,
+                        selected: next,
+                    };
+                });
+            },
         });
     }, [baseProxy, listenerType]);
 

--- a/packages/retree-react/src/useSelect.ts
+++ b/packages/retree-react/src/useSelect.ts
@@ -6,15 +6,28 @@
 
 import { RetreeSelectOptions, TreeNode } from "@retreejs/core";
 import {
+    createRetreeTrackedSelectionObserver,
     createRetreeSelectionObserver,
     getBaseProxy,
     getReproxyNode,
+    runTrackedSelection,
 } from "@retreejs/core/internal";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { subscribeToNode } from "./internals/subscriptionHub";
 import { NodeFactory } from "./types";
 
 export type UseSelectOptions<TSelected> = RetreeSelectOptions<TSelected>;
+
+type UseTrackedSelectArgs<TSelected> = [
+    selector: () => TSelected,
+    options?: UseSelectOptions<TSelected>
+];
+
+type UseNodeSelectArgs<TNode extends TreeNode, TSelected> = [
+    node: TNode | NodeFactory<TNode>,
+    selector: (node: TNode) => TSelected,
+    options?: UseSelectOptions<TSelected>
+];
 
 function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
     if (typeof node === "function") {
@@ -43,6 +56,12 @@ function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
  * `useSelect` may re-render this component, but it does not force the node
  * passed to `useSelect` to receive a fresh reproxy. Use `@select` on a
  * `ReactiveNode` getter when the owner node itself should emit `nodeChanged`.
+ * You can also call `useSelect(() => value)` without a node. That form traps
+ * reads automatically. Whole Retree-managed values are subscribed to broadly.
+ * Property reads subscribe to the owner node but compare the specific property
+ * value, so `task.done` can react to task replacement or `done` changes
+ * without reacting to unrelated task fields. Primitive reads are kept as
+ * comparison values.
  *
  * Do not use `useSelect` to cache expensive computation for reuse elsewhere.
  * Put that work behind `memo`, `@memo`, or `@fnMemo`, then select the cached
@@ -88,8 +107,41 @@ function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
  *     self.attribute,
  * ]);
  * ```
+ *
+ * @example
+ * ```tsx
+ * function DoneCount() {
+ *     const doneCount = useSelect(() =>
+ *         project.tasks.filter((task) => task.done).length
+ *     );
+ *
+ *     return <span>{doneCount}</span>;
+ * }
+ * ```
  */
 export function useSelect<TNode extends TreeNode, TSelected>(
+    ...args:
+        | UseTrackedSelectArgs<TSelected>
+        | UseNodeSelectArgs<TNode, TSelected>
+): TSelected {
+    const [nodeOrSelector, selectorOrOptions, options] = args;
+    if (args.length < 2) {
+        return useTrackedSelect(nodeOrSelector as () => TSelected);
+    }
+    if (typeof selectorOrOptions !== "function") {
+        return useTrackedSelect(
+            nodeOrSelector as () => TSelected,
+            selectorOrOptions
+        );
+    }
+    return useNodeSelect(
+        nodeOrSelector as TNode | NodeFactory<TNode>,
+        selectorOrOptions,
+        options
+    );
+}
+
+function useNodeSelect<TNode extends TreeNode, TSelected>(
     node: TNode | NodeFactory<TNode>,
     selector: (node: TNode) => TSelected,
     options?: UseSelectOptions<TSelected>
@@ -135,6 +187,38 @@ export function useSelect<TNode extends TreeNode, TSelected>(
             },
         });
     }, [baseProxy, listenerType]);
+
+    return selectedState.selected;
+}
+
+function useTrackedSelect<TSelected>(
+    selector: () => TSelected,
+    options?: UseSelectOptions<TSelected>
+): TSelected {
+    const equals = options?.equals;
+    const selectorRef = useRef(selector);
+    const equalsRef = useRef(equals);
+    selectorRef.current = selector;
+    equalsRef.current = equals;
+
+    const [selectedState, setSelectedState] = useState(() => ({
+        selected: runTrackedSelection(selector).selected,
+    }));
+
+    useEffect(() => {
+        return createRetreeTrackedSelectionObserver({
+            selector: () => selectorRef.current(),
+            equals: equalsRef.current,
+            subscribeToNode,
+            onChange: (next) => {
+                setSelectedState(() => {
+                    return {
+                        selected: next,
+                    };
+                });
+            },
+        });
+    }, []);
 
     return selectedState.selected;
 }

--- a/packages/retree-react/src/useSelect.ts
+++ b/packages/retree-react/src/useSelect.ts
@@ -39,6 +39,11 @@ function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
  * not included as reactive entries in a dependency list. Pass `equals` when
  * the selected value or tuple should be compared structurally.
  *
+ * Dependency-list subscriptions are observational: if a tuple entry changes,
+ * `useSelect` may re-render this component, but it does not force the node
+ * passed to `useSelect` to receive a fresh reproxy. Use `@select` on a
+ * `ReactiveNode` getter when the owner node itself should emit `nodeChanged`.
+ *
  * Do not use `useSelect` to cache expensive computation for reuse elsewhere.
  * Put that work behind `memo`, `@memo`, or `@fnMemo`, then select the cached
  * value.

--- a/packages/retree-react/src/useTree.ts
+++ b/packages/retree-react/src/useTree.ts
@@ -14,8 +14,14 @@ const LISTENER_TYPE = "treeChanged";
  * Stateful version of an object and its child nodes.
  *
  * @remarks
- * Only use in cases where re-rendering of a parent component will not cause expensive re-renders of child components.
- * The root of the node provided must have been first passed to {@link Retree.root}.
+ * `useTree` subscribes to `treeChanged`, so the component re-renders when the
+ * node or any descendant changes. Use it for small local subtrees that should
+ * render together, such as a compact summary or table section.
+ *
+ * Do not use `useTree` as the default for broad app roots. Prefer
+ * `useNode(child)` for focused child components and `useSelect(...)` for
+ * derived values. The root of the node provided must have been first passed
+ * to {@link Retree.root}.
  *
  * @param node object to make stateful
  * @returns a stateful version of the node provided
@@ -47,7 +53,7 @@ function Headers({ headers }) {
 }
 
 function Row({ row }) {
-    // In this simple case, `useNode` and `useTree` can be used interchangably.
+    // In this simple case, `useNode` and `useTree` can be used interchangeably.
     const rowState = useNode(row);
     return (
         <tr>

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.3.1"
+        "@retreejs/core": "0.4.0"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.3.0"
+        "@retreejs/core": "0.3.1"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.3.1",
-        "@retreejs/react": "0.3.1"
+        "@retreejs/core": "0.4.0",
+        "@retreejs/react": "0.4.0"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.3.0",
-        "@retreejs/react": "0.3.0"
+        "@retreejs/core": "0.3.1",
+        "@retreejs/react": "0.3.1"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.3.1",
-        "@retreejs/react": "0.3.1",
+        "@retreejs/core": "0.4.0",
+        "@retreejs/react": "0.4.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.3.0",
-        "@retreejs/react": "0.3.0",
+        "@retreejs/core": "0.3.1",
+        "@retreejs/react": "0.3.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/04.convex-react-nextjs/.babelrc
+++ b/samples/04.convex-react-nextjs/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["next/babel"],
+    "plugins": [["@babel/plugin-proposal-decorators", { "version": "2023-11" }]]
+}

--- a/samples/04.convex-react-nextjs/app/page.tsx
+++ b/samples/04.convex-react-nextjs/app/page.tsx
@@ -1,50 +1,205 @@
 "use client";
 
-import { useNode, useRoot } from "@retreejs/react";
-import { useEffect } from "react";
+import { useNode, useRoot, useSelect } from "@retreejs/react";
+import { FormEvent, useEffect, useState } from "react";
 import { Doc, Id } from "../convex/_generated/dataModel";
-import { TasksState } from "./tasks-state";
+import {
+    TaskFilterNode,
+    TaskFilterValue,
+    TaskRowState,
+    TasksState,
+} from "./tasks-state";
+
+const filterOptions: { label: string; value: TaskFilterValue }[] = [
+    { label: "No filter", value: null },
+    { label: "Completed tasks", value: true },
+    { label: "Incomplete tasks", value: false },
+];
 
 export default function Home() {
     const root = useRoot(
         () => new TasksState(process.env.NEXT_PUBLIC_CONVEX_URL!)
     );
-    const tasks = useNode(root.tasks);
+    const [tasks, queryStatus] = useSelect(root.tasks, (query) => {
+        const tasks = query.state ?? [];
+        return [
+            tasks,
+            query.result.status,
+            tasks.map((task) => task._id).join("|"),
+        ];
+    });
 
     useEffect(() => {
         return () => root.dispose();
     }, [root]);
 
     return (
-        <main className="flex min-h-screen flex-col items-center justify-between p-24">
-            {tasks.state?.map((task) => (
-                <TaskRow
-                    key={task._id}
-                    task={task}
-                    onToggle={(taskId) => void root.toggleCompleted(taskId)}
-                />
-            ))}
+        <main className="min-h-screen bg-zinc-50 px-5 py-8 text-zinc-950 sm:px-8">
+            <section className="mx-auto flex w-full max-w-3xl flex-col gap-5">
+                <header className="flex flex-col gap-4 border-b border-zinc-200 pb-5 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <p className="text-sm font-medium text-zinc-500">
+                            Retree + Convex
+                        </p>
+                        <h1 className="text-3xl font-semibold tracking-normal">
+                            Tasks
+                        </h1>
+                    </div>
+                    <FilterControls root={root} />
+                </header>
+
+                <AddTaskForm root={root} />
+
+                <section className="flex flex-col gap-3">
+                    {queryStatus === "pending" ? (
+                        <div className="rounded-md border border-dashed border-zinc-300 bg-white px-4 py-8 text-center text-sm text-zinc-500">
+                            Loading tasks
+                        </div>
+                    ) : null}
+                    {tasks.map((task) => (
+                        <TaskCard
+                            key={task._id}
+                            task={task}
+                            filter={root.filter}
+                            onToggle={(taskId) =>
+                                void root.toggleCompleted(taskId)
+                            }
+                        />
+                    ))}
+                    {queryStatus !== "pending" && tasks.length === 0 ? (
+                        <div className="rounded-md border border-dashed border-zinc-300 bg-white px-4 py-8 text-center text-sm text-zinc-500">
+                            No tasks yet
+                        </div>
+                    ) : null}
+                </section>
+            </section>
         </main>
     );
 }
 
-function TaskRow({
-    task: taskNode,
+function FilterControls({ root }: { root: TasksState }) {
+    const filter = useNode(root.filter);
+
+    return (
+        <div className="inline-flex rounded-md border border-zinc-200 bg-white p-1 shadow-sm">
+            {filterOptions.map((option) => {
+                const isSelected = filter.isComplete === option.value;
+                return (
+                    <button
+                        key={option.label}
+                        type="button"
+                        aria-pressed={isSelected}
+                        onClick={() => root.setFilter(option.value)}
+                        className={[
+                            "rounded-sm px-3 py-2 text-sm font-medium transition",
+                            isSelected
+                                ? "bg-zinc-900 text-white"
+                                : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-950",
+                        ].join(" ")}
+                    >
+                        {option.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+function AddTaskForm({ root }: { root: TasksState }) {
+    const [text, setText] = useState("");
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const trimmedText = text.trim();
+        if (trimmedText.length === 0) {
+            return;
+        }
+
+        setIsSaving(true);
+        setError(null);
+        try {
+            await root.addTask(trimmedText);
+            setText("");
+        } catch (unknownError) {
+            const message =
+                unknownError instanceof Error
+                    ? unknownError.message
+                    : String(unknownError);
+            setError(message);
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    return (
+        <form
+            onSubmit={(event) => void handleSubmit(event)}
+            className="rounded-md border border-zinc-200 bg-white p-3 shadow-sm"
+        >
+            <div className="flex flex-col gap-2 sm:flex-row">
+                <input
+                    value={text}
+                    onChange={(event) => setText(event.target.value)}
+                    placeholder="Add a task"
+                    className="min-h-11 flex-1 rounded-sm border border-zinc-200 px-3 text-base outline-none transition placeholder:text-zinc-400 focus:border-zinc-500"
+                />
+                <button
+                    type="submit"
+                    disabled={isSaving || text.trim().length === 0}
+                    className="min-h-11 rounded-sm bg-zinc-900 px-4 text-sm font-semibold text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:bg-zinc-300"
+                >
+                    {isSaving ? "Adding" : "Add task"}
+                </button>
+            </div>
+            {error ? (
+                <p className="mt-2 text-sm text-red-600">{error}</p>
+            ) : null}
+        </form>
+    );
+}
+
+function TaskCard({
+    task,
+    filter,
     onToggle,
 }: {
     task: Doc<"tasks">;
+    filter: TaskFilterNode;
     onToggle: (taskId: Id<"tasks">) => void;
 }) {
-    const task = useNode(taskNode);
+    const taskRowNode = useRoot(() => new TaskRowState(task, filter));
+    const taskRow = useNode(taskRowNode);
+
+    if (!taskRow.isVisible) {
+        return null;
+    }
 
     return (
-        <div>
+        <article className="flex items-start gap-3 rounded-md border border-zinc-200 bg-white p-4 shadow-sm">
             <input
                 type="checkbox"
-                checked={task.isCompleted}
-                onChange={() => onToggle(task._id)}
+                checked={taskRow.task.isCompleted}
+                onChange={() => onToggle(taskRow.task._id)}
+                className="mt-1 size-4 accent-zinc-900"
+                aria-label={`Toggle ${taskRow.task.text}`}
             />
-            {task.text}
-        </div>
+            <div className="min-w-0 flex-1">
+                <p
+                    className={[
+                        "break-words text-base font-medium",
+                        taskRow.task.isCompleted
+                            ? "text-zinc-500 line-through"
+                            : "text-zinc-950",
+                    ].join(" ")}
+                >
+                    {taskRow.task.text}
+                </p>
+                <p className="mt-1 text-sm text-zinc-500">
+                    {taskRow.task.isCompleted ? "Completed" : "Incomplete"}
+                </p>
+            </div>
+        </article>
     );
 }

--- a/samples/04.convex-react-nextjs/app/page.tsx
+++ b/samples/04.convex-react-nextjs/app/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useNode, useRoot, useSelect } from "@retreejs/react";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, memo, useEffect } from "react";
 import { Doc, Id } from "../convex/_generated/dataModel";
 import {
+    AddTaskState,
     TaskFilterNode,
     TaskFilterValue,
     TaskRowState,
@@ -17,16 +18,10 @@ const filterOptions: { label: string; value: TaskFilterValue }[] = [
 ];
 
 export default function Home() {
-    const root = useRoot(
-        () => new TasksState(process.env.NEXT_PUBLIC_CONVEX_URL!)
-    );
-    const [tasks, queryStatus] = useSelect(root.tasks, (query) => {
-        const tasks = query.state ?? [];
-        return [
-            tasks,
-            query.result.status,
-            tasks.map((task) => task._id).join("|"),
-        ];
+    const root = useRoot(() => new TasksState());
+    const [tasks, filter, queryStatus] = useSelect(() => {
+        const tasks = root.tasks ?? [];
+        return [tasks, root.filter, root.status] as const;
     });
 
     useEffect(() => {
@@ -45,10 +40,10 @@ export default function Home() {
                             Tasks
                         </h1>
                     </div>
-                    <FilterControls root={root} />
+                    <FilterControls filter={filter} />
                 </header>
 
-                <AddTaskForm root={root} />
+                <AddTaskForm />
 
                 <section className="flex flex-col gap-3">
                     {queryStatus === "pending" ? (
@@ -60,10 +55,8 @@ export default function Home() {
                         <TaskCard
                             key={task._id}
                             task={task}
-                            filter={root.filter}
-                            onToggle={(taskId) =>
-                                void root.toggleCompleted(taskId)
-                            }
+                            onToggle={root.toggleCompleted}
+                            onRename={root.renameTask}
                         />
                     ))}
                     {queryStatus !== "pending" && tasks.length === 0 ? (
@@ -77,19 +70,27 @@ export default function Home() {
     );
 }
 
-function FilterControls({ root }: { root: TasksState }) {
-    const filter = useNode(root.filter);
+const FilterControls = memo(function FilterControls({
+    filter: filterNode,
+}: {
+    filter: TaskFilterNode;
+}) {
+    const filter = useNode(filterNode);
+
+    useEffect(() => {
+        console.log("FilterControls render");
+    });
 
     return (
         <div className="inline-flex rounded-md border border-zinc-200 bg-white p-1 shadow-sm">
             {filterOptions.map((option) => {
-                const isSelected = filter.isComplete === option.value;
+                const isSelected = filter.isCompleted === option.value;
                 return (
                     <button
                         key={option.label}
                         type="button"
                         aria-pressed={isSelected}
-                        onClick={() => root.setFilter(option.value)}
+                        onClick={() => (filter.isCompleted = option.value)}
                         className={[
                             "rounded-sm px-3 py-2 text-sm font-medium transition",
                             isSelected
@@ -103,34 +104,15 @@ function FilterControls({ root }: { root: TasksState }) {
             })}
         </div>
     );
-}
+});
 
-function AddTaskForm({ root }: { root: TasksState }) {
-    const [text, setText] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
-    const [error, setError] = useState<string | null>(null);
+const AddTaskForm = memo(function AddTaskForm() {
+    const addTaskNode = useRoot(() => new AddTaskState());
+    const addTask = useNode(addTaskNode);
 
     async function handleSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
-        const trimmedText = text.trim();
-        if (trimmedText.length === 0) {
-            return;
-        }
-
-        setIsSaving(true);
-        setError(null);
-        try {
-            await root.addTask(trimmedText);
-            setText("");
-        } catch (unknownError) {
-            const message =
-                unknownError instanceof Error
-                    ? unknownError.message
-                    : String(unknownError);
-            setError(message);
-        } finally {
-            setIsSaving(false);
-        }
+        await addTask.submit();
     }
 
     return (
@@ -140,66 +122,72 @@ function AddTaskForm({ root }: { root: TasksState }) {
         >
             <div className="flex flex-col gap-2 sm:flex-row">
                 <input
-                    value={text}
-                    onChange={(event) => setText(event.target.value)}
+                    value={addTask.text}
+                    onChange={(event) => addTask.setText(event.target.value)}
                     placeholder="Add a task"
                     className="min-h-11 flex-1 rounded-sm border border-zinc-200 px-3 text-base outline-none transition placeholder:text-zinc-400 focus:border-zinc-500"
                 />
                 <button
                     type="submit"
-                    disabled={isSaving || text.trim().length === 0}
+                    disabled={!addTask.canSubmit}
                     className="min-h-11 rounded-sm bg-zinc-900 px-4 text-sm font-semibold text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:bg-zinc-300"
                 >
-                    {isSaving ? "Adding" : "Add task"}
+                    {addTask.isSaving ? "Adding" : "Add task"}
                 </button>
             </div>
-            {error ? (
-                <p className="mt-2 text-sm text-red-600">{error}</p>
+            {addTask.error ? (
+                <p className="mt-2 text-sm text-red-600">{addTask.error}</p>
             ) : null}
         </form>
     );
-}
+});
 
-function TaskCard({
+const TaskCard = memo(function TaskCard({
     task,
-    filter,
     onToggle,
+    onRename,
 }: {
     task: Doc<"tasks">;
-    filter: TaskFilterNode;
     onToggle: (taskId: Id<"tasks">) => void;
+    onRename: (taskId: Id<"tasks">, text: string) => Promise<null>;
 }) {
-    const taskRowNode = useRoot(() => new TaskRowState(task, filter));
-    const taskRow = useNode(taskRowNode);
+    const taskRowNode = useRoot(() => new TaskRowState(task));
+    const taskId = useSelect(() => taskRowNode.task._id);
+    const taskText = useSelect(() => taskRowNode.task.text);
+    const isCompleted = useSelect(() => taskRowNode.task.isCompleted);
 
-    if (!taskRow.isVisible) {
-        return null;
-    }
+    useEffect(() => {
+        if (taskRowNode.task === task) return;
+        taskRowNode.updateTask(task);
+    }, [task, taskRowNode]);
 
     return (
         <article className="flex items-start gap-3 rounded-md border border-zinc-200 bg-white p-4 shadow-sm">
             <input
                 type="checkbox"
-                checked={taskRow.task.isCompleted}
-                onChange={() => onToggle(taskRow.task._id)}
+                checked={isCompleted}
+                onChange={() => onToggle(taskId)}
                 className="mt-1 size-4 accent-zinc-900"
-                aria-label={`Toggle ${taskRow.task.text}`}
+                aria-label={`Toggle ${taskText}`}
             />
             <div className="min-w-0 flex-1">
-                <p
+                <input
+                    value={taskText}
+                    onChange={(event) =>
+                        void onRename(taskId, event.target.value)
+                    }
                     className={[
-                        "break-words text-base font-medium",
-                        taskRow.task.isCompleted
+                        "w-full rounded-sm border border-transparent bg-transparent px-0 py-0 text-base font-medium outline-none transition focus:border-zinc-300 focus:bg-white focus:px-2 focus:py-1",
+                        isCompleted
                             ? "text-zinc-500 line-through"
                             : "text-zinc-950",
                     ].join(" ")}
-                >
-                    {taskRow.task.text}
-                </p>
+                    aria-label={`Edit ${taskText}`}
+                />
                 <p className="mt-1 text-sm text-zinc-500">
-                    {taskRow.task.isCompleted ? "Completed" : "Incomplete"}
+                    {isCompleted ? "Completed" : "Incomplete"}
                 </p>
             </div>
         </article>
     );
-}
+});

--- a/samples/04.convex-react-nextjs/app/page.tsx
+++ b/samples/04.convex-react-nextjs/app/page.tsx
@@ -18,15 +18,12 @@ const filterOptions: { label: string; value: TaskFilterValue }[] = [
 ];
 
 export default function Home() {
-    const root = useRoot(() => new TasksState());
-    const [tasks, filter, queryStatus] = useSelect(() => {
-        const tasks = root.tasks ?? [];
-        return [tasks, root.filter, root.status] as const;
-    });
+    const _root = useRoot(() => new TasksState());
+    const root = useNode(_root);
 
     useEffect(() => {
-        return () => root.dispose();
-    }, [root]);
+        return () => _root.dispose();
+    }, [_root]);
 
     return (
         <main className="min-h-screen bg-zinc-50 px-5 py-8 text-zinc-950 sm:px-8">
@@ -40,18 +37,18 @@ export default function Home() {
                             Tasks
                         </h1>
                     </div>
-                    <FilterControls filter={filter} />
+                    <FilterControls filter={root.filter} />
                 </header>
 
                 <AddTaskForm />
 
                 <section className="flex flex-col gap-3">
-                    {queryStatus === "pending" ? (
+                    {root.status === "pending" ? (
                         <div className="rounded-md border border-dashed border-zinc-300 bg-white px-4 py-8 text-center text-sm text-zinc-500">
                             Loading tasks
                         </div>
                     ) : null}
-                    {tasks.map((task) => (
+                    {root.tasks?.map((task) => (
                         <TaskCard
                             key={task._id}
                             task={task}
@@ -59,7 +56,7 @@ export default function Home() {
                             onRename={root.renameTask}
                         />
                     ))}
-                    {queryStatus !== "pending" && tasks.length === 0 ? (
+                    {root.status !== "pending" && root.tasks?.length === 0 ? (
                         <div className="rounded-md border border-dashed border-zinc-300 bg-white px-4 py-8 text-center text-sm text-zinc-500">
                             No tasks yet
                         </div>

--- a/samples/04.convex-react-nextjs/app/tasks-state.ts
+++ b/samples/04.convex-react-nextjs/app/tasks-state.ts
@@ -82,11 +82,13 @@ export class TasksState extends ConvexNode {
     private _tasks: ConvexQueryNode<typeof api.tasks.get>;
     public readonly filter = new TaskFilterNode();
 
-    @select() public get status() {
+    @select
+    public get status() {
         return this._tasks.result?.status;
     }
 
-    @select() public get tasks(): Doc<"tasks">[] | undefined {
+    @select
+    public get tasks(): Doc<"tasks">[] | undefined {
         return this._tasks.state?.filter(
             (task) =>
                 this.filter.isCompleted === null ||

--- a/samples/04.convex-react-nextjs/app/tasks-state.ts
+++ b/samples/04.convex-react-nextjs/app/tasks-state.ts
@@ -1,15 +1,17 @@
 "use client";
 
 import { ReactiveNode, link, select } from "@retreejs/core";
-import { ConvexNode, ConvexQueryNode } from "@retreejs/convex";
+import { BaseConvexNode, ConvexNode, ConvexQueryNode } from "@retreejs/convex";
 import { ConvexClient } from "convex/browser";
 import { api } from "../convex/_generated/api";
-import { Doc, Id } from "../convex/_generated/dataModel";
+import type { Doc, Id } from "../convex/_generated/dataModel";
+
+const convexClient = new ConvexClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export type TaskFilterValue = boolean | null;
 
 export class TaskFilterNode extends ReactiveNode {
-    public isComplete: TaskFilterValue = null;
+    public isCompleted: boolean | null = null;
 
     get dependencies() {
         return [];
@@ -20,39 +22,14 @@ export class TaskRowState extends ReactiveNode {
     @link
     public task: Doc<"tasks">;
 
-    @link
-    public filter: TaskFilterNode;
-
-    constructor(task: Doc<"tasks">, filter: TaskFilterNode) {
+    constructor(task: Doc<"tasks">) {
         super();
         this.task = task;
-        this.filter = filter;
     }
 
-    @select((self: TaskRowState) => {
-        const isVisible =
-            self.filter.isComplete === null ||
-            self.task.isCompleted === self.filter.isComplete;
-        if (isVisible) {
-            return [
-                self.task,
-                self.filter,
-                self.filter.isComplete,
-                self.task.isCompleted,
-            ];
-        }
-
-        return [
-            self.dependency(self.task, [self.task.isCompleted]),
-            self.filter,
-            self.filter.isComplete,
-        ];
-    })
-    get isVisible() {
-        return (
-            this.filter.isComplete === null ||
-            this.task.isCompleted === this.filter.isComplete
-        );
+    public updateTask(task: Doc<"tasks">) {
+        if (this.task === task) return;
+        this.task = task;
     }
 
     get dependencies() {
@@ -60,14 +37,66 @@ export class TaskRowState extends ReactiveNode {
     }
 }
 
+export class AddTaskState extends BaseConvexNode {
+    public text = "";
+    public isSaving = false;
+    public error: string | null = null;
+
+    constructor() {
+        super(convexClient);
+    }
+
+    get dependencies() {
+        return [];
+    }
+
+    get canSubmit() {
+        return this.text.length > 0 && !this.isSaving;
+    }
+
+    public setText(text: string): void {
+        this.text = text;
+    }
+
+    public async submit(): Promise<void> {
+        if (this.text.length === 0) return;
+
+        this.isSaving = true;
+        this.error = null;
+        try {
+            const createTask = this.mutation(api.tasks.create);
+            await createTask({ text: this.text });
+            this.text = "";
+        } catch (unknownError) {
+            this.error =
+                unknownError instanceof Error
+                    ? unknownError.message
+                    : String(unknownError);
+        } finally {
+            this.isSaving = false;
+        }
+    }
+}
+
 export class TasksState extends ConvexNode {
-    public readonly tasks: ConvexQueryNode<typeof api.tasks.get>;
+    private _tasks: ConvexQueryNode<typeof api.tasks.get>;
     public readonly filter = new TaskFilterNode();
 
-    constructor(convexUrl: string) {
-        const client = new ConvexClient(convexUrl);
-        super(client);
-        this.tasks = this.query(api.tasks.get, { initialState: [] });
+    @select() public get status() {
+        return this._tasks.result?.status;
+    }
+
+    @select() public get tasks(): Doc<"tasks">[] | undefined {
+        return this._tasks.state?.filter(
+            (task) =>
+                this.filter.isCompleted === null ||
+                task.isCompleted === this.filter.isCompleted
+        );
+    }
+
+    constructor() {
+        super(convexClient);
+        this._tasks = this.query(api.tasks.get, { initialState: [] });
     }
 
     get dependencies() {
@@ -75,17 +104,7 @@ export class TasksState extends ConvexNode {
     }
 
     public dispose(): void {
-        this.tasks.dispose();
-        void this.client.close();
-    }
-
-    public setFilter(isComplete: TaskFilterValue): void {
-        this.filter.isComplete = isComplete;
-    }
-
-    public addTask(text: string): Promise<Id<"tasks">> {
-        const createTask = this.mutation(api.tasks.create);
-        return createTask({ text });
+        this._tasks.dispose();
     }
 
     public toggleCompleted(taskId: Id<"tasks">): Promise<null> {
@@ -96,7 +115,7 @@ export class TasksState extends ConvexNode {
             { taskId },
             {
                 withOptimisticUpdate: (ctx) => {
-                    this.tasks.optimisticUpdate({
+                    this._tasks.optimisticUpdate({
                         ctx,
                         apply(tasks) {
                             const task = tasks.find(
@@ -104,6 +123,27 @@ export class TasksState extends ConvexNode {
                             );
                             if (!task) return;
                             task.isCompleted = !task.isCompleted;
+                        },
+                    });
+                },
+            }
+        );
+    }
+
+    public renameTask(taskId: Id<"tasks">, text: string): Promise<null> {
+        const updateTextMutation = this.mutation(api.tasks.updateText);
+        return updateTextMutation(
+            { taskId, text },
+            {
+                withOptimisticUpdate: (ctx) => {
+                    this._tasks.optimisticUpdate({
+                        ctx,
+                        apply(tasks) {
+                            const task = tasks.find(
+                                (candidateTask) => candidateTask._id === taskId
+                            );
+                            if (!task) return;
+                            task.text = text;
                         },
                     });
                 },

--- a/samples/04.convex-react-nextjs/app/tasks-state.ts
+++ b/samples/04.convex-react-nextjs/app/tasks-state.ts
@@ -1,17 +1,73 @@
 "use client";
 
+import { ReactiveNode, link, select } from "@retreejs/core";
 import { ConvexNode, ConvexQueryNode } from "@retreejs/convex";
 import { ConvexClient } from "convex/browser";
 import { api } from "../convex/_generated/api";
-import { Id } from "../convex/_generated/dataModel";
+import { Doc, Id } from "../convex/_generated/dataModel";
+
+export type TaskFilterValue = boolean | null;
+
+export class TaskFilterNode extends ReactiveNode {
+    public isComplete: TaskFilterValue = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+
+export class TaskRowState extends ReactiveNode {
+    @link
+    public task: Doc<"tasks">;
+
+    @link
+    public filter: TaskFilterNode;
+
+    constructor(task: Doc<"tasks">, filter: TaskFilterNode) {
+        super();
+        this.task = task;
+        this.filter = filter;
+    }
+
+    @select((self: TaskRowState) => {
+        const isVisible =
+            self.filter.isComplete === null ||
+            self.task.isCompleted === self.filter.isComplete;
+        if (isVisible) {
+            return [
+                self.task,
+                self.filter,
+                self.filter.isComplete,
+                self.task.isCompleted,
+            ];
+        }
+
+        return [
+            self.dependency(self.task, [self.task.isCompleted]),
+            self.filter,
+            self.filter.isComplete,
+        ];
+    })
+    get isVisible() {
+        return (
+            this.filter.isComplete === null ||
+            this.task.isCompleted === this.filter.isComplete
+        );
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
 
 export class TasksState extends ConvexNode {
     public readonly tasks: ConvexQueryNode<typeof api.tasks.get>;
+    public readonly filter = new TaskFilterNode();
 
     constructor(convexUrl: string) {
         const client = new ConvexClient(convexUrl);
         super(client);
-        this.tasks = this.query(api.tasks.get);
+        this.tasks = this.query(api.tasks.get, { initialState: [] });
     }
 
     get dependencies() {
@@ -21,6 +77,15 @@ export class TasksState extends ConvexNode {
     public dispose(): void {
         this.tasks.dispose();
         void this.client.close();
+    }
+
+    public setFilter(isComplete: TaskFilterValue): void {
+        this.filter.isComplete = isComplete;
+    }
+
+    public addTask(text: string): Promise<Id<"tasks">> {
+        const createTask = this.mutation(api.tasks.create);
+        return createTask({ text });
     }
 
     public toggleCompleted(taskId: Id<"tasks">): Promise<null> {

--- a/samples/04.convex-react-nextjs/app/tasks-state.ts
+++ b/samples/04.convex-react-nextjs/app/tasks-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactiveNode, link, select } from "@retreejs/core";
+import { ReactiveNode, fnMemo, link, memo, select } from "@retreejs/core";
 import { BaseConvexNode, ConvexNode, ConvexQueryNode } from "@retreejs/convex";
 import { ConvexClient } from "convex/browser";
 import { api } from "../convex/_generated/api";
@@ -27,8 +27,8 @@ export class TaskRowState extends ReactiveNode {
         this.task = task;
     }
 
+    @fnMemo
     public updateTask(task: Doc<"tasks">) {
-        if (this.task === task) return;
         this.task = task;
     }
 
@@ -50,10 +50,12 @@ export class AddTaskState extends BaseConvexNode {
         return [];
     }
 
+    @memo
     get canSubmit() {
         return this.text.length > 0 && !this.isSaving;
     }
 
+    @fnMemo
     public setText(text: string): void {
         this.text = text;
     }

--- a/samples/04.convex-react-nextjs/convex/tasks.ts
+++ b/samples/04.convex-react-nextjs/convex/tasks.ts
@@ -13,13 +13,12 @@ export const create = mutation({
         text: v.string(),
     },
     handler: async (ctx, { text }) => {
-        const trimmedText = text.trim();
-        if (trimmedText.length === 0) {
+        if (text.length === 0) {
             throw new Error("Task text is required.");
         }
 
         return await ctx.db.insert("tasks", {
-            text: trimmedText,
+            text,
             isCompleted: false,
         });
     },
@@ -37,6 +36,23 @@ export const toggleCompleted = mutation({
 
         await ctx.db.patch(taskId, {
             isCompleted: !task.isCompleted,
+        });
+    },
+});
+
+export const updateText = mutation({
+    args: {
+        taskId: v.id("tasks"),
+        text: v.string(),
+    },
+    handler: async (ctx, { taskId, text }) => {
+        const task = await ctx.db.get(taskId);
+        if (task === null) {
+            throw new Error(`Task not found for id ${taskId}`);
+        }
+
+        await ctx.db.patch(taskId, {
+            text,
         });
     },
 });

--- a/samples/04.convex-react-nextjs/convex/tasks.ts
+++ b/samples/04.convex-react-nextjs/convex/tasks.ts
@@ -4,7 +4,24 @@ import { mutation, query } from "./_generated/server";
 export const get = query({
     args: {},
     handler: async (ctx) => {
-        return await ctx.db.query("tasks").collect();
+        return await ctx.db.query("tasks").order("desc").collect();
+    },
+});
+
+export const create = mutation({
+    args: {
+        text: v.string(),
+    },
+    handler: async (ctx, { text }) => {
+        const trimmedText = text.trim();
+        if (trimmedText.length === 0) {
+            throw new Error("Task text is required.");
+        }
+
+        return await ctx.db.insert("tasks", {
+            text: trimmedText,
+            isCompleted: false,
+        });
     },
 });
 

--- a/samples/04.convex-react-nextjs/next.config.ts
+++ b/samples/04.convex-react-nextjs/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
     reactCompiler: true,
+    transpilePackages: [
+        "@retreejs/core",
+        "@retreejs/react",
+        "@retreejs/convex",
+    ],
+    turbopack: {
+        root: path.join(__dirname, "../.."),
+    },
+    webpack(config) {
+        config.resolve ??= {};
+        config.resolve.symlinks = false;
+        return config;
+    },
 };
 
 export default nextConfig;

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.1",
+                "@retreejs/core": "0.4.0",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.3.0",
+                "@retreejs/core": "0.3.1",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }


### PR DESCRIPTION
- Added `link`, `move`, `moveTo`, and `clone` APIs
- Improved error messages
- `link` decorator for storing references to variables that are owned by another retree node
- Improved docs and llms.txt
- `useSelect`, `select`, `memo`, and `fnMemo` now auto trap dependencies
- More flexible dependencies array in `ReactiveNode`
- Published up to 0.4.1