### PR TITLE
Link pre-proxy reference fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12830,11 +12830,11 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.4.8"
+                "@retreejs/core": "0.4.9"
             },
             "bin": {
                 "retree-benchmark": "bin/cli.js"
@@ -12848,22 +12848,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -12879,34 +12879,34 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "packages/retree-react-convex": {
             "name": "@retreejs/react-convex",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/convex": "0.4.8",
+                "@retreejs/convex": "0.4.9",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/convex": "0.4.8",
+                "@retreejs/convex": "0.4.9",
                 "convex": "^1.39.1"
             }
         },
@@ -12915,7 +12915,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.4.8"
+                "@retreejs/core": "0.4.9"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13364,8 +13364,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.8",
-                "@retreejs/react": "0.4.8",
+                "@retreejs/core": "0.4.9",
+                "@retreejs/react": "0.4.9",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13385,8 +13385,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.8",
-                "@retreejs/react": "0.4.8",
+                "@retreejs/core": "0.4.9",
+                "@retreejs/react": "0.4.9",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12830,11 +12830,11 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.4.9"
+                "@retreejs/core": "0.4.10"
             },
             "bin": {
                 "retree-benchmark": "bin/cli.js"
@@ -12848,22 +12848,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -12879,34 +12879,34 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "packages/retree-react-convex": {
             "name": "@retreejs/react-convex",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/convex": "0.4.9",
+                "@retreejs/convex": "0.4.10",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/convex": "0.4.9",
+                "@retreejs/convex": "0.4.10",
                 "convex": "^1.39.1"
             }
         },
@@ -12915,7 +12915,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.4.9"
+                "@retreejs/core": "0.4.10"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13364,8 +13364,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.9",
-                "@retreejs/react": "0.4.9",
+                "@retreejs/core": "0.4.10",
+                "@retreejs/react": "0.4.10",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13385,8 +13385,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.9",
-                "@retreejs/react": "0.4.9",
+                "@retreejs/core": "0.4.10",
+                "@retreejs/react": "0.4.10",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.4.8"
+        "@retreejs/core": "0.4.9"
     },
     "devDependencies": {
         "@types/node": "^20.2.3",

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.4.9"
+        "@retreejs/core": "0.4.10"
     },
     "devDependencies": {
         "@types/node": "^20.2.3",

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -13,13 +13,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.4.8",
+        "@retreejs/core": "0.4.9",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.8",
+        "@retreejs/core": "0.4.9",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -13,13 +13,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.4.9",
+        "@retreejs/core": "0.4.10",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.9",
+        "@retreejs/core": "0.4.10",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
-import { ignore } from "./decorators";
+import { ignore, link } from "./decorators";
 import { getCustomProxyHandler, getUnproxiedNode } from "./internals";
 import { proxiedChildrenKey } from "./internals/proxy-types";
 import {
@@ -229,6 +229,46 @@ class OptionalDependencyNode extends ReactiveNode {
         return [
             this.dependency(this.dependencyNode, [
                 this.dependencyNode?.length ?? null,
+            ]),
+        ];
+    }
+}
+
+class ValueChangeTrackerNode extends ReactiveNode {
+    public valueChangeCountsById: Record<string, number> = { valueA: 0 };
+
+    public valueChangeCountFor(valueId: string): number {
+        return this.valueChangeCountsById[valueId] ?? 0;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class ProjectNode extends ReactiveNode {
+    public changeTracker = new ValueChangeTrackerNode();
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class ValueBackingDependencyNode extends ReactiveNode {
+    @link
+    public project: ProjectNode | null = null;
+    public _backing = {
+        valueId: "valueA",
+    };
+
+    get dependencies() {
+        return [
+            this.dependency(this.project?.changeTracker.valueChangeCountsById, [
+                this._backing.valueId
+                    ? this.project?.changeTracker.valueChangeCountFor(
+                          this._backing.valueId
+                      ) ?? 0
+                    : 0,
             ]),
         ];
     }
@@ -704,6 +744,42 @@ describe("ReactiveNode", () => {
         nodeChanged.mockClear();
 
         dependencyNode.push(1);
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits when an explicit object dependency comparison changes by keyed increment", () => {
+        const root = trackRoot(
+            Retree.root({
+                project: new ProjectNode(),
+                dependent: new ValueBackingDependencyNode(),
+            })
+        );
+        const nodeChanged = vi.fn();
+
+        root.dependent.project = root.project;
+        Retree.on(root.dependent, "nodeChanged", nodeChanged);
+        nodeChanged.mockClear();
+
+        root.project.changeTracker.valueChangeCountsById.valueA++;
+
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("subscribes to an explicit object dependency when an optional link becomes available", () => {
+        const root = trackRoot(
+            Retree.root({
+                project: new ProjectNode(),
+                dependent: new ValueBackingDependencyNode(),
+            })
+        );
+        const nodeChanged = vi.fn();
+
+        Retree.on(root.dependent, "nodeChanged", nodeChanged);
+        root.dependent.project = root.project;
+        nodeChanged.mockClear();
+
+        root.project.changeTracker.valueChangeCountsById.valueA++;
 
         expect(nodeChanged).toHaveBeenCalledTimes(1);
     });

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -840,6 +840,41 @@ describe("Retree", () => {
         }).toThrow(/Retree.move/);
     });
 
+    it("enforces the single-parent rule for raw objects that already belong to a tree", () => {
+        const rawChild = { value: 1 };
+        const root1 = trackRoot(Retree.root({ child: rawChild }));
+        const root2 = trackRoot(
+            Retree.root({ other: null as null | { value: number } })
+        );
+
+        expect(root1.child).toBeDefined();
+        expect(() => {
+            root2.other = rawChild;
+        }).toThrow(/already has a structural parent/i);
+        expect(() => {
+            root2.other = rawChild;
+        }).toThrow(/Current parent: Object at key child/i);
+        expect(() => {
+            root2.other = rawChild;
+        }).toThrow(/Retree.move/);
+    });
+
+    it("reads raw aliases to managed nodes without changing structural parentage", () => {
+        const rawChild = { value: 1 };
+        const root = trackRoot(
+            Retree.root({
+                child: rawChild,
+                alias: { data: rawChild },
+            })
+        );
+
+        expect(root.child).toBeDefined();
+        const aliasData = root.alias.data;
+
+        expect(getUnproxiedNode(aliasData)).toBe(getUnproxiedNode(root.child));
+        expect(Retree.parent(aliasData)).toBe(root);
+    });
+
     it("stores a Retree.link without reparenting the linked target", () => {
         const source = trackRoot(Retree.root({ child: { value: 1 } }));
         const owner = trackRoot(

--- a/packages/retree-core/src/decorators.spec.ts
+++ b/packages/retree-core/src/decorators.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReactiveNode } from "./ReactiveNode";
 import { Retree } from "./Retree";
 import { ignore, link, memo, select } from "./decorators";
+import { getUnproxiedNode } from "./internals";
 import { getReproxyNode } from "./internals/reproxy";
 import { Transactions } from "./internals/transactions";
 
@@ -40,6 +41,34 @@ class LinkedPointerNode extends ReactiveNode {
 
     @link
     public selected: { value: number } | null = null;
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class ConstructorLinkedChildNode extends ReactiveNode {
+    @link
+    public parent: ConstructorLinkedParentNode;
+
+    constructor(parent: ConstructorLinkedParentNode) {
+        super();
+        this.parent = parent;
+    }
+
+    get dependencies() {
+        return [];
+    }
+}
+
+class ConstructorLinkedParentNode extends ReactiveNode {
+    public value = 0;
+    public child: ConstructorLinkedChildNode;
+
+    constructor() {
+        super();
+        this.child = new ConstructorLinkedChildNode(this);
+    }
 
     get dependencies() {
         return [];
@@ -404,6 +433,42 @@ describe("link", () => {
         }
         expect(selectedAfterChange).not.toBe(selectedBeforeChange);
         expect(selectedAfterChange.value).toBe(1);
+    });
+
+    it("resolves a raw constructor-time self reference to the managed parent proxy", () => {
+        const state = trackRoot(Retree.root(new ConstructorLinkedParentNode()));
+
+        expect(getUnproxiedNode(state.child.parent)).toBe(
+            getUnproxiedNode(state)
+        );
+    });
+
+    it("returns the latest reproxy for a raw constructor-time linked parent", () => {
+        const state = trackRoot(Retree.root(new ConstructorLinkedParentNode()));
+        const parentBeforeChange = state.child.parent;
+
+        state.value = 1;
+
+        expect(state.child.parent).not.toBe(parentBeforeChange);
+        expect(state.child.parent.value).toBe(1);
+    });
+
+    it("allows assigning a raw object to @link after that object belongs to a Retree tree", () => {
+        const rawChild = { value: 0 };
+        const source = trackRoot(Retree.root({ child: rawChild }));
+        const owner = trackRoot(Retree.root(new LinkedPointerNode()));
+
+        expect(source.child).toBeDefined();
+        owner.selected = rawChild;
+        const selectedBeforeChange = owner.selected;
+
+        source.child.value = 1;
+
+        expect(owner.selected).not.toBe(selectedBeforeChange);
+        expect(owner.selected?.value).toBe(1);
+        expect(getUnproxiedNode(owner.selected)).toBe(
+            getUnproxiedNode(source.child)
+        );
     });
 });
 

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -23,8 +23,10 @@ import {
 } from "./proxy-types";
 import { getReactiveNodeGetter, popMemoGetter, pushMemoGetter } from "./memo";
 import {
+    getManagedProxyForUnproxiedNode,
     getReproxyNode,
     getReproxyNodeForUnproxiedNode,
+    registerBaseProxy,
     updateReproxyNode,
 } from "./reproxy";
 import {
@@ -123,6 +125,16 @@ function getLatestIgnoredValue(value: unknown) {
     return value;
 }
 
+function getLatestLinkedValue(value: unknown) {
+    if (isCustomProxy(value)) {
+        return getReproxyNode(value);
+    }
+    if (value !== null && typeof value === "object") {
+        return getManagedProxyForUnproxiedNode(value as TreeNode) ?? value;
+    }
+    return value;
+}
+
 function assertValidLinkedValue(prop: string | symbol, value: unknown) {
     if (value === null || value === undefined) {
         return;
@@ -133,11 +145,14 @@ function assertValidLinkedValue(prop: string | symbol, value: unknown) {
     if (isCustomProxy(value)) {
         return;
     }
+    if (getManagedProxyForUnproxiedNode(value as TreeNode) !== undefined) {
+        return;
+    }
     // @retree-throws
     throw new Error(
         `@link field ${String(
             prop
-        )} can only store a Retree-managed node, null, undefined, or a non-object leaf value. This is expected when assigning a plain object to @link. Fix: pass the object through Retree.root(...) or read it from an existing Retree tree first; use @ignore for non-reactive objects that should not be managed by Retree.`
+        )} can only store a Retree-managed node, a raw node that already belongs to a Retree tree, null, undefined, or a non-object leaf value. This is expected when assigning a plain object to @link. Fix: pass the object through Retree.root(...) or read it from an existing Retree tree first; use @ignore for non-reactive objects that should not be managed by Retree.`
     );
 }
 
@@ -157,6 +172,11 @@ export function buildProxy<T extends TreeNode = TreeNode>(
     parent?: IProxyParent<any>
 ): T {
     let isApplyingSet = false;
+    if (object === null) return object;
+    const existingManagedProxy = getManagedProxyForUnproxiedNode(object);
+    if (existingManagedProxy !== undefined) {
+        return existingManagedProxy as T;
+    }
     const boundFunctionCache = new Map<
         string | symbol,
         BoundFunctionCacheEntry
@@ -191,7 +211,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     return trackDependencyPropertyAccess(
                         getBaseProxy(receiver),
                         prop,
-                        getLatestIgnoredValue(Reflect.get(target, prop, target))
+                        getLatestLinkedValue(Reflect.get(target, prop, target))
                     );
                 }
             }
@@ -609,9 +629,9 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             return returnValue;
         },
     };
-    if (object === null) return object;
     if (isCustomProxy(object)) return getBaseProxy(object);
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
+    registerBaseProxy(object, proxy);
     if (object instanceof Map) {
         for (const [key, value] of object.entries()) {
             if (isCustomProxy(value)) {

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -173,10 +173,6 @@ export function buildProxy<T extends TreeNode = TreeNode>(
 ): T {
     let isApplyingSet = false;
     if (object === null) return object;
-    const existingManagedProxy = getManagedProxyForUnproxiedNode(object);
-    if (existingManagedProxy !== undefined) {
-        return existingManagedProxy as T;
-    }
     const boundFunctionCache = new Map<
         string | symbol,
         BoundFunctionCacheEntry
@@ -422,10 +418,23 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     if (isCustomProxy(newValue)) {
                         valueToSet = reparentProxy(newValue, parentToSet);
                         proxyHandler[proxiedChildrenKey][prop] = valueToSet;
+                    } else if (
+                        getManagedProxyForUnproxiedNode(newValue) !== undefined
+                    ) {
+                        valueToSet = createStructuralProxyForValue(
+                            newValue,
+                            parentToSet,
+                            emitter
+                        );
+                        proxyHandler[proxiedChildrenKey][prop] = valueToSet;
                     } else if (shouldCreatePlainObjectProxyLazily(newValue)) {
                         deleteProxiedChild(proxyHandler, prop);
                     } else {
-                        valueToSet = buildProxy(newValue, emitter, parentToSet);
+                        valueToSet = createStructuralProxyForValue(
+                            newValue,
+                            parentToSet,
+                            emitter
+                        );
                         proxyHandler[proxiedChildrenKey][prop] = valueToSet;
                     }
                 } else {
@@ -842,10 +851,29 @@ function getOrCreateProxiedChild(
         proxyNode: baseProxy,
         propName: prop,
     };
-    const childProxy = buildProxy(value, emitter, parentToSet);
+    const existingManagedProxy = getManagedProxyForUnproxiedNode(value);
+    const childProxy =
+        existingManagedProxy === undefined
+            ? createStructuralProxyForValue(value, parentToSet, emitter)
+            : existingManagedProxy;
     const baseChildProxy = getBaseProxy(childProxy);
     proxyHandler[proxiedChildrenKey][prop] = baseChildProxy;
     return baseChildProxy;
+}
+
+function createStructuralProxyForValue(
+    value: object,
+    parentToSet: IProxyParent<any>,
+    emitter: TreeChangeEmitter
+): object {
+    if (isCustomProxy(value)) {
+        return reparentProxy(value, parentToSet);
+    }
+    const existingManagedProxy = getManagedProxyForUnproxiedNode(value);
+    if (existingManagedProxy !== undefined) {
+        return reparentProxy(existingManagedProxy, parentToSet);
+    }
+    return buildProxy(value, emitter, parentToSet);
 }
 
 function isProxyableObject(value: unknown): value is object {
@@ -880,9 +908,11 @@ function preparePropertyValue(
         proxyNode: baseProxy,
         propName: prop,
     };
-    const valueToSet = isCustomProxy(value)
-        ? reparentProxy(value, parentToSet)
-        : buildProxy(value, emitter, parentToSet);
+    const valueToSet = createStructuralProxyForValue(
+        value,
+        parentToSet,
+        emitter
+    );
     proxyHandler[proxiedChildrenKey][prop] = valueToSet;
     return valueToSet;
 }
@@ -972,9 +1002,11 @@ function getOrCreateMapValueProxy(
         proxyNode: baseProxy,
         propName: mapKeyAsPropName(key),
     };
-    const valueToRead = isCustomProxy(value)
-        ? reparentProxy(value, parentToSet)
-        : buildProxy(value, emitter, parentToSet);
+    const valueToRead = createStructuralProxyForValue(
+        value,
+        parentToSet,
+        emitter
+    );
     if (valueToRead !== value) {
         Map.prototype.set.call(target, key, valueToRead);
     }
@@ -1134,9 +1166,11 @@ function getOrCreateSetValueProxy(
         proxyNode: baseProxy,
         propName: null,
     };
-    const valueToRead = isCustomProxy(value)
-        ? reparentProxy(value, parentToSet)
-        : buildProxy(value, emitter, parentToSet);
+    const valueToRead = createStructuralProxyForValue(
+        value,
+        parentToSet,
+        emitter
+    );
     if (valueToRead !== value) {
         Set.prototype.delete.call(target, value);
         Set.prototype.add.call(target, valueToRead);

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -32,6 +32,14 @@ import {
 } from "./proxy-types";
 
 const reproxyMap: WeakMap<TreeNode, TCustomProxy<TreeNode>> = new WeakMap();
+const baseProxyMap: WeakMap<TreeNode, TCustomProxy<TreeNode>> = new WeakMap();
+
+export function registerBaseProxy<T extends TreeNode = TreeNode>(
+    unproxiedNode: T,
+    baseProxy: TCustomProxy<T>
+): void {
+    baseProxyMap.set(unproxiedNode, baseProxy);
+}
 
 export function updateReproxyNode<T extends TreeNode = TreeNode>(
     node: TCustomProxy<T>
@@ -66,6 +74,15 @@ export function getReproxyNodeForUnproxiedNode<T extends TreeNode = TreeNode>(
     unproxiedNode: T
 ): TCustomProxy<T> | undefined {
     return reproxyMap.get(unproxiedNode) as TCustomProxy<T> | undefined;
+}
+
+export function getManagedProxyForUnproxiedNode<T extends TreeNode = TreeNode>(
+    unproxiedNode: T
+): TCustomProxy<T> | undefined {
+    return (
+        getReproxyNodeForUnproxiedNode(unproxiedNode) ??
+        (baseProxyMap.get(unproxiedNode) as TCustomProxy<T> | undefined)
+    );
 }
 
 function buildReproxy<T extends TreeNode = TreeNode>(
@@ -106,7 +123,7 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                     );
                 }
                 if (target[LINKED_KEYS_SYMBOL].has(prop)) {
-                    return getLatestIgnoredValue(
+                    return getLatestLinkedValue(
                         Reflect.get(target, prop, target)
                     );
                 }
@@ -208,6 +225,18 @@ function buildReproxy<T extends TreeNode = TreeNode>(
 function getLatestIgnoredValue(value: unknown) {
     if (isCustomProxy(value)) {
         return trackDependencyAccess(getReproxyNode(value));
+    }
+    return trackDependencyAccess(value);
+}
+
+function getLatestLinkedValue(value: unknown) {
+    if (isCustomProxy(value)) {
+        return trackDependencyAccess(getReproxyNode(value));
+    }
+    if (value !== null && typeof value === "object") {
+        return trackDependencyAccess(
+            getManagedProxyForUnproxiedNode(value as TreeNode) ?? value
+        );
     }
     return trackDependencyAccess(value);
 }

--- a/packages/retree-react-convex/package.json
+++ b/packages/retree-react-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react-convex",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "Use ConvexReactClient with Retree Convex nodes.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,13 +14,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/convex": "0.4.8",
+        "@retreejs/convex": "0.4.9",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/convex": "0.4.8",
+        "@retreejs/convex": "0.4.9",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-react-convex/package.json
+++ b/packages/retree-react-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react-convex",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "Use ConvexReactClient with Retree Convex nodes.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,13 +14,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/convex": "0.4.9",
+        "@retreejs/convex": "0.4.10",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/convex": "0.4.9",
+        "@retreejs/convex": "0.4.10",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.4.8",
+        "@retreejs/core": "0.4.9",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.8",
+        "@retreejs/core": "0.4.9",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -14,14 +14,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.4.9",
+        "@retreejs/core": "0.4.10",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.9",
+        "@retreejs/core": "0.4.10",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.9"
+        "@retreejs/core": "0.4.10"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.8"
+        "@retreejs/core": "0.4.9"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.4.8",
-        "@retreejs/react": "0.4.8"
+        "@retreejs/core": "0.4.9",
+        "@retreejs/react": "0.4.9"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.4.9",
-        "@retreejs/react": "0.4.9"
+        "@retreejs/core": "0.4.10",
+        "@retreejs/react": "0.4.10"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.9",
-        "@retreejs/react": "0.4.9",
+        "@retreejs/core": "0.4.10",
+        "@retreejs/react": "0.4.10",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.8",
-        "@retreejs/react": "0.4.8",
+        "@retreejs/core": "0.4.9",
+        "@retreejs/react": "0.4.9",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.8",
+                "@retreejs/core": "0.4.9",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -836,7 +836,7 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.8",
+            "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
@@ -909,7 +909,7 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.8",
+            "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
@@ -975,7 +975,7 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.8",
+            "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
@@ -5085,7 +5085,7 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.8",
+            "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
@@ -5158,7 +5158,7 @@
             }
         },
         "node_modules/levn": {
-            "version": "0.4.8",
+            "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
@@ -6831,7 +6831,7 @@
             "license": "0BSD"
         },
         "node_modules/type-check": {
-            "version": "0.4.8",
+            "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.9",
+                "@retreejs/core": "0.4.10",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -836,7 +836,7 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.9",
+            "version": "0.4.10",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
@@ -909,7 +909,7 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.9",
+            "version": "0.4.10",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
@@ -975,7 +975,7 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.9",
+            "version": "0.4.10",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
@@ -5085,7 +5085,7 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.9",
+            "version": "0.4.10",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
@@ -5158,7 +5158,7 @@
             }
         },
         "node_modules/levn": {
-            "version": "0.4.9",
+            "version": "0.4.10",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
@@ -6831,7 +6831,7 @@
             "license": "0BSD"
         },
         "node_modules/type-check": {
-            "version": "0.4.9",
+            "version": "0.4.10",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,


### PR DESCRIPTION
- Fixed bug where setting a link via a base unproxied object during constuction caused link to store reference to unproxied object.
- Bump to 0.4.10