### PR TITLE
Performance enhancement, `raw`, `useRaw`, `peekInto`, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ npx skills use ryanbliss/retree@retree
 -   [`Retree.on`](#core-api-examples) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
 -   [`Retree.select`](#core-api-examples) is the non-React version of `useSelect`. Use it to narrow notifications; it is not a cache.
 -   [`Retree.parent`](#core-api-examples) returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+-   [`Retree.raw`](#core-api-examples) returns the raw, proxy-free object behind a node for native-speed, read-only access. Raw subtrees are guaranteed proxy-free.
+-   [`Retree.source`](#core-api-examples) resolves a raw value back to its managed node — the inverse of `Retree.raw`.
+-   [`Retree.peekInto`](#core-api-examples) runs a read-only query against a node's raw object and resolves the result to its managed node when one exists.
+-   [`Retree.untracked`](#core-api-examples) pauses dependency tracking during a synchronous callback, for bulk reads inside tracked selectors and memo getters.
+-   [`useRaw`](#useraw-hook) subscribes like `useNode` but returns `[raw, toSource]` for native-speed, proxy-free render reads. Use it for components that read wide.
 -   [`Retree.move`](#core-api-examples) transfers an existing node to a new structural parent. Use it when ownership should change.
 -   [`Retree.link` and `@link`](#core-api-examples) store a reactive pointer without reparenting. Use them for selected items and cross-references.
 -   [`Retree.clone`](#core-api-examples) makes a detached copy. Use it when two places need independent state.
@@ -270,6 +275,43 @@ const [, , attribute] = useSelect(row, (self) => [
 Dependency-list subscriptions in `useSelect` are observational: selected dependency changes can re-render the component, but they do not force the node passed to `useSelect` to receive a fresh reproxy. Use `@select` when a `ReactiveNode` owner should emit `nodeChanged`.
 
 `useSelect` is a subscription primitive, not a memo cache. Use `memo`, `@memo`, or `@fnMemo` for expensive computation you want to cache, then select the cached value when you want narrower renders.
+
+#### useRaw hook
+
+Use `useRaw` when a component reads wide during render — big tables, canvas
+layers, subtree serialization. It subscribes exactly like `useNode`
+(`nodeChanged` by default) but returns `[raw, toSource]`: the live raw object
+for native-speed, proxy-free reads plus a resolver back to managed nodes.
+
+```tsx
+import React from "react";
+import { useNode, useRaw } from "@retreejs/react";
+
+function TaskListView({ list }: { list: TaskList }) {
+    // Re-renders only when the array itself changes: add / remove / reorder.
+    const [tasksRaw, toSource] = useRaw(list.tasks);
+    return (
+        <ul>
+            {tasksRaw.map((rawTask) => (
+                <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+            ))}
+        </ul>
+    );
+}
+
+const TaskRow = React.memo(function TaskRow({ task }: { task: Task }) {
+    const t = useNode(task); // node prop: own subscription, write surface
+    return <li onClick={() => (t.isComplete = !t.isComplete)}>{t.title}</li>;
+});
+```
+
+Pass **nodes** to children via `toSource`, never raw values — nodes carry
+subscriptions, writes, and identity; raw is a local read view. `toSource`
+always resolves direct children of the subscribed node (object/array
+children, Map values, Set members). Deep changes re-render only when declared
+— via the node's `dependencies` / `@select`, via `useSelect` for derived
+views, or via the `treeChanged` opt-in. Never write to raw values or use raw
+references as `React.memo` props or `useMemo` deps.
 
 #### useTree hook
 
@@ -985,6 +1027,28 @@ class ProjectState extends ReactiveNode {
 const root = Retree.root(new ProjectState());
 root.prepareTree({ depth: 1 });
 ```
+
+Use `Retree.raw` for native-speed, read-only scans; `Retree.source` to
+resolve raw values back to managed nodes; `Retree.peekInto` to query raw and
+get the managed result in one call; and `Retree.untracked` to pause
+dependency tracking during bulk reads:
+
+```ts
+const rawTasks = Retree.raw(tree.todos); // ✅ proxy-free, native-speed reads
+const found = Retree.peekInto(tree.todos, (raw) =>
+    raw.find((todo) => todo.id === id)
+);
+found?.toggle(); // ✅ peekInto resolved the managed node
+
+const managed = Retree.source(rawTasks[0]); // raw → managed node
+```
+
+Raw subtrees are guaranteed proxy-free under every write path (raw purity),
+so `structuredClone(Retree.raw(node))` is a valid point-in-time copy. Treat
+raw values as read-only, never use raw references as memo/equality tokens,
+and note that change payloads (`INodeFieldChanges.previous` / `.new`) are
+always raw values — `Retree.source(change.previous)` opts back into the
+managed node.
 
 ### Core samples
 

--- a/benchmarks/findings-jul-10-2026.md
+++ b/benchmarks/findings-jul-10-2026.md
@@ -265,6 +265,31 @@ code shape; the next meaningful lever for algorithmic reads remains
 version-cached snapshots (`Retree.snapshot`), with `Retree.raw`/`peekInto`
 already covering the escape-hatch cases.
 
+## Results — raw purity + useRaw (same day, third pass)
+
+Implemented per `specs/retree-raw.md` (status: implemented). Summary:
+
+- **Raw purity invariant:** raw targets and raw collections now store raw
+  values only; proxies live in handler caches (children record + new Map/Set
+  side caches keyed by map key / raw member). All ten impurity repro cases
+  (reparent, move, map read write-back, set iteration, post-construction
+  non-plain assignment, linked fields) now read pure; enforced by
+  `packages/retree-core/src/raw-purity.spec.ts` (15 tests + payload/no-op
+  semantics).
+- **Change payloads are consistently raw** (`previous` and `new`), and
+  reassigning the node already stored at a property is now a no-op (raw-to-raw
+  comparison). `structuredClone(Retree.raw(n))` is now a valid point-in-time
+  copy.
+- **New APIs:** `Retree.source(rawValue)` (raw→managed resolution) and
+  `useRaw(node) → [raw, toSource]` in `@retreejs/react` (nodeChanged default,
+  toSource materialize-on-miss guarantee for direct children incl. Map/Set).
+- **Convex reconcilers** read raw / write proxied; `IStateReconciler.reconcile`
+  gained a backward-compatible `rawCurrent` third parameter.
+- **Perf:** bundle probes within noise or better (materialize/steady improved
+  again — Map/Set read write-backs and `findSetStoredValue`'s linear scan are
+  gone); wide-table render 200×40: `useRaw` 1.1 ms vs `useNode` 9.2 ms (~8×);
+  2k-row mount with `toSource` per row at parity with `useNode`.
+
 ## Recommended order
 
 1. De-quadratic dependency tracking (side indexes + tombstones) — biggest algorithmic win, no semantic change.

--- a/benchmarks/findings-jul-10-2026.md
+++ b/benchmarks/findings-jul-10-2026.md
@@ -181,6 +181,90 @@ profile after fix: GC 37%, `registerCustomProxyMetadata` 14.6%,
   (delete-free) case.
 - Lazy reproxy-on-write (dirty flag) remains unimplemented.
 
+## Results — allocation pass (same day, second pass)
+
+Follow-up pass targeting the CPU-profile findings from the first pass (GC 37%,
+per-proxy WeakMap registrations ~22%, per-node trap closures). Measured with a
+standalone esbuild bundle (20 rounds of 10k-item first-touch materialization,
+100 steady scans, 20k scalar writes, 10k pushes; medians of 3 runs) plus the
+vitest perf probe. All 307 tests pass after each step.
+
+| Bundle measurement | Pass start | After | Change |
+| --- | --- | --- | --- |
+| Materialize 20 rounds | 655 ms | ~372 ms | **−43%** |
+| Steady scan ×100 | 776 ms | ~430 ms | **−44%** |
+| 20k scalar writes | 26 ms | ~16 ms | −35% |
+| 10k pushes | 16–19 ms | ~14 ms | −15% |
+
+Vitest probe first-touch materialization: ~55 ms (before either pass) → 38 ms
+(first pass) → **23.6 ms** now. GC share of the materialization profile:
+37% → 12%.
+
+**What changed (kept):**
+
+1. **Handler-class refactor.** `buildProxy`'s handler object literal with four
+   trap closures (plus the bound-function helper closure) became
+   `BaseProxyHandler`, with traps on the prototype and per-node state in
+   fields; `buildReproxy` likewise became `ReproxyHandler` (a per-write
+   allocation). Materialize −11%, and steady-state reads −33% — shared
+   prototype trap functions keep V8's inline caches monomorphic where
+   per-node closures fragmented them.
+2. **Sentinel-symbol proxy metadata.** The proxy→handler WeakMap
+   (`registerCustomProxyMetadata`, 14.6% of materialization) is gone: Retree
+   get traps intercept `proxyHandlerSentinel` as their first check and return
+   the handler, so identity checks need no per-proxy registration.
+   `getCustomProxyHandlerFromMetadata` guards with `isCustomProxyHandler`
+   (foreign proxies answering arbitrary keys) and try/catch (revoked proxies
+   throw on reads). Materialize −34% on top of the class refactor; writes and
+   pushes −18–20% (reproxies skip the registration too). Tracked-scan and
+   select probes show no regression from trap-dispatch identity checks.
+3. **Lazy children cache.** `proxiedChildrenKey` records start as `null`; leaf
+   nodes (roughly half the probe tree) never allocate one, and the get trap's
+   null check is cheaper than an empty-record property miss. The reproxy
+   handler now delegates the children record to the base handler through an
+   accessor instead of copying the reference at construction (required for
+   laziness, and removes a stale-copy hazard). Materialize −3%, steady −10%.
+4. `updateReproxyNode` passes its handler into `buildReproxy` (one sentinel
+   dispatch saved per write).
+
+**Experiments run and rejected (with measurements):**
+
+- **Symbol property instead of the raw→proxy WeakMap** (`registerBaseProxy`,
+  ~8%). Non-enumerable `defineProperty` measures the same as `WeakMap.set`
+  (~20 ms/200k vs 20 ms). A plain enumerable set is 4–5× faster (4–9 ms) and
+  copied-pointer aliasing can be neutralized with a read-side self-check, but
+  the enumerable symbol leaks into deep-equality assertions on raw nodes —
+  vitest/jest `toEqual` compares symbol properties, so user tests comparing
+  `Retree.raw(...)` results against literals would break. WeakMap stays; this
+  is the one remaining per-node registration and it is semantically required
+  (raw→proxy discovery when re-attaching known raw nodes).
+- **Lazy reproxy-on-write (dirty flag).** Stubbing reproxy creation out
+  entirely moves 20k writes from ~16 ms to ~15 ms — a ≤6% ceiling that does
+  not justify rewiring the emitter payloads and every emit site. Post-refactor
+  reproxy construction is already cheap; the write path is dominated by trap +
+  emit bookkeeping.
+- **First-character gate before the legacy `"[[Handler]]"` string compares**
+  in the get trap: measured ~10% *slower* (charCodeAt call beats two
+  fast-rejecting string compares); reverted.
+
+**Regression caught and fixed:** the sentinel made each `isCustomProxy` /
+handler lookup on a proxy a trap dispatch instead of a `WeakMap.get`, and the
+dependency-tracking hot path paid it up to four times per tracked read
+(`isCustomProxy(owner)` then the handler fetch, again for the value, again in
+the tail entry). A 100k-iteration micro-probe on 3-read tracking frames caught
+it: 0.68→0.95 µs/frame. Deduplicating to one handler read per owner and one
+per value (`getCustomProxyHandlerFromMetadata` result doubles as the
+`isCustomProxy` check) recovered to ~0.78 µs — a residual ~12% on tiny
+tracking frames traded for the −40% materialization / −20% writes. Large
+tracked scans and select probes are unaffected.
+
+**Remaining profile after this pass** (materialize+steady bundle): steady-scan
+loop 38%, get trap 22%, GC 12%, `registerBaseProxy` 8%, `buildProxy` 4%. The
+get trap and GC shares are now mostly intrinsic to the proxy model at this
+code shape; the next meaningful lever for algorithmic reads remains
+version-cached snapshots (`Retree.snapshot`), with `Retree.raw`/`peekInto`
+already covering the escape-hatch cases.
+
 ## Recommended order
 
 1. De-quadratic dependency tracking (side indexes + tombstones) — biggest algorithmic win, no semantic change.

--- a/benchmarks/findings-jul-10-2026.md
+++ b/benchmarks/findings-jul-10-2026.md
@@ -120,7 +120,7 @@ trustworthy signals at this sample count.
 | Related write with tracked `select` active | ~85 ms | ~9–14 ms | ~7×; remaining cost is the legitimate selector re-run + O(N) resubscription |
 | 100 writes, ReactiveNode with 50 dependency edges on one node | 92.7 ms | 15.0 ms | 6.2× (dependencies getter runs once per group, not per edge) |
 | First-touch materialization, 10k items | ~55 ms | ~38 ms | ~30% (descriptor-lookup elimination, flattened lazy path, metadata record removal) |
-| `Retree.peek` scan, 10k items | n/a | 0.21–0.25 ms | ≈ raw speed (proxied steady-state scan is ~5.3 ms) |
+| `Retree.raw` scan, 10k items | n/a | 0.21–0.25 ms | ≈ raw speed (proxied steady-state scan is ~5.3 ms) |
 | Steady-state proxied scan | 5.6 ms | 5.3 ms | inherent trap dispatch; `peek` is the designed escape |
 
 **What changed:**
@@ -147,9 +147,19 @@ trustworthy signals at this sample count.
    fresh children directly; proxy metadata stores the handler itself instead of
    allocating a `{handler, target}` record per proxy (reproxy handlers carry a
    `proxyTargetKey`).
-5. New public APIs: `Retree.peek(node)` (raw read escape hatch) and
-   `Retree.untracked(fn)` (pause dependency collection). Both documented with
-   read-only / caveat guidance and covered by tests.
+5. New public APIs: `Retree.raw(node)` (raw read escape hatch),
+   `Retree.untracked(fn)` (pause dependency collection), and
+   `Retree.peekInto(node, fn)` (run a read-only query against the raw object,
+   then resolve the result to its managed node — latest reproxy or base proxy
+   — when one exists). `ReactiveNode` exposes instance conveniences `raw()`,
+   `untracked(fn)`, and `peekInto(fn)` that delegate to the static APIs via
+   the existing implementation-injection pattern. (`query` was considered as
+   the name for `peekInto` but is reserved by `ConvexNode.query`.) All
+   documented with read-only / caveat guidance and covered by tests. Caveat:
+   `peekInto` resolves only the returned value itself (not container
+   elements), and children never read through the managed tree have no proxy
+   yet, so they resolve raw — traverse once or `prepareTree` when a managed
+   result is required.
 6. Hygiene: `FUNCTION_NAMES_BIND_TO_RAW` is a `Set`; ReactiveNode get-trap key
    checks avoid `String(prop)` allocation for symbols.
 

--- a/benchmarks/findings-jul-10-2026.md
+++ b/benchmarks/findings-jul-10-2026.md
@@ -1,0 +1,183 @@
+# Findings July 10, 2026 — Proxy trap & materialization costs for query-heavy workloads
+
+Focus: performance of algorithms that query large collections of deeply nested lists through Retree proxies, with emphasis on materialization (first-touch lazy proxying) and dependency-tracked reads.
+
+## Measurements
+
+Probe: a tree of 100 groups × 100 items (10k items, each with a nested `tags` array of 2 objects → ~30k+ object nodes). `scan()` iterates every group/item/tag and reads ~5 fields per item. Run against source via vitest on this machine (M-series, node). One-off probe, deleted after measurement; numbers are directional, not tracked benchmarks.
+
+| Scenario | Time |
+| --- | --- |
+| Raw object scan (steady) | **0.28 ms** |
+| `Retree.root()` (lazy, no touch) | 2.2 ms |
+| Proxied scan, **first touch** (materialization) | **58.7 ms** (~200× raw) |
+| Proxied scan, steady-state (children cached) | **5.6 ms** (~20× raw) |
+| Scan via `getUnproxiedNode(tree)` | 0.32 ms (≈ raw) |
+| Dependency-tracked scan, 250 items | 7.7 ms |
+| Dependency-tracked scan, 500 items | 25.0 ms |
+| Dependency-tracked scan, 1000 items | 94.4 ms |
+| Dependency-tracked scan, 2000 items | **400.4 ms** |
+| `Retree.select(tracked)` subscribe, 1k items | 91.9 ms |
+| Single scalar write with tracked select active | **88.8 ms** (every write) |
+| Push 1000 items, no listeners | 3.9 ms |
+| Push 1000 items, `treeChanged` on root | 11.3 ms |
+| Push 1000 items in `runTransaction` | 1.8 ms |
+
+Three separate problems compound for the "algorithm queries a big tree" case:
+
+1. Dependency tracking is **O(N²)** in the number of tracked reads (8× items → 52× time).
+2. First-touch materialization costs ~2 µs/node — 10× the already-proxied steady-state scan and ~200× raw.
+3. A tracked selector re-runs **in full, under tracking, on every write** to any dependency — so one scalar write costs the full quadratic scan (88 ms above).
+
+## 1. Dependency tracking is quadratic — highest-leverage algorithmic fix
+
+Every tracked property read runs
+[dependency-tracking.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/dependency-tracking.ts:182) `trackDependencyPropertyAccess`, which calls:
+
+- `removePendingManagedValueAccess(currentFrame, ownerUnproxiedNode)` — a reverse **linear scan of every entry recorded so far**, with `splice` (itself O(n)) on match.
+- In `comparisons` mode additionally `removePendingPropertyValueAccess(...)` — a second full linear scan per read.
+
+So a selector that reads N properties does N scans over a frame that grows to N entries → O(N²) with two constant factors. This is exactly the "query a large collection of deeply nested lists inside `@select` / trapped `memo` / tracked `Retree.select`" path.
+
+**Fix shape** (keeps semantics, changes bookkeeping):
+
+- Give `DependencyAccessFrame` side indexes: `managedValueEntries: Map<TreeNode, number[]>` and `propertyValueEntries: Map<TreeNode, number[]>` mapping unproxied node → entry indices.
+- Replace `splice` with tombstoning (`entries[i] = undefined` or a `dead` flag) and filter dead entries once in `collectDependencyAccesses` / `collectDependencyComparisonAccesses`. Removal becomes amortized O(1); collection totals O(N).
+- Same for `isWrittenPropertyEntry`: build a `Set` of `owner→keys` from `frame.writes` once at collection time instead of scanning `writes` per entry.
+
+Expected effect: the 2000-item tracked scan drops from ~400 ms to roughly the steady-state trap cost (~a few ms) plus O(N) bookkeeping.
+
+Secondary constant-factor cost in the same path: each tracked read allocates an entry object, an `IReactiveDependency`, a comparison-accessor object, and a closure ([dependency-tracking.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/dependency-tracking.ts:223)). Four allocations per read is a lot at 100k reads; consider pooling or flattening into parallel arrays after the quadratic fix lands.
+
+## 2. Tracked selectors re-run fully on every dependency write
+
+Two multiplication effects:
+
+- `createRetreeTrackedSelectionObserver.evaluate()` ([select.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/select.ts:392)) re-runs the whole selector under `collectDependencyAccesses` on **every** `nodeChanged` from **any** dependency. With a selector that scans 1k items, each write costs ~90 ms today.
+- For `ReactiveNode`, `hasReactiveDependencyChanged` ([Retree.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/Retree.ts:1765)) calls `getReactiveNodeDependencies(dependent.reactiveNode, false)`, which re-runs `dependencies` **and every `@select` getter** — per dependent, per notification. Multiple dependents on one node re-run the same getters repeatedly within a single flush.
+
+**Fix shapes:**
+
+- **Cheap validation before recompute.** `runTrappedMemo` already has the right pattern: keep the comparison accessors from the last run and call `getValues()` (one targeted `Reflect.get` per accessor) to decide whether anything relevant changed before re-running the selector. Tracked `Retree.select` should adopt the same validation pass instead of unconditional re-run.
+- **Field-scoped invalidation.** The emitter now carries `INodeFieldChanges[]` (#26), and comparison accessors know their `(ownerUnproxiedNode, propertyKey)`. When a `nodeChanged` arrives with `changes` for keys that no accessor on that owner reads, skip validation entirely. This turns "any write to a watched node" into "writes to watched fields."
+- **Per-flush dependency cache.** Cache the result of `getReactiveNodeDependencies` keyed by (node, reproxy identity or a version counter) for the duration of one notification flush so N dependents don't re-run all select getters N times.
+
+## 3. Materialization (first-touch) is ~10× steady-state reads
+
+Lazy proxying moved the cost out of `Retree.root()` (2 ms — good), but the first full traversal pays ~2 µs per node. Per uncached object-valued read, the `get` trap does:
+
+- `Reflect.getOwnPropertyDescriptor` — allocates a descriptor object per read until the child is cached ([proxy.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/proxy.ts:366)).
+- `shouldLazilyProxyProperty` → `isCustomProxy` (WeakMap get), `instanceof` ×4, `getPrototypeOf`; then `shouldKeepRawPropertyValue` repeats `isProxyableObject` + `isCustomProxy` on the same value.
+- `getOrCreateProxiedChild` → `getManagedProxyForUnproxiedNode` (2 more WeakMap gets) → `buildProxy`, which allocates the handler + closures + Proxy, registers two WeakMap entries, and then **eagerly walks `Object.entries(object)`** doing a descriptor lookup per object-valued field just to decide "defer this" ([proxy.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/proxy.ts:728)).
+
+**Fix shapes:**
+
+- **Skip descriptor lookups on the common shape.** Non-writable / non-configurable own data props are rare. Check `Object.isFrozen(target) || Object.isSealed(target)` once (per node, cacheable) and skip per-prop descriptor allocation when false and the prototype is `Array.prototype`/`Object.prototype`. Keep the slow path for exotic nodes.
+- **Trim redundant lookups.** One `isCustomProxy` per value per get is enough; thread the result through instead of re-checking in `shouldKeepRawPropertyValue` / `createStructuralProxyForValue` / `getOrCreateProxiedChild` (each does its own metadata WeakMap get).
+- **Defer the `buildProxy` constructor walk.** For plain objects/arrays every child is deferred anyway; the `Object.entries` loop mostly confirms that at descriptor-lookup cost. Restrict the eager walk to shapes that need it (ReactiveNode collected/linked keys, existing custom-proxy children needing reparent) and let everything else resolve through the lazy read path.
+- **Direct batch materializer.** `ReactiveNode.prepareTree` currently materializes by reading through the get traps, paying the full per-read overhead. An internal recursive materializer that walks raw targets and populates `proxiedChildrenKey` directly (no trap dispatch, no tracking checks) would make explicit preparation several times cheaper than trap-driven touch.
+
+## 4. Steady-state trap overhead (~20× raw)
+
+Acceptable for UI reads; painful for algorithms. Worthwhile constant-factor cuts:
+
+- `FUNCTION_NAMES_BIND_TO_RAW.includes(prop)` — linear array scan on **every function-valued get** (every `map`/`filter`/`push` access). Make it a `Set`.
+- `String(prop)` allocation per get on ReactiveNode instances ([proxy.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/proxy.ts:256)) — only needed for the `RETREE_` prefix check; check `typeof prop === "string"` first and avoid symbol coercion.
+- `proxyHandler[proxiedChildrenKey]` is a plain object mutated with `Reflect.deleteProperty` — deletes push V8 objects into dictionary mode, and array nodes fill it with thousands of numeric-string keys. A `Map` is more predictable for both.
+- **Array read-method fast paths.** Arrays already bind methods to the base proxy, so `arr.map(...)` pays full trap dispatch per element (`length` + `has` + `get` per index). The Map/Set wrappers show the pattern: intercept hot read-only methods (`forEach`, `map`, `filter`, `find`, `some`, `every`, `reduce`, `slice`) with wrappers that iterate the **raw target** and serve children from the `proxiedChildrenKey` cache (materializing on demand), skipping generic trap logic per element.
+- `reproxy.get` reads object-valued props **twice** — once from the raw target, then again through the base proxy to get the custom-proxy value ([reproxy.ts](/Users/ryanbliss/Documents/Development-Personal/Libraries/Retree/packages/retree-core/src/internals/reproxy.ts:222)). Consulting `handler[proxiedChildrenKey]` first (it's shared with the base handler) would skip the second dispatch for cached children.
+
+## 5. Give algorithms a sanctioned raw-read escape hatch
+
+`scan via getUnproxiedNode` ran at raw speed (0.32 ms vs 5.6 ms proxied). There is no public API for this today.
+
+- **`Retree.peek(node)`** (or `Retree.raw`): documented public accessor for the unproxied target, positioned as "query on peek, mutate through the proxy." Caveat to document/handle: raw targets can contain base proxies for children that were assigned as existing proxies (the `set` trap stores the reparented proxy into the target), so a raw-tree walk is not guaranteed 100% proxy-free — fine for reads, but identity-sensitive code should normalize with `getUnproxiedNode` per node.
+- **`Retree.untracked(fn)`**: public wrapper over the existing `runWithoutDependencyTracking`, so selector/memo authors can exclude a bulk scan from dependency collection deliberately (subscribe to the collection node coarsely instead).
+- **Longer-term: version-cached snapshots (Valtio-style).** Every mutation already refreshes reproxy identity; a per-node version counter enables `Retree.snapshot(node)` returning an immutable plain-object snapshot with structural sharing, cached until the subtree version changes. Queries then run at native speed on plain data and get stable identities for React. This is the cleanest long-term answer for query-heavy workloads.
+
+## 6. Write path notes
+
+- Each `set` builds a fresh reproxy (`updateReproxyNode` → handler + closures + `new Proxy`) even when nothing will observe it. A dirty-flag scheme — mark the reproxy stale on write, build lazily on the next `getReproxyNode` — would remove per-write proxy allocation for unobserved/batched writes. Care needed: listeners receive the reproxy in the emit payload, so laziness must materialize before listener dispatch (or only when a listener exists for that node).
+- `runTransaction` already halves un-listened bulk-push cost (1.8 ms vs 3.9 ms per 1000 pushes); worth recommending loudly in docs for algorithmic writes.
+- `setValuesIterator` / `setEntriesIterator` do `Array.from(...)` per iteration call — O(n) allocation per loop over a Set.
+
+## Results — implementation pass (same day)
+
+Fixes 1–6 from the recommended order below were implemented and measured with
+the targeted probe in `packages/retree-core/src/perf-probe.spec.ts`
+(`npx vitest run packages/retree-core/src/perf-probe.spec.ts --project core --disable-console-intercept`).
+All 298 tests pass. Benchmark artifacts: `retree-benchmark-BASELINE-JUL10`,
+`-FIX1-TRACKING`, `-FIX2-SELECT`, `-FIX3-REACTIVE`, `-FINAL-JUL10`. Note the
+stable/medium CLI profile has high run-to-run variance on sub-ms scenario
+averages (same-code runs flipped ±60%); medians and the targeted probe are the
+trustworthy signals at this sample count.
+
+| Probe measurement | Baseline | After | Change |
+| --- | --- | --- | --- |
+| Tracked scan, 2000 items | 383 ms | 5.8 ms | **66× faster, quadratic → linear** (8× items now 4.5× time, was 53.5×) |
+| Tiny tracked frame (3 reads) | 0.70 µs | 0.68 µs | unchanged (lazy index allocation) |
+| Unrelated write with 1k-item tracked `select` active | ~87 ms | ~5 µs amortized | **~16,000×** (field-scoped skip; first skip pays ~0.5 ms lazy summary build) |
+| Related write with tracked `select` active | ~85 ms | ~9–14 ms | ~7×; remaining cost is the legitimate selector re-run + O(N) resubscription |
+| 100 writes, ReactiveNode with 50 dependency edges on one node | 92.7 ms | 15.0 ms | 6.2× (dependencies getter runs once per group, not per edge) |
+| First-touch materialization, 10k items | ~55 ms | ~38 ms | ~30% (descriptor-lookup elimination, flattened lazy path, metadata record removal) |
+| `Retree.peek` scan, 10k items | n/a | 0.21–0.25 ms | ≈ raw speed (proxied steady-state scan is ~5.3 ms) |
+| Steady-state proxied scan | 5.6 ms | 5.3 ms | inherent trap dispatch; `peek` is the designed escape |
+
+**What changed:**
+
+1. `dependency-tracking.ts`: tombstoned entries + lazily-allocated side indexes
+   (`managedValueIndices`, `propertyValueIndices`, `writtenKeys` Set) replace the
+   per-read reverse scans and splices. Writes-during-tracking keep a linear scan
+   (rare path) so reads pay no index maintenance for them.
+2. Tracked `Retree.select` / `useSelect(() => ...)`: a validation gate
+   (`canSkipTrackedDependencyChange`) runs before selector re-runs. Plain-object
+   dependencies skip outright when emitted change keys miss the selector's read
+   set; otherwise per-node comparison accessors re-read just the values the
+   selector read from the changed node. Arrays are excluded from key scoping
+   (index writes imply `length` changes that emissions don't record) and
+   ReactiveNodes are excluded (dependency-driven emissions forward foreign
+   change records); both still get accessor validation. The React subscription
+   hub now forwards `changes` to hub listeners.
+3. `handleReactiveDependentNodeChanged` computes the dependent group's current
+   dependency list at most once per group (lazy, key-indexed) instead of once
+   per dependency edge.
+4. Materialization: `buildProxy`'s constructor walk checks lazy-deferral before
+   descriptor lookups (and skips its always-no-op child-record deletes);
+   `Object.keys` replaces `Object.entries`; `getOrCreateProxiedChild` builds
+   fresh children directly; proxy metadata stores the handler itself instead of
+   allocating a `{handler, target}` record per proxy (reproxy handlers carry a
+   `proxyTargetKey`).
+5. New public APIs: `Retree.peek(node)` (raw read escape hatch) and
+   `Retree.untracked(fn)` (pause dependency collection). Both documented with
+   read-only / caveat guidance and covered by tests.
+6. Hygiene: `FUNCTION_NAMES_BIND_TO_RAW` is a `Set`; ReactiveNode get-trap key
+   checks avoid `String(prop)` allocation for symbols.
+
+**Follow-ups identified by CPU profile, not done in this pass** (materialization
+profile after fix: GC 37%, `registerCustomProxyMetadata` 14.6%,
+`buildProxy` 11.5%, get trap 9.2%, `registerBaseProxy` 7.3%):
+
+- The two per-node `WeakMap.set` registrations are ~22% of materialization.
+  Eliminating them requires symbol-keyed metadata on raw nodes plus get-trap
+  interception — feasible but touches `clone`/`prepareTree`/ownKeys semantics;
+  design carefully before attempting.
+- Handler-class refactor: `buildProxy` allocates 4 trap closures + helper
+  closures per node; moving traps to a prototype with per-node state on the
+  handler instance would cut most of the GC share. Large mechanical change.
+- Reproxy read path still double-dispatches uncached object-valued reads.
+- Array read-method fast paths and a `Map`-based children cache were evaluated
+  and deferred: `for..of` index reads can't be intercepted by method wrappers,
+  and the plain-record children cache stays in fast mode for the common
+  (delete-free) case.
+- Lazy reproxy-on-write (dirty flag) remains unimplemented.
+
+## Recommended order
+
+1. De-quadratic dependency tracking (side indexes + tombstones) — biggest algorithmic win, no semantic change.
+2. Validation-before-recompute + field-scoped invalidation for tracked `select` and `@select` getters — turns "88 ms per write" into "µs per unrelated write."
+3. Per-flush cache for `getReactiveNodeDependencies`.
+4. Materialization constant factors (descriptor skip, redundant `isCustomProxy` threading, deferred constructor walk) + direct `prepareTree` materializer.
+5. Public `Retree.peek` / `Retree.untracked` + docs guidance for query-heavy algorithms.
+6. Array read-method fast paths; `Set` for `FUNCTION_NAMES_BIND_TO_RAW`; `Map` for `proxiedChildrenKey`.
+7. Lazy reproxy on write (dirty flag).
+8. Evaluate version-counter snapshots (`Retree.snapshot`) as the long-term architecture for algorithmic reads.

--- a/llms.txt
+++ b/llms.txt
@@ -27,6 +27,10 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
 - DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
 - DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
+- DO use `Retree.raw(node)` / `Retree.peekInto(node, fn)` (or React's `useRaw`) for wide, read-only scans. Raw subtrees are guaranteed proxy-free and read at native speed.
+- DO resolve raw values back to managed nodes with `Retree.source(rawValue)` (or `useRaw`'s `toSource`) before writing, subscribing, or passing them as component props.
+- DO use `Retree.untracked(fn)` for bulk reads inside tracked selectors/memo getters that should not become dependencies.
+- DO read `rawCurrent` and write `current` inside custom Convex reconcilers (`reconcile(current, next, rawCurrent)`).
 - DO dispose Convex query, paginated query, and connection-state nodes when their owner is torn down.
 - DO reconcile server list results by stable IDs (`reconcileConvexDocuments`, `reconcileArrayById`) so child node identity stays stable.
 - DO set the lowest-level value and/or primitive that changed.
@@ -42,6 +46,9 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - DON'T expect `useSelect(...)` or `Retree.select(...)` dependency lists to reproxy the node passed to the selector. They are observational; use `@select` when a `ReactiveNode` owner should emit.
 - DON'T pass selector-only `useSelect(() => ...)` or `Retree.select(() => ..., callback)` when you need a fixed root listener with `listenerType: "treeChanged"`. The selector-only forms trap Retree-managed reads and subscribe to those nodes automatically.
 - DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
+- DON'T write to values from `Retree.raw` / `useRaw`. Writes must go through managed nodes to emit; raw is a read-only view.
+- DON'T use raw references as `React.memo` props, `useMemo` deps, or equality tokens. Raw identity never changes; nodes are the identity currency.
+- DON'T expect `changes[].previous` / `changes[].new` in listener payloads to be managed nodes. Payload values are always raw; use `Retree.source(value)` to opt back in.
 - DON'T rely on dependency reordering being silent. If `ReactiveNode.dependencies` or `@select` entries are added, removed, or reordered, Retree treats that as changed and emits when the owner is observed.
 - DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
 - DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
@@ -58,6 +65,10 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
 - `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use `Retree.select(node, selector, callback)` for an explicit root, or `Retree.select(() => value, callback)` for automatic dependency trapping. It is not a cache.
 - `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+- `Retree.raw`: Returns the raw, proxy-free object behind a node for native-speed, read-only access. Guaranteed proxy-free at any depth (raw purity); `structuredClone(Retree.raw(node))` is a valid point-in-time copy. `ReactiveNode` exposes `this.raw()`.
+- `Retree.source`: Resolves a raw value back to its managed node (the inverse of `Retree.raw`). Returns `undefined` for values never materialized as nodes.
+- `Retree.peekInto`: Runs a read-only query against a node's raw object and resolves the returned value to its managed node when one exists. `ReactiveNode` exposes `this.peekInto(fn)`.
+- `Retree.untracked`: Pauses dependency tracking during a synchronous callback. Use it for bulk reads inside tracked selectors and memo getters. `ReactiveNode` exposes `this.untracked(fn)`.
 - `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
 - `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
 - `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
@@ -72,13 +83,14 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
 - `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
 - `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use `useSelect(node, selector)` for an explicit root, or `useSelect(() => value)` for automatic dependency trapping. Good for counts, totals, booleans, labels, and VM dependency arrays.
+- `useRaw`: Subscribes like `useNode` (`nodeChanged` default) but returns `[raw, toSource]` for native-speed, proxy-free render reads. Use it for components that read wide (tables, canvas, serialization). Pass nodes to children via `toSource`, never raw values.
 - `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
 - `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
 - `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.
 - `ConvexPaginatedQueryNode`: Stores one live paginated Convex query and exposes `loadMore(...)`.
 - `ConvexConnectionStateNode`: Stores the Convex client's connection state in Retree state.
 - `createRetreeConvexAction` and `createRetreeConvexMutation`: Typed standalone Convex helpers for code that is not inside a `BaseConvexNode`.
-- `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow.
+- `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow. They read raw and write through the managed state internally; custom reconcilers receive `rawCurrent` as a third argument (read `rawCurrent`, write `current`).
 - `RetreeConvexReactClient`: Extends Convex's `ConvexReactClient` with the Retree Convex subscription methods used by `ConvexNode` query, paginated query, and connection-state helpers.
 
 ## Documentation
@@ -101,6 +113,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 - [useNode](https://ryanbliss.github.io/retree/functions/_retreejs_react.useNode.html): React hook for subscribing to direct node changes with fine-grained re-rendering.
 - [useTree](https://ryanbliss.github.io/retree/functions/_retreejs_react.useTree.html): React hook for subscribing to node and descendant-tree changes.
 - [useRoot](https://ryanbliss.github.io/retree/functions/_retreejs_react.useRoot.html): React hook for creating and retaining a Retree root in a component.
+- [useRaw](https://ryanbliss.github.io/retree/functions/_retreejs_react.useRaw.html): React hook returning `[raw, toSource]` for native-speed, proxy-free render reads with `useNode`-style invalidation.
 - [@retreejs/convex API](https://ryanbliss.github.io/retree/modules/_retreejs_convex.html): Convex exports for `BaseConvexNode`, `ConvexNode`, `ConvexQueryNode`, `ConvexPaginatedQueryNode`, `ConvexConnectionStateNode`, action and mutation helpers, optimistic update contexts, and reconcilers.
 - [BaseConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.BaseConvexNode.html): Base Retree node for classes that own a Convex client and need protected action, mutation, and one-off query helpers.
 - [ConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexNode.html): Base class for Retree nodes that own a Convex client and create typed query, paginated query, action, mutation, query-once, and connection-state helpers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12792,12 +12792,12 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.4.15",
-                "@retreejs/react": "0.4.15",
+                "@retreejs/core": "0.4.16",
+                "@retreejs/react": "0.4.16",
                 "jsdom": "^26.1.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
@@ -12814,22 +12814,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -12845,34 +12845,34 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "packages/retree-react-convex": {
             "name": "@retreejs/react-convex",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/convex": "0.4.15",
+                "@retreejs/convex": "0.4.16",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/convex": "0.4.15",
+                "@retreejs/convex": "0.4.16",
                 "convex": "^1.39.1"
             }
         },
@@ -12881,7 +12881,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.4.15"
+                "@retreejs/core": "0.4.16"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13330,8 +13330,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.15",
-                "@retreejs/react": "0.4.15",
+                "@retreejs/core": "0.4.16",
+                "@retreejs/react": "0.4.16",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13351,8 +13351,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.15",
-                "@retreejs/react": "0.4.15",
+                "@retreejs/core": "0.4.16",
+                "@retreejs/react": "0.4.16",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12792,12 +12792,12 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.4.14",
-                "@retreejs/react": "0.4.14",
+                "@retreejs/core": "0.4.15",
+                "@retreejs/react": "0.4.15",
                 "jsdom": "^26.1.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
@@ -12814,22 +12814,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -12845,34 +12845,34 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "packages/retree-react-convex": {
             "name": "@retreejs/react-convex",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/convex": "0.4.14",
+                "@retreejs/convex": "0.4.15",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/convex": "0.4.14",
+                "@retreejs/convex": "0.4.15",
                 "convex": "^1.39.1"
             }
         },
@@ -12881,7 +12881,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.4.14"
+                "@retreejs/core": "0.4.15"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13330,8 +13330,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.14",
-                "@retreejs/react": "0.4.14",
+                "@retreejs/core": "0.4.15",
+                "@retreejs/react": "0.4.15",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13351,8 +13351,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.14",
-                "@retreejs/react": "0.4.14",
+                "@retreejs/core": "0.4.15",
+                "@retreejs/react": "0.4.15",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12792,12 +12792,12 @@
         },
         "packages/retree-benchmark-cli": {
             "name": "@retreejs/benchmark-cli",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.4.13",
-                "@retreejs/react": "0.4.13",
+                "@retreejs/core": "0.4.14",
+                "@retreejs/react": "0.4.14",
                 "jsdom": "^26.1.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
@@ -12814,22 +12814,22 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -12845,34 +12845,34 @@
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "packages/retree-react-convex": {
             "name": "@retreejs/react-convex",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/convex": "0.4.13",
+                "@retreejs/convex": "0.4.14",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/convex": "0.4.13",
+                "@retreejs/convex": "0.4.14",
                 "convex": "^1.39.1"
             }
         },
@@ -12881,7 +12881,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@retreejs/core": "0.4.13"
+                "@retreejs/core": "0.4.14"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -13330,8 +13330,8 @@
         "samples/02.react-example": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.13",
-                "@retreejs/react": "0.4.13",
+                "@retreejs/core": "0.4.14",
+                "@retreejs/react": "0.4.14",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
             },
@@ -13351,8 +13351,8 @@
         "samples/03.react-recursion": {
             "version": "0.0.0",
             "dependencies": {
-                "@retreejs/core": "0.4.13",
-                "@retreejs/react": "0.4.13",
+                "@retreejs/core": "0.4.14",
+                "@retreejs/react": "0.4.14",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "uuid": "^9.0.0"

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -19,8 +19,8 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.4.14",
-        "@retreejs/react": "0.4.14",
+        "@retreejs/core": "0.4.15",
+        "@retreejs/react": "0.4.15",
         "jsdom": "^26.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -19,8 +19,8 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.4.15",
-        "@retreejs/react": "0.4.15",
+        "@retreejs/core": "0.4.16",
+        "@retreejs/react": "0.4.16",
         "jsdom": "^26.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/benchmark-cli",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "Benchmark Retree listener emission performance across deterministic tree scenarios.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -19,8 +19,8 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.4.13",
-        "@retreejs/react": "0.4.13",
+        "@retreejs/core": "0.4.14",
+        "@retreejs/react": "0.4.14",
         "jsdom": "^26.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"

--- a/packages/retree-convex/README.md
+++ b/packages/retree-convex/README.md
@@ -253,6 +253,30 @@ this.tasks = this.query(api.tasks.listByProject, {
 });
 ```
 
+Custom reconcilers receive a third `rawCurrent` argument — the proxy-free raw
+view of `current` (`Retree.raw`). Reconciliation is read-dominated, so **read
+from `rawCurrent`, write to `current`**: comparisons run at native speed and
+writes through `current` emit `nodeChanged` for changed rows while keeping
+item identity stable. Writing to `rawCurrent` skips emission — never do it.
+
+```ts
+const reconcileTasks: IStateReconciler<Task[]> = {
+    reconcile(current, next, rawCurrent) {
+        if (current === undefined) return next;
+        for (let index = 0; index < next.length; index++) {
+            if (rawCurrent?.[index]?.text !== next[index]!.text) {
+                current[index]!.text = next[index]!.text; // ✅ emits
+            }
+        }
+        current.length = next.length;
+        return current;
+    },
+};
+```
+
+The built-in reconcilers (`reconcileConvexDocuments`, `reconcileArrayById`)
+already read raw and write through `current` internally.
+
 ## Docs
 
 Docs are hosted at https://ryanbliss.github.io/retree/.

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -14,13 +14,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.4.13",
+        "@retreejs/core": "0.4.14",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.13",
+        "@retreejs/core": "0.4.14",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -14,13 +14,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.4.15",
+        "@retreejs/core": "0.4.16",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.15",
+        "@retreejs/core": "0.4.16",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -14,13 +14,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.4.14",
+        "@retreejs/core": "0.4.15",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.14",
+        "@retreejs/core": "0.4.15",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-convex/src/ConvexQueryNode.spec.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.spec.ts
@@ -21,6 +21,7 @@ import {
     reconcileArrayById,
 } from "./index";
 import { reconcileArray } from "./internals/reconcile";
+import { getCustomProxyHandler } from "@retreejs/core/internal";
 
 type TasksQuery = FunctionReference<
     "query",
@@ -984,6 +985,55 @@ describe("ConvexQueryNode", () => {
             text: "Buy groceries",
             isCompleted: true,
         });
+    });
+
+    it("passes a raw read view to custom reconcilers (read raw, write current)", () => {
+        const client = new FakeConvexClient();
+        const seen: {
+            current: unknown;
+            rawCurrent: unknown;
+        }[] = [];
+        const node = Retree.root(
+            new ConvexQueryNode(client, tasksQuery, {
+                args: { listId: "today" },
+                reconcile: {
+                    reconcile(current, next, rawCurrent) {
+                        seen.push({ current, rawCurrent });
+                        if (current === undefined) {
+                            return next;
+                        }
+                        // Read from rawCurrent, write to current.
+                        if (rawCurrent?.[0]?.text !== next[0]?.text) {
+                            current[0]!.text = next[0]!.text;
+                        }
+                        return current;
+                    },
+                },
+            })
+        );
+        Retree.on(node, "nodeChanged", () => undefined);
+        client.subscriptions[0].callback([
+            { id: "task-1", text: "Buy groceries", isCompleted: false },
+        ]);
+        const task = node.state?.[0];
+        client.subscriptions[0].callback([
+            { id: "task-1", text: "Buy oat milk", isCompleted: false },
+        ]);
+
+        // First call: no current state yet.
+        expect(seen[0].current).toBeUndefined();
+        expect(seen[0].rawCurrent).toBeUndefined();
+        // Second call: rawCurrent is the proxy-free raw view of current.
+        expect(seen[1].current).toBeDefined();
+        expect(seen[1].rawCurrent).toBe(
+            Retree.raw(seen[1].current as { id: string }[])
+        );
+        expect(getCustomProxyHandler(seen[1].rawCurrent as object)).toBe(
+            undefined
+        );
+        // Writes through current kept identity and applied the diff.
+        expect(node.state?.[0]).toBe(task);
+        expect(node.state?.[0]?.text).toBe("Buy oat milk");
     });
 
     it("keeps unchanged array item proxies stable when another item changes", () => {

--- a/packages/retree-convex/src/ConvexQueryNode.ts
+++ b/packages/retree-convex/src/ConvexQueryNode.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ignore, Retree } from "@retreejs/core";
+import { ignore, Retree, TreeNode } from "@retreejs/core";
+import { getUnproxiedNode } from "@retreejs/core/internal";
 import type { FunctionReturnType } from "convex/server";
 import { BaseConvexNode } from "./BaseConvexNode";
 import { tryReconcileConvexDocuments } from "./internals/reconcile";
@@ -409,7 +410,14 @@ export class ConvexQueryNode<
         }
 
         const current = this.state;
-        const reconciled = this.reconciler.reconcile(current, next);
+        // Read from raw, write through the managed state (raw purity makes
+        // the raw view proxy-free and native-speed).
+        const rawCurrent =
+            current !== null && typeof current === "object"
+                ? ((getUnproxiedNode(current as TreeNode) ??
+                      current) as typeof current)
+                : current;
+        const reconciled = this.reconciler.reconcile(current, next, rawCurrent);
         if (reconciled === current) {
             return;
         }

--- a/packages/retree-convex/src/internals/reconcile.ts
+++ b/packages/retree-convex/src/internals/reconcile.ts
@@ -1,15 +1,30 @@
+import { getUnproxiedNode } from "@retreejs/core/internal";
+import { TreeNode } from "@retreejs/core";
+
+function unwrapRaw<T>(value: T): T {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+    return (getUnproxiedNode(value as unknown as TreeNode) ?? value) as T;
+}
+
 export function tryReconcileConvexDocuments(
     current: unknown,
     next: unknown
 ): boolean {
-    if (!isConvexDocumentArray(current)) {
+    // Validation reads run against the raw array (raw purity guarantees it
+    // is proxy-free); reconciliation writes still go through `current`.
+    if (!isConvexDocumentArray(unwrapRaw(current))) {
         return false;
     }
     if (!isConvexDocumentArray(next)) {
         return false;
     }
 
-    reconcileDocumentArrayById(current, next);
+    reconcileDocumentArrayById(
+        current as Array<Record<"_id", PropertyKey>>,
+        next as Array<Record<"_id", PropertyKey>>
+    );
     return true;
 }
 
@@ -18,12 +33,17 @@ export function reconcileArray<TItem extends object>(
     next: TItem[],
     getId: (item: TItem) => PropertyKey
 ): void {
-    if (current.length === next.length) {
+    // Reconciliation is read-dominated: compare every field of every item,
+    // write only the diffs. Reads (ids, field comparisons) run against the
+    // raw array at native speed; writes go through the managed `current` so
+    // changed rows emit and item identity stays stable for useNode rows.
+    const rawCurrent = unwrapRaw(current);
+    if (rawCurrent.length === next.length) {
         let allItemsStayedInPlace = true;
         for (let index = 0; index < next.length; index++) {
-            const currentItem = current[index];
+            const rawItem = rawCurrent[index];
             const nextItem = next[index];
-            if (currentItem === undefined) {
+            if (rawItem === undefined) {
                 allItemsStayedInPlace = false;
                 break;
             }
@@ -31,12 +51,12 @@ export function reconcileArray<TItem extends object>(
                 allItemsStayedInPlace = false;
                 break;
             }
-            if (getId(currentItem) !== getId(nextItem)) {
+            if (getId(rawItem) !== getId(nextItem)) {
                 allItemsStayedInPlace = false;
                 break;
             }
 
-            reconcileObject(currentItem, nextItem);
+            reconcileObject(current[index]!, nextItem, rawItem);
         }
 
         if (allItemsStayedInPlace) {
@@ -45,11 +65,13 @@ export function reconcileArray<TItem extends object>(
     }
 
     const currentById = new Map<PropertyKey, TItem>();
-    for (const currentItem of current) {
-        if (currentItem === undefined) {
+    for (let index = 0; index < rawCurrent.length; index++) {
+        const rawItem = rawCurrent[index];
+        if (rawItem === undefined) {
             continue;
         }
-        currentById.set(getId(currentItem), currentItem);
+        // Managed item for writes; raw id for the key.
+        currentById.set(getId(rawItem), current[index]!);
     }
 
     for (let index = 0; index < next.length; index++) {
@@ -64,10 +86,12 @@ export function reconcileArray<TItem extends object>(
         }
 
         reconcileObject(currentItem, nextItem);
-        const currentSlot = current[index];
+        // rawCurrent is a live view of `current`, so this reads the latest
+        // slot state even after earlier assignments in this loop.
+        const rawSlot = rawCurrent[index];
         if (
-            currentSlot !== undefined &&
-            getId(currentSlot) === getId(currentItem)
+            rawSlot !== undefined &&
+            getId(rawSlot) === getId(unwrapRaw(currentItem))
         ) {
             continue;
         }
@@ -121,14 +145,23 @@ function reconcileDocumentArrayById(
     reconcileArray(current, next, (item) => item._id);
 }
 
-function reconcileObject<T extends object>(target: T, source: T): void {
-    for (const key of Object.keys(target)) {
+function reconcileObject<T extends object>(
+    target: T,
+    source: T,
+    rawTarget?: T
+): void {
+    const raw = rawTarget ?? unwrapRaw(target);
+    for (const key of Object.keys(raw)) {
         if (!Object.prototype.hasOwnProperty.call(source, key)) {
             Reflect.deleteProperty(target, key);
         }
     }
 
     for (const [key, value] of Object.entries(source)) {
-        Reflect.set(target, key, value);
+        // Compare against raw at native speed; dispatch a trapped write only
+        // for fields that actually changed.
+        if ((raw as Record<string, unknown>)[key] !== value) {
+            Reflect.set(target, key, value);
+        }
     }
 }

--- a/packages/retree-convex/src/types.ts
+++ b/packages/retree-convex/src/types.ts
@@ -323,11 +323,25 @@ export interface IStateReconciler<TState> {
     /**
      * Reconcile `next` into `current`.
      *
-     * @param current Current query state, if any.
-     * @param next Newly emitted query state.
+     * @remarks
+     * Reconciliation is read-dominated: it compares every field and writes
+     * only the diffs. **Read from `rawCurrent`, write to `current`.**
+     * `rawCurrent` is the raw object behind `current` (`Retree.raw`) —
+     * native-speed, proxy-free reads. Writes must go through `current` so
+     * changed rows emit `nodeChanged` and item identity stays stable for
+     * `useNode` rows; writes to `rawCurrent` skip emission entirely.
+     *
+     * @param current Current query state, if any. Write surface.
+     * @param next Newly emitted query state (raw server data).
+     * @param rawCurrent Raw view of `current` for fast reads; `undefined`
+     * when `current` is `undefined` or not object-valued.
      * @returns The state object that should be assigned to the query node.
      */
-    reconcile(current: TState | undefined, next: TState): TState;
+    reconcile(
+        current: TState | undefined,
+        next: TState,
+        rawCurrent?: TState
+    ): TState;
 }
 
 /**

--- a/packages/retree-core/README.md
+++ b/packages/retree-core/README.md
@@ -24,6 +24,10 @@ Use this as a quick map before choosing an API:
 -   [`Retree.on`](#listen-to-nodechanged-treechanged-and-noderemoved) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React or inside lower-level integrations.
 -   [`Retree.select`](#select-derived-values) subscribes to a selected value or ordered dependency list. Use it to narrow notifications; it is not a cache.
 -   [`Retree.parent`](#find-a-parent) returns the structural parent of a node. Use it for tree-local actions like deleting yourself from an array.
+-   [`Retree.raw`](#read-fast-with-raw) returns the raw, proxy-free object behind a node for native-speed, read-only access. Use it for algorithms that scan large trees.
+-   [`Retree.source`](#read-fast-with-raw) resolves a raw value back to its managed node. Use it to recover the write surface after a raw scan or from a change payload.
+-   [`Retree.peekInto`](#read-fast-with-raw) runs a read-only query against a node's raw object and resolves the result to its managed node when one exists.
+-   [`Retree.untracked`](#read-fast-with-raw) pauses dependency tracking during a synchronous callback. Use it for bulk reads inside tracked selectors and memo getters.
 -   [`Retree.move`](#move-link-or-clone-existing-nodes) transfers an existing node to a new structural parent. Use it when ownership should change.
 -   [`Retree.link` and `@link`](#move-link-or-clone-existing-nodes) store a reactive pointer to a node without reparenting it. Use it for selected items and cross-references.
 -   [`Retree.clone`](#move-link-or-clone-existing-nodes) creates a detached copy. Use it when two places need independent state.
@@ -277,6 +281,54 @@ class Task {
 ```
 
 Links are not structural parents: if `editor.selectedTask` is a `@link` field pointing at `project.tasks[0]`, `Retree.parent(editor.selectedTask)` still returns `project.tasks`.
+
+## Read fast with raw
+
+Reads through Retree proxies pay a per-property trap cost. For algorithms and
+render paths that read wide (large lists, deep scans, serialization), read the
+raw object instead:
+
+```ts
+const project = Retree.root({ items: [{ id: "a", score: 1 }] });
+
+// Native-speed, read-only view. Guaranteed proxy-free at any depth.
+const rawItems = Retree.raw(project.items);
+const total = rawItems.reduce((sum, item) => sum + item.score, 0);
+
+// Resolve a raw value back to its managed node when you need to write.
+const item = Retree.source(rawItems[0]);
+if (item) item.score = 2; // ✅ emits normally
+
+// Query raw and resolve the returned value to its managed node in one call.
+const found = Retree.peekInto(project.items, (raw) =>
+    raw.find((candidate) => candidate.id === "a")
+);
+
+// Pause dependency tracking for bulk reads inside tracked selectors/memos.
+const count = Retree.untracked(() => project.items.length);
+```
+
+Rules that keep raw reads safe:
+
+-   **Raw purity guarantee:** `Retree.raw(node)` subtrees contain zero Retree
+    proxies under every write path — reparenting assignments, `Retree.move`,
+    Map/Set value reads, and post-construction assignment of class instances
+    or collections. Every read is native speed, and
+    `structuredClone(Retree.raw(node))` is a valid point-in-time copy.
+-   Treat raw values as **read-only**. Writes go through managed nodes;
+    writing to raw skips emission entirely.
+-   Raw references keep the same identity across changes. Never use them as
+    memo/equality tokens — nodes are the identity currency.
+-   Raw reads are invisible to reactivity: they are not trapped by
+    `useSelect`/`Retree.select` selectors or `@memo` dependency collection.
+-   Change payloads (`INodeFieldChanges.previous` / `.new`) are always raw
+    values; use `Retree.source(change.previous)` to opt back into the managed
+    node.
+-   `Retree.source` returns `undefined` for values never materialized as
+    nodes; traverse the path once (or use `useRaw`'s `toSource` in React)
+    when a managed result is required.
+-   `ReactiveNode` exposes instance conveniences: `this.raw()`,
+    `this.untracked(fn)`, and `this.peekInto(fn)`.
 
 ## Reactive dependencies
 

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-core/src/Map.spec.ts
+++ b/packages/retree-core/src/Map.spec.ts
@@ -210,7 +210,10 @@ describe("Map within Retree proxy", () => {
             expect(sourceMap.get("a")).toBe(inner);
             const stored = root.map.get("a")!;
             expect(stored).not.toBe(inner);
-            expect(sourceMap.get("a")).toBe(stored);
+            // Raw purity: the raw map keeps the raw value; reads through the
+            // proxy serve the managed child from the handler's side cache.
+            expect(sourceMap.get("a")).toBe(inner);
+            expect(Retree.raw(stored)).toBe(inner);
             expect(Retree.parent(stored)).toBe(root.map);
 
             const treeChanged = vi.fn();
@@ -439,8 +442,11 @@ describe("Map within Retree proxy", () => {
                 throw new Error("Expected an original Set object value.");
             }
             expect(original).not.toBe(raw);
-            expect(sourceSet.has(raw)).toBe(false);
-            expect(sourceSet.has(original)).toBe(true);
+            // Raw purity: the raw set keeps the raw member; the managed child
+            // is served from the handler's side cache.
+            expect(sourceSet.has(raw)).toBe(true);
+            expect(sourceSet.has(original)).toBe(false);
+            expect(Retree.raw(original)).toBe(raw);
             const removed = vi.fn();
             Retree.on(original, "nodeRemoved", removed);
 

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -549,8 +549,8 @@ describe("ReactiveNode", () => {
         nested.prepareTree({ depth: 0 });
 
         expect(root.dependenciesReadCount).toBe(0);
-        expect(nestedHandler[proxiedChildrenKey].payload).toBeDefined();
-        expect(nestedHandler[proxiedChildrenKey].items).toBeDefined();
+        expect(nestedHandler[proxiedChildrenKey]?.payload).toBeDefined();
+        expect(nestedHandler[proxiedChildrenKey]?.items).toBeDefined();
 
         const payloadHandler = getCustomProxyHandler(nested.payload);
         if (payloadHandler === undefined) {
@@ -558,7 +558,7 @@ describe("ReactiveNode", () => {
                 "ReactiveNode prepareTree test expected payload to expose proxy metadata."
             );
         }
-        expect(payloadHandler[proxiedChildrenKey].stats).toBeUndefined();
+        expect(payloadHandler[proxiedChildrenKey]?.stats).toBeUndefined();
     });
 
     it("auto prepares lazy ReactiveNode data fields when configured", () => {
@@ -570,8 +570,8 @@ describe("ReactiveNode", () => {
             );
         }
 
-        expect(rootHandler[proxiedChildrenKey].payload).toBeDefined();
-        expect(rootHandler[proxiedChildrenKey].items).toBeDefined();
+        expect(rootHandler[proxiedChildrenKey]?.payload).toBeDefined();
+        expect(rootHandler[proxiedChildrenKey]?.items).toBeDefined();
 
         const payloadHandler = getCustomProxyHandler(root.payload);
         if (payloadHandler === undefined) {
@@ -579,7 +579,7 @@ describe("ReactiveNode", () => {
                 "ReactiveNode auto prepare test expected payload to expose proxy metadata."
             );
         }
-        expect(payloadHandler[proxiedChildrenKey].stats).toBeUndefined();
+        expect(payloadHandler[proxiedChildrenKey]?.stats).toBeUndefined();
     });
 
     it("shares one Retree listener for many dependents on the same dependency node", () => {

--- a/packages/retree-core/src/ReactiveNode.spec.ts
+++ b/packages/retree-core/src/ReactiveNode.spec.ts
@@ -814,3 +814,72 @@ describe("ReactiveNode", () => {
         expect(nodeChanged).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("ReactiveNode raw/untracked/peekInto", () => {
+    class TaskList extends ReactiveNode {
+        public tasks: { id: string; done: boolean }[] = [
+            { id: "a", done: false },
+            { id: "b", done: true },
+        ];
+
+        get dependencies() {
+            return [this.dependency(this.tasks)];
+        }
+
+        public rawSelf() {
+            return this.raw();
+        }
+
+        public findTask(id: string) {
+            return this.peekInto((raw) =>
+                raw.tasks.find((task) => task.id === id)
+            );
+        }
+
+        public untrackedDoneCount() {
+            return this.untracked(
+                () => this.tasks.filter((task) => task.done).length
+            );
+        }
+    }
+
+    it("raw() returns the unproxied instance", () => {
+        const instance = new TaskList();
+        const node = Retree.root(instance);
+        expect(node.rawSelf()).toBe(instance);
+        expect(node.raw()).toBe(instance);
+    });
+
+    it("raw() throws for a detached (unmanaged) instance", () => {
+        const instance = new TaskList();
+        expect(() => instance.raw()).toThrowError(/Retree.raw/);
+    });
+
+    it("peekInto() scans raw and resolves managed results", () => {
+        const node = Retree.root(new TaskList());
+        node.tasks.forEach(() => {}); // materialize children
+        const task = node.findTask("b");
+        expect(task).toBeDefined();
+        if (task === undefined) {
+            throw new Error("expected findTask to locate task b");
+        }
+        const changed = vi.fn();
+        const unsubscribe = Retree.on(task, "nodeChanged", changed);
+        task.done = false;
+        expect(changed).toHaveBeenCalledTimes(1);
+        unsubscribe();
+    });
+
+    it("untracked() pauses dependency collection in tracked contexts", () => {
+        const node = Retree.root(new TaskList());
+        node.tasks.forEach(() => {});
+        const callback = vi.fn();
+        const unsubscribe = Retree.select(
+            () => node.untrackedDoneCount(),
+            callback
+        );
+        node.tasks[0].done = true;
+        expect(callback).not.toHaveBeenCalled();
+        unsubscribe();
+    });
+});

--- a/packages/retree-core/src/ReactiveNode.ts
+++ b/packages/retree-core/src/ReactiveNode.ts
@@ -53,6 +53,63 @@ export function setReactiveNodeMoveImplementation(
     moveReactiveNode = implementation;
 }
 
+type RawReactiveNode = <TNode extends ReactiveNode>(node: TNode) => TNode;
+
+let rawReactiveNode: RawReactiveNode = () => {
+    // @retree-throws
+    throw new Error(
+        "ReactiveNode.raw: Retree raw support has not been initialized. This is unexpected and likely a Retree packaging or module-loading bug. Fix: import ReactiveNode and Retree from the same @retreejs/core package instance. If your app already does that, please file a Retree issue with your package manager lockfile and a minimal reproduction."
+    );
+};
+
+type UntrackedReactiveNode = <T>(fn: () => T) => T;
+
+let untrackedReactiveNode: UntrackedReactiveNode = () => {
+    // @retree-throws
+    throw new Error(
+        "ReactiveNode.untracked: Retree untracked support has not been initialized. This is unexpected and likely a Retree packaging or module-loading bug. Fix: import ReactiveNode and Retree from the same @retreejs/core package instance. If your app already does that, please file a Retree issue with your package manager lockfile and a minimal reproduction."
+    );
+};
+
+type PeekIntoReactiveNode = <TNode extends ReactiveNode, TResult>(
+    node: TNode,
+    fn: (raw: TNode) => TResult
+) => TResult;
+
+let peekIntoReactiveNode: PeekIntoReactiveNode = () => {
+    // @retree-throws
+    throw new Error(
+        "ReactiveNode.peekInto: Retree peekInto support has not been initialized. This is unexpected and likely a Retree packaging or module-loading bug. Fix: import ReactiveNode and Retree from the same @retreejs/core package instance. If your app already does that, please file a Retree issue with your package manager lockfile and a minimal reproduction."
+    );
+};
+
+/**
+ * @internal
+ */
+export function setReactiveNodeRawImplementation(
+    implementation: RawReactiveNode
+) {
+    rawReactiveNode = implementation;
+}
+
+/**
+ * @internal
+ */
+export function setReactiveNodeUntrackedImplementation(
+    implementation: UntrackedReactiveNode
+) {
+    untrackedReactiveNode = implementation;
+}
+
+/**
+ * @internal
+ */
+export function setReactiveNodePeekIntoImplementation(
+    implementation: PeekIntoReactiveNode
+) {
+    peekIntoReactiveNode = implementation;
+}
+
 /**
  * A dependency for {@link ReactiveNode}.
  * @remarks
@@ -283,6 +340,107 @@ export abstract class ReactiveNode {
      */
     public link<TNode extends TreeNode>(node: TNode): RetreeLink<TNode> {
         return linkReactiveNode(node);
+    }
+
+    /**
+     * Get the raw, unproxied object behind this node for read-only,
+     * non-reactive access.
+     *
+     * @remarks
+     * This is a convenience wrapper around {@link Retree.raw} for `this`.
+     * Reads on the returned object skip proxy traps entirely, so algorithms
+     * that scan large collections owned by this node can run at native speed.
+     *
+     * Treat the result as read-only: direct mutations skip Retree change
+     * emission. Reads are invisible to reactivity, including this node's own
+     * auto-trapped `@memo` / `@select` dependency collection. Throws when the
+     * node is not yet Retree-managed (for example inside the constructor,
+     * before `Retree.root(...)` or tree attachment).
+     *
+     * @returns The raw object behind this node.
+     *
+     * @example
+     * ```ts
+     * class Leaderboard extends ReactiveNode {
+     *     public scores: number[] = [];
+     *
+     *     get dependencies() {
+     *         return [this.dependency(this.scores)];
+     *     }
+     *
+     *     get total() {
+     *         // Raw scan; reactivity comes from `dependencies`.
+     *         return this.raw().scores.reduce((sum, s) => sum + s, 0);
+     *     }
+     * }
+     * ```
+     */
+    public raw(): this {
+        return rawReactiveNode(this);
+    }
+
+    /**
+     * Run a synchronous function with Retree dependency tracking paused.
+     *
+     * @remarks
+     * This is a convenience wrapper around {@link Retree.untracked}. Use it
+     * inside auto-trapped `@memo`, `@fnMemo`, and `@select` bodies when bulk
+     * reads should not become dependencies. Reads still go through Retree
+     * proxies; writes still emit normally.
+     *
+     * @param fn Function to run without dependency tracking.
+     * @returns The function's return value.
+     */
+    public untracked<T>(fn: () => T): T {
+        return untrackedReactiveNode(fn);
+    }
+
+    /**
+     * Run a read-only query against this node's raw object at native speed,
+     * then resolve the result back to its Retree-managed node when one
+     * exists.
+     *
+     * @remarks
+     * This is a convenience wrapper around {@link Retree.peekInto} for
+     * `this`. The callback receives the raw object behind this node
+     * ({@link ReactiveNode.raw}), so reads inside it skip proxy traps and are
+     * not tracked as dependencies. If the returned value is an object that
+     * belongs to a Retree tree, the latest managed node (reproxy or base
+     * proxy) is returned instead; primitives and unmanaged objects are
+     * returned as-is.
+     *
+     * Only the returned value itself is resolved. Containers built inside the
+     * callback (for example `filter` results) are returned unchanged, with
+     * raw elements. Children that have never been read through the managed
+     * tree have no proxy yet and resolve to their raw value; traverse the
+     * path once, or use `prepareTree` / `autoPrepare`, when a managed result
+     * is required.
+     *
+     * @param fn Read-only callback that receives the raw object behind this
+     * node.
+     * @returns The callback result, resolved to its managed node when one
+     * exists.
+     *
+     * @example
+     * ```ts
+     * class TaskList extends ReactiveNode {
+     *     public tasks: Task[] = [];
+     *
+     *     get dependencies() {
+     *         return [this.dependency(this.tasks)];
+     *     }
+     *
+     *     public findTask(id: string): Task | undefined {
+     *         // Scans raw at native speed; returns the managed task node.
+     *         return this.peekInto((raw) =>
+     *             raw.tasks.find((task) => task.id === id)
+     *         );
+     *     }
+     * }
+     * ```
+     */
+    public peekInto<TResult>(fn: (raw: this) => TResult): TResult {
+        return peekIntoReactiveNode(this, fn);
     }
 
     /**

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -1315,3 +1315,91 @@ describe("Retree", () => {
         expect(nodeChanged).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("Retree.peek", () => {
+    it("returns the raw object behind a root node", () => {
+        const raw = { count: 0, child: { value: 1 } };
+        const root = Retree.root(raw);
+        expect(Retree.peek(root)).toBe(raw);
+    });
+
+    it("returns the raw object behind a child node and a reproxy", () => {
+        const raw = { child: { value: 1 } };
+        const root = Retree.root(raw);
+        expect(Retree.peek(root.child)).toBe(raw.child);
+
+        let latest: typeof root | undefined;
+        const unsubscribe = Retree.on(root, "nodeChanged", (reproxy) => {
+            latest = reproxy;
+        });
+        (root as { count?: number }).count = 1;
+        expect(latest).toBeDefined();
+        if (latest === undefined) {
+            throw new Error("expected nodeChanged listener to run");
+        }
+        expect(Retree.peek(latest)).toBe(raw);
+        unsubscribe();
+    });
+
+    it("throws for unmanaged values", () => {
+        expect(() => Retree.peek({ count: 0 })).toThrowError(/Retree.peek/);
+    });
+
+    it("reads via peek do not subscribe a tracked select", () => {
+        const root = Retree.root({ items: [{ score: 1 }, { score: 2 }] });
+        // Materialize children before selecting.
+        expect(root.items[1].score).toBe(2);
+        const callback = vi.fn();
+        const unsubscribe = Retree.select(() => {
+            const rawItems = Retree.peek(root.items);
+            let total = 0;
+            for (const item of rawItems) {
+                total += item.score;
+            }
+            return total;
+        }, callback);
+        root.items[0].score = 100;
+        expect(callback).not.toHaveBeenCalled();
+        unsubscribe();
+    });
+});
+
+describe("Retree.untracked", () => {
+    it("pauses dependency collection inside tracked selectors", () => {
+        const root = Retree.root({
+            flag: false,
+            items: [{ score: 1 }, { score: 2 }],
+        });
+        const callback = vi.fn();
+        const unsubscribe = Retree.select(() => {
+            const flag = root.flag;
+            const total = Retree.untracked(() =>
+                root.items.reduce((sum, item) => sum + item.score, 0)
+            );
+            return flag ? total : -1;
+        }, callback);
+
+        // Untracked reads must not subscribe: item mutations are invisible.
+        root.items[0].score = 100;
+        expect(callback).not.toHaveBeenCalled();
+
+        // Tracked reads still subscribe.
+        root.flag = true;
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenLastCalledWith(102, -1);
+        unsubscribe();
+    });
+
+    it("returns the callback result and still emits writes", () => {
+        const root = Retree.root({ count: 0 });
+        const nodeChanged = vi.fn();
+        const unsubscribe = Retree.on(root, "nodeChanged", nodeChanged);
+        const result = Retree.untracked(() => {
+            root.count = 5;
+            return root.count * 2;
+        });
+        expect(result).toBe(10);
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        unsubscribe();
+    });
+});

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -845,7 +845,7 @@ describe("Retree", () => {
             throw new Error("Expected root to expose proxy metadata.");
         }
 
-        expect(Object.keys(rootHandler[proxiedChildrenKey])).toEqual([]);
+        expect(Object.keys(rootHandler[proxiedChildrenKey] ?? {})).toEqual([]);
 
         const child = root.child;
         const list = root.list;

--- a/packages/retree-core/src/Retree.spec.ts
+++ b/packages/retree-core/src/Retree.spec.ts
@@ -1316,17 +1316,17 @@ describe("Retree", () => {
     });
 });
 
-describe("Retree.peek", () => {
+describe("Retree.raw", () => {
     it("returns the raw object behind a root node", () => {
         const raw = { count: 0, child: { value: 1 } };
         const root = Retree.root(raw);
-        expect(Retree.peek(root)).toBe(raw);
+        expect(Retree.raw(root)).toBe(raw);
     });
 
     it("returns the raw object behind a child node and a reproxy", () => {
         const raw = { child: { value: 1 } };
         const root = Retree.root(raw);
-        expect(Retree.peek(root.child)).toBe(raw.child);
+        expect(Retree.raw(root.child)).toBe(raw.child);
 
         let latest: typeof root | undefined;
         const unsubscribe = Retree.on(root, "nodeChanged", (reproxy) => {
@@ -1337,21 +1337,21 @@ describe("Retree.peek", () => {
         if (latest === undefined) {
             throw new Error("expected nodeChanged listener to run");
         }
-        expect(Retree.peek(latest)).toBe(raw);
+        expect(Retree.raw(latest)).toBe(raw);
         unsubscribe();
     });
 
     it("throws for unmanaged values", () => {
-        expect(() => Retree.peek({ count: 0 })).toThrowError(/Retree.peek/);
+        expect(() => Retree.raw({ count: 0 })).toThrowError(/Retree.raw/);
     });
 
-    it("reads via peek do not subscribe a tracked select", () => {
+    it("reads via raw do not subscribe a tracked select", () => {
         const root = Retree.root({ items: [{ score: 1 }, { score: 2 }] });
         // Materialize children before selecting.
         expect(root.items[1].score).toBe(2);
         const callback = vi.fn();
         const unsubscribe = Retree.select(() => {
-            const rawItems = Retree.peek(root.items);
+            const rawItems = Retree.raw(root.items);
             let total = 0;
             for (const item of rawItems) {
                 total += item.score;
@@ -1400,6 +1400,92 @@ describe("Retree.untracked", () => {
         });
         expect(result).toBe(10);
         expect(nodeChanged).toHaveBeenCalledTimes(1);
+        unsubscribe();
+    });
+});
+
+describe("Retree.peekInto", () => {
+    it("resolves a found raw child back to its managed node", () => {
+        const project = Retree.root({
+            tasks: [
+                { id: "a", done: false },
+                { id: "b", done: true },
+            ],
+        });
+        // Materialize children so managed proxies exist.
+        project.tasks.forEach(() => {});
+
+        const task = Retree.peekInto(project.tasks, (rawTasks) =>
+            rawTasks.find((candidate) => candidate.id === "b")
+        );
+        expect(task).toBeDefined();
+        if (task === undefined) {
+            throw new Error("expected peekInto to find task b");
+        }
+        // The result is managed: mutations emit.
+        const nodeChanged = vi.fn();
+        const unsubscribe = Retree.on(task, "nodeChanged", nodeChanged);
+        task.done = false;
+        expect(nodeChanged).toHaveBeenCalledTimes(1);
+        unsubscribe();
+    });
+
+    it("returns the latest reproxy for nodes that have reproxied", () => {
+        const project = Retree.root({ settings: { theme: "light" } });
+        project.settings.theme = "dark"; // forces a reproxy of settings
+        const settings = Retree.peekInto(project, (raw) => raw.settings);
+        expect(settings).toBe(getReproxyNode(project.settings));
+        expect(settings.theme).toBe("dark");
+    });
+
+    it("returns primitives and callback-built containers as-is", () => {
+        const project = Retree.root({
+            tasks: [
+                { id: "a", done: false },
+                { id: "b", done: true },
+            ],
+        });
+        project.tasks.forEach(() => {});
+
+        const count = Retree.peekInto(
+            project.tasks,
+            (rawTasks) => rawTasks.filter((candidate) => candidate.done).length
+        );
+        expect(count).toBe(1);
+
+        const rawTasks = Retree.raw(project.tasks);
+        const filtered = Retree.peekInto(project.tasks, (raw) =>
+            raw.filter((candidate) => candidate.done)
+        );
+        // A fresh array is not a managed node; elements stay raw.
+        expect(Array.isArray(filtered)).toBe(true);
+        expect(filtered[0]).toBe(rawTasks[1]);
+    });
+
+    it("returns raw values for children that were never materialized", () => {
+        const project = Retree.root({ hidden: { value: 1 } });
+        // No traversal of project.hidden through the proxy.
+        const hidden = Retree.peekInto(project, (raw) => raw.hidden);
+        expect(hidden).toBe(Retree.raw(project).hidden);
+    });
+
+    it("does not subscribe reads inside the callback to tracked selects", () => {
+        const project = Retree.root({
+            tasks: [{ done: false }],
+            label: "x",
+        });
+        project.tasks.forEach(() => {});
+        const callback = vi.fn();
+        const unsubscribe = Retree.select(() => {
+            void project.label; // tracked
+            return Retree.peekInto(
+                project.tasks,
+                (rawTasks) =>
+                    rawTasks.filter((candidate) => candidate.done).length
+            );
+        }, callback);
+        project.tasks[0].done = true;
+        expect(callback).not.toHaveBeenCalled();
         unsubscribe();
     });
 });

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -11,7 +11,11 @@ import {
     getUnproxiedNodeFromProxy,
 } from "./internals";
 import { TreeChangeEmitter } from "./internals/NodeChangeEmitter";
-import { proxiedParentKey, TCustomProxy } from "./internals/proxy-types";
+import {
+    isCustomProxy,
+    proxiedParentKey,
+    TCustomProxy,
+} from "./internals/proxy-types";
 import {
     deleteReactiveDependencies,
     deleteReactiveDependent,
@@ -24,6 +28,7 @@ import {
     setReactiveDependents,
 } from "./internals/reactive-node-utils";
 import {
+    getManagedProxyForUnproxiedNode,
     getReproxyNode,
     getReproxyNodeForUnproxiedNode,
     updateReproxyNode,
@@ -57,6 +62,9 @@ import {
     SELECT_GETTERS_SYMBOL,
     setReactiveNodeLinkImplementation,
     setReactiveNodeMoveImplementation,
+    setReactiveNodeRawImplementation,
+    setReactiveNodePeekIntoImplementation,
+    setReactiveNodeUntrackedImplementation,
 } from "./ReactiveNode";
 import {
     RetreeObjectMoveKey,
@@ -135,6 +143,11 @@ export class Retree {
         setReactiveNodeLinkImplementation((node) => Retree.link(node));
         setReactiveNodeMoveImplementation((node, destination, key) =>
             Retree.moveInternal(node, destination, key)
+        );
+        setReactiveNodeRawImplementation((node) => Retree.raw(node));
+        setReactiveNodeUntrackedImplementation((fn) => Retree.untracked(fn));
+        setReactiveNodePeekIntoImplementation((node, fn) =>
+            Retree.peekInto(node, fn)
         );
     }
 
@@ -619,15 +632,15 @@ export class Retree {
      *
      * Treat the returned object as read-only. Mutating it directly skips
      * Retree change emission and can desynchronize memoized comparisons; make
-     * all writes through the managed node. Reads through `peek` are invisible
+     * all writes through the managed node. Reads through `raw` are invisible
      * to reactivity: they are not trapped by `useSelect`/`Retree.select`
      * selectors or `@memo` dependency collection, and children read this way
      * are not prepared for `Retree.parent` / `Retree.on` usage.
      *
      * Children that were assigned into the tree as already-managed nodes are
      * stored as proxies, so a raw traversal may still encounter Retree
-     * proxies on some branches. Values read from `peek` results should not be
-     * assumed to be raw; normalize per node with another `peek` call when
+     * proxies on some branches. Values read from `raw` results should not be
+     * assumed to be raw; normalize per node with another `raw` call when
      * identity matters.
      *
      * @param node Retree-managed node to unwrap.
@@ -637,14 +650,14 @@ export class Retree {
      * ```ts
      * const project = Retree.root({ items: [{ score: 1 }, { score: 92 }] });
      *
-     * const rawItems = Retree.peek(project.items);
+     * const rawItems = Retree.raw(project.items);
      * const total = rawItems.reduce((sum, item) => sum + item.score, 0); // ✅ native-speed read
      *
      * project.items[0].score = 50; // ✅ writes stay on the managed tree
      * ```
      */
-    static peek<TNode extends TreeNode>(node: TNode): TNode {
-        this.assertRetreeManagedNode(node, "Retree.peek");
+    static raw<TNode extends TreeNode>(node: TNode): TNode {
+        this.assertRetreeManagedNode(node, "Retree.raw");
         return getUnproxiedNode(node) as TNode;
     }
 
@@ -659,7 +672,7 @@ export class Retree {
      * result is already covered by a narrower dependency.
      *
      * Reads inside `untracked` still go through Retree proxies (combine with
-     * {@link Retree.peek} for native-speed scans). Writes inside `untracked`
+     * {@link Retree.raw} for native-speed scans). Writes inside `untracked`
      * still emit normally; this pauses dependency collection, not change
      * emission.
      *
@@ -681,6 +694,76 @@ export class Retree {
      */
     static untracked<T>(fn: () => T): T {
         return runWithoutDependencyTracking(fn);
+    }
+
+    /**
+     * Run a read-only query against a node's raw object at native speed, then
+     * resolve the result back to its Retree-managed node when one exists.
+     *
+     * @remarks
+     * `peekInto` combines {@link Retree.raw} and {@link Retree.untracked}:
+     * the callback receives the raw object behind `node`, so every read
+     * inside it skips proxy traps and dependency tracking. If the callback
+     * returns an object that belongs to a Retree tree, the latest managed
+     * node (reproxy, or base proxy when the node has never reproxied) is
+     * returned instead, ready for mutation or subscription. Primitives,
+     * `null`, `undefined`, and unmanaged objects are returned as-is.
+     *
+     * Only the returned value itself is resolved. A container built inside
+     * the callback — a `filter` result, a tuple, an object literal — is
+     * returned unchanged with raw elements; resolve elements individually
+     * when they must be managed. Children that have never been read through
+     * the managed tree are not yet materialized and resolve to their raw
+     * value; traverse the path once, or use `prepareTree` / `autoPrepare`,
+     * when a managed result is required.
+     *
+     * @param node Retree-managed node to query.
+     * @param fn Read-only callback that receives the raw object behind
+     * `node`.
+     * @returns The callback result, resolved to its managed node when one
+     * exists.
+     *
+     * @example
+     * ```ts
+     * const project = Retree.root({
+     *     tasks: [
+     *         { id: "a", done: false },
+     *         { id: "b", done: true },
+     *     ],
+     * });
+     * project.tasks.forEach(() => {}); // materialize once (or prepareTree)
+     *
+     * const task = Retree.peekInto(project.tasks, (rawTasks) =>
+     *     rawTasks.find((candidate) => candidate.id === "b")
+     * );
+     * // `task` is the managed node: mutations emit normally.
+     * if (task) task.done = false; // ✅ emits
+     *
+     * const doneCount = Retree.peekInto(
+     *     project.tasks,
+     *     (rawTasks) => rawTasks.filter((candidate) => candidate.done).length
+     * ); // ✅ primitive result returned as-is
+     * ```
+     */
+    static peekInto<TNode extends TreeNode, TResult>(
+        node: TNode,
+        fn: (raw: TNode) => TResult
+    ): TResult {
+        const raw = this.raw(node);
+        const result = runWithoutDependencyTracking(() => fn(raw));
+        if (result === null || typeof result !== "object") {
+            return result;
+        }
+        if (isCustomProxy(result)) {
+            return getReproxyNode(result) as TResult;
+        }
+        const managedProxy = getManagedProxyForUnproxiedNode(
+            result as TreeNode
+        );
+        if (managedProxy !== undefined) {
+            return managedProxy as TResult;
+        }
+        return result;
     }
 
     /**

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -37,7 +37,10 @@ import {
     RetreeSelectSelector,
     RetreeTrackedSelectSelector,
 } from "./internals/select";
-import { runWithIsolatedDependencyTracking } from "./internals/dependency-tracking";
+import {
+    runWithIsolatedDependencyTracking,
+    runWithoutDependencyTracking,
+} from "./internals/dependency-tracking";
 import {
     areDependencyValuesEqual,
     getDependencyComparisonValues,
@@ -603,6 +606,81 @@ export class Retree {
     static parent(node: TreeNode): TreeNode | null {
         const response = this.getParentInternal(node);
         return response?.proxyNode ?? null;
+    }
+
+    /**
+     * Get the raw, unproxied object behind a Retree-managed node for
+     * read-only, non-reactive access.
+     *
+     * @remarks
+     * Reads through Retree proxies pay per-property trap overhead. That is
+     * usually irrelevant, but algorithms that scan large collections of
+     * deeply nested nodes can read the raw object at native speed instead.
+     *
+     * Treat the returned object as read-only. Mutating it directly skips
+     * Retree change emission and can desynchronize memoized comparisons; make
+     * all writes through the managed node. Reads through `peek` are invisible
+     * to reactivity: they are not trapped by `useSelect`/`Retree.select`
+     * selectors or `@memo` dependency collection, and children read this way
+     * are not prepared for `Retree.parent` / `Retree.on` usage.
+     *
+     * Children that were assigned into the tree as already-managed nodes are
+     * stored as proxies, so a raw traversal may still encounter Retree
+     * proxies on some branches. Values read from `peek` results should not be
+     * assumed to be raw; normalize per node with another `peek` call when
+     * identity matters.
+     *
+     * @param node Retree-managed node to unwrap.
+     * @returns The raw object behind the node.
+     *
+     * @example
+     * ```ts
+     * const project = Retree.root({ items: [{ score: 1 }, { score: 92 }] });
+     *
+     * const rawItems = Retree.peek(project.items);
+     * const total = rawItems.reduce((sum, item) => sum + item.score, 0); // ✅ native-speed read
+     *
+     * project.items[0].score = 50; // ✅ writes stay on the managed tree
+     * ```
+     */
+    static peek<TNode extends TreeNode>(node: TNode): TNode {
+        this.assertRetreeManagedNode(node, "Retree.peek");
+        return getUnproxiedNode(node) as TNode;
+    }
+
+    /**
+     * Run a synchronous function with Retree dependency tracking paused.
+     *
+     * @remarks
+     * Inside tracked contexts — `Retree.select(() => ...)`, `useSelect`
+     * selectors, and auto-trapped `@memo` / `@fnMemo` / `@select` bodies —
+     * every Retree read is recorded as a dependency. Wrap bulk reads in
+     * `untracked` when they should not subscribe, such as a wide scan whose
+     * result is already covered by a narrower dependency.
+     *
+     * Reads inside `untracked` still go through Retree proxies (combine with
+     * {@link Retree.peek} for native-speed scans). Writes inside `untracked`
+     * still emit normally; this pauses dependency collection, not change
+     * emission.
+     *
+     * @param fn Function to run without dependency tracking.
+     * @returns The function's return value.
+     *
+     * @example
+     * ```ts
+     * const doneCount = Retree.select(
+     *     () => {
+     *         const tasks = project.tasks; // ✅ tracked: subscribes to tasks
+     *         return Retree.untracked(
+     *             () => tasks.filter((task) => task.done).length
+     *         );
+     *     },
+     *     (count) => console.log(count)
+     * );
+     * ```
+     */
+    static untracked<T>(fn: () => T): T {
+        return runWithoutDependencyTracking(fn);
     }
 
     /**
@@ -1689,9 +1767,33 @@ export class Retree {
         }
         const groupedDependents = this.groupReactiveDependents(dependents);
         groupedDependents.forEach((group) => {
+            // All dependents in a group share one ReactiveNode, so its current
+            // dependency list is computed at most once per group. Recomputing it
+            // per dependent re-runs the `dependencies` getter and every @select
+            // getter M times for a node with M edges onto the changed node.
+            let latestDependenciesByKey:
+                | Map<string, IActiveReactiveDependency>
+                | undefined;
+            const getLatestDependenciesByKey = () => {
+                if (latestDependenciesByKey === undefined) {
+                    latestDependenciesByKey = new Map();
+                    const latestDependencies = this.getReactiveNodeDependencies(
+                        group.reactiveNode,
+                        false
+                    );
+                    for (const dependency of latestDependencies) {
+                        latestDependenciesByKey.set(dependency.key, dependency);
+                    }
+                }
+                return latestDependenciesByKey;
+            };
             if (
                 !group.dependents.some((dependent) =>
-                    this.shouldNotifyReactiveDependent(dependent, _unproxy)
+                    this.shouldNotifyReactiveDependent(
+                        dependent,
+                        _unproxy,
+                        getLatestDependenciesByKey
+                    )
                 )
             ) {
                 return;
@@ -1745,11 +1847,13 @@ export class Retree {
 
     private static shouldNotifyReactiveDependent(
         dependent: IPreviousReactiveDependent,
-        changedUnproxiedNode: TreeNode
+        changedUnproxiedNode: TreeNode,
+        getLatestDependenciesByKey: () => Map<string, IActiveReactiveDependency>
     ) {
         const dependencyChanged = this.hasReactiveDependencyChanged(
             dependent,
-            changedUnproxiedNode
+            changedUnproxiedNode,
+            getLatestDependenciesByKey
         );
         if (!dependencyChanged) {
             return false;
@@ -1764,16 +1868,14 @@ export class Retree {
 
     private static hasReactiveDependencyChanged(
         dependent: IPreviousReactiveDependent,
-        changedUnproxiedNode: TreeNode
+        changedUnproxiedNode: TreeNode,
+        getLatestDependenciesByKey: () => Map<string, IActiveReactiveDependency>
     ) {
         const previousComparisons = dependent.comparisons;
         if (previousComparisons === undefined) {
             return true;
         }
-        const latest = this.getReactiveNodeDependencies(
-            dependent.reactiveNode,
-            false
-        ).find((dependency) => dependency.key === dependent.key);
+        const latest = getLatestDependenciesByKey().get(dependent.key);
         if (latest === undefined) {
             return true;
         }

--- a/packages/retree-core/src/Retree.ts
+++ b/packages/retree-core/src/Retree.ts
@@ -637,11 +637,13 @@ export class Retree {
      * selectors or `@memo` dependency collection, and children read this way
      * are not prepared for `Retree.parent` / `Retree.on` usage.
      *
-     * Children that were assigned into the tree as already-managed nodes are
-     * stored as proxies, so a raw traversal may still encounter Retree
-     * proxies on some branches. Values read from `raw` results should not be
-     * assumed to be raw; normalize per node with another `raw` call when
-     * identity matters.
+     * **Raw purity guarantee:** the returned subtree contains zero Retree
+     * proxies, under every write path — including reparenting assignments,
+     * `Retree.move`, Map/Set value reads, and post-construction assignment of
+     * class instances or collections. Every value is plain data, every read
+     * is native speed, and `structuredClone(Retree.raw(node))` is a valid
+     * point-in-time copy. Use {@link Retree.source} to resolve a raw value
+     * back to its managed node.
      *
      * @param node Retree-managed node to unwrap.
      * @returns The raw object behind the node.
@@ -659,6 +661,47 @@ export class Retree {
     static raw<TNode extends TreeNode>(node: TNode): TNode {
         this.assertRetreeManagedNode(node, "Retree.raw");
         return getUnproxiedNode(node) as TNode;
+    }
+
+    /**
+     * Resolve a raw value back to its Retree-managed node.
+     *
+     * @remarks
+     * This is the inverse of {@link Retree.raw} for values that belong to a
+     * Retree tree: given a raw object (for example an element read while
+     * scanning a {@link Retree.raw} subtree, or a `previous`/`new` value from
+     * a change payload), it returns the latest managed node — ready for
+     * mutation, subscription, or navigation. Passing a managed node returns
+     * its latest managed identity.
+     *
+     * Returns `undefined` when the value has never been materialized as a
+     * Retree node or is not part of a Retree tree; a miss is a normal query
+     * outcome, not an error. Values become materialized when they are read
+     * through a managed node, so scanning via managed proxies first (or using
+     * `useRaw`'s `toSource`, which materializes direct children on demand)
+     * guarantees resolution.
+     *
+     * @param value Raw object to resolve.
+     * @returns The managed node, or `undefined` when none exists.
+     *
+     * @example
+     * ```ts
+     * const project = Retree.root({ items: [{ score: 1 }] });
+     * project.items.forEach(() => {}); // materialize
+     *
+     * const rawItem = Retree.raw(project.items)[0];
+     * const item = Retree.source(rawItem);
+     * if (item) item.score = 2; // ✅ emits normally
+     * ```
+     */
+    static source<TNode extends TreeNode>(value: TNode): TNode | undefined {
+        if (value === null || typeof value !== "object") {
+            return undefined;
+        }
+        const managed = getManagedProxyForUnproxiedNode(
+            getUnproxiedNode(value) as TreeNode
+        );
+        return managed as TNode | undefined;
     }
 
     /**

--- a/packages/retree-core/src/internals/dependency-tracking.ts
+++ b/packages/retree-core/src/internals/dependency-tracking.ts
@@ -8,14 +8,34 @@ import {
 } from "./proxy-types";
 
 interface DependencyAccessFrame {
-    entries: DependencyAccessEntry[];
+    /**
+     * Append-only entry log. Removals tombstone slots to `undefined` instead of
+     * splicing so that per-access bookkeeping stays O(1) amortized; collection
+     * skips dead slots in one pass.
+     */
+    entries: (DependencyAccessEntry | undefined)[];
     mode: "dependencies" | "comparisons";
-    writes: DependencyPropertyWrite[];
-}
-
-interface DependencyPropertyWrite {
-    ownerUnproxiedNode: TreeNode;
-    propertyKey: string | symbol;
+    /**
+     * Live indices of `managed-value` entries keyed by unproxied node, so a
+     * later property read on the same owner can retire them without scanning.
+     * Allocated on first use so tiny frames (e.g. trapped memos with a couple
+     * of reads) skip the Map allocations entirely.
+     */
+    managedValueIndices: Map<TreeNode, number[]> | null;
+    /**
+     * Live indices of property-read entries keyed by the read value's unproxied
+     * node. Only maintained in `comparisons` mode, where intermediate path
+     * reads are deduped when the same node is read from again as an owner.
+     */
+    propertyValueIndices: Map<TreeNode, number[]> | null;
+    /**
+     * Property keys written during the frame, keyed by owner. Reads of a
+     * written property are excluded from comparisons at collection time.
+     * Writes retire earlier reads with a linear scan instead of an index:
+     * writes during tracking are rare, while reads are the hot path that
+     * must not pay per-read index maintenance for them.
+     */
+    writtenKeys: Map<TreeNode, Set<string | symbol>> | null;
 }
 
 export interface DependencyComparisonAccessor {
@@ -72,12 +92,20 @@ export function isDependencyTrackingActive(): boolean {
     return dependencyAccessStack.length > 0;
 }
 
-export function collectDependencyAccesses<T>(callback: () => T): unknown[] {
-    const frame: DependencyAccessFrame = {
+function createDependencyAccessFrame(
+    mode: "dependencies" | "comparisons"
+): DependencyAccessFrame {
+    return {
         entries: [],
-        mode: "dependencies",
-        writes: [],
+        mode,
+        managedValueIndices: null,
+        propertyValueIndices: null,
+        writtenKeys: null,
     };
+}
+
+export function collectDependencyAccesses<T>(callback: () => T): unknown[] {
+    const frame = createDependencyAccessFrame("dependencies");
     dependencyAccessStack.push(frame);
     try {
         callback();
@@ -86,9 +114,179 @@ export function collectDependencyAccesses<T>(callback: () => T): unknown[] {
     }
     const dependencies: unknown[] = [];
     for (const entry of frame.entries) {
+        if (entry === undefined) {
+            continue;
+        }
         dependencies.push(entry.value);
     }
     return dependencies;
+}
+
+/**
+ * One re-checkable read captured while a tracked selector ran. `accessor`
+ * re-reads the current value of the same property; `capturedValues` holds the
+ * comparison cells observed during the tracked run.
+ */
+export interface ITrackedAccessValidator {
+    accessor: DependencyComparisonAccessor;
+    capturedValues: readonly unknown[];
+}
+
+/**
+ * Everything a tracked selector read from one node, grouped so a later
+ * `nodeChanged` from that node can be validated cheaply instead of re-running
+ * the whole selector.
+ */
+export interface ITrackedNodeAccessSummary {
+    /**
+     * The selector observed this node as a whole value (not just properties),
+     * so any change to the node may change the selection.
+     */
+    wholeNodeRead: boolean;
+    /**
+     * True when every validated read is attributable to a property key, so
+     * emitted field changes that miss `propertyKeys` can be skipped outright.
+     */
+    keyScopable: boolean;
+    propertyKeys: Set<string>;
+    validators: ITrackedAccessValidator[];
+}
+
+export interface ITrackedSelectionAccesses<T> {
+    value: T;
+    dependencies: unknown[];
+    /**
+     * Builds (and memoizes) per-node read summaries keyed by unproxied node.
+     * Lazy because summaries are only needed when a dependency emits between
+     * selector runs; selector-only runs skip the Map/Set allocations.
+     */
+    getAccessSummaries: () => Map<TreeNode, ITrackedNodeAccessSummary>;
+}
+
+function getOrCreateAccessSummary(
+    accessSummaries: Map<TreeNode, ITrackedNodeAccessSummary>,
+    node: TreeNode
+): ITrackedNodeAccessSummary {
+    const existing = accessSummaries.get(node);
+    if (existing !== undefined) {
+        return existing;
+    }
+    const created: ITrackedNodeAccessSummary = {
+        wholeNodeRead: false,
+        keyScopable: true,
+        propertyKeys: new Set(),
+        validators: [],
+    };
+    accessSummaries.set(node, created);
+    return created;
+}
+
+function getEntryDependencyUnproxiedNode(
+    entry: DependencyAccessEntry
+): TreeNode | undefined {
+    if (entry.kind !== "dependency") {
+        return undefined;
+    }
+    if (entry.ownerUnproxiedNode !== undefined) {
+        return entry.ownerUnproxiedNode;
+    }
+    const value = entry.value;
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+    if (!("node" in value)) {
+        return undefined;
+    }
+    const dependencyNode = (value as IReactiveDependency).node;
+    if (
+        dependencyNode === null ||
+        dependencyNode === undefined ||
+        typeof dependencyNode !== "object"
+    ) {
+        return undefined;
+    }
+    const handler = getCustomProxyHandlerFromMetadata(dependencyNode);
+    if (handler === undefined) {
+        return undefined;
+    }
+    return handler[unproxiedBaseNodeKey];
+}
+
+/**
+ * Like {@link collectDependencyAccesses}, but also returns per-node read
+ * summaries so tracked `Retree.select` can validate a dependency's
+ * `nodeChanged` without re-running the selector.
+ */
+export function collectTrackedSelectionAccesses<T>(
+    callback: () => T
+): ITrackedSelectionAccesses<T> {
+    let value: T | undefined;
+    const frame = createDependencyAccessFrame("dependencies");
+    dependencyAccessStack.push(frame);
+    try {
+        value = callback();
+    } finally {
+        dependencyAccessStack.pop();
+    }
+    const dependencies: unknown[] = [];
+    const liveEntries: DependencyAccessEntry[] = [];
+    for (const entry of frame.entries) {
+        if (entry === undefined) {
+            continue;
+        }
+        dependencies.push(entry.value);
+        liveEntries.push(entry);
+    }
+    let memoizedSummaries: Map<TreeNode, ITrackedNodeAccessSummary> | undefined;
+    return {
+        value: value as T,
+        dependencies,
+        getAccessSummaries: () => {
+            memoizedSummaries ??= buildAccessSummaries(liveEntries);
+            return memoizedSummaries;
+        },
+    };
+}
+
+function buildAccessSummaries(
+    entries: readonly DependencyAccessEntry[]
+): Map<TreeNode, ITrackedNodeAccessSummary> {
+    const accessSummaries = new Map<TreeNode, ITrackedNodeAccessSummary>();
+    for (const entry of entries) {
+        if (entry.kind === "managed-value") {
+            getOrCreateAccessSummary(
+                accessSummaries,
+                entry.unproxiedNode
+            ).wholeNodeRead = true;
+            continue;
+        }
+        const dependencyUnproxiedNode = getEntryDependencyUnproxiedNode(entry);
+        if (dependencyUnproxiedNode === undefined) {
+            // Primitive read with no owner; nothing subscribes to it.
+            continue;
+        }
+        const summary = getOrCreateAccessSummary(
+            accessSummaries,
+            dependencyUnproxiedNode
+        );
+        if (entry.comparisonAccessor === undefined) {
+            // Cannot re-check this read; treat the node as broadly observed.
+            summary.wholeNodeRead = true;
+            continue;
+        }
+        const capturedValues =
+            (entry.value as IReactiveDependency).comparisons ?? [];
+        summary.validators.push({
+            accessor: entry.comparisonAccessor,
+            capturedValues,
+        });
+        if (entry.propertyKey === undefined) {
+            summary.keyScopable = false;
+        } else {
+            summary.propertyKeys.add(String(entry.propertyKey));
+        }
+    }
+    return accessSummaries;
 }
 
 export function collectDependencyComparisonAccesses<T>(callback: () => T): {
@@ -96,11 +294,7 @@ export function collectDependencyComparisonAccesses<T>(callback: () => T): {
     comparisons: unknown[];
 } {
     let value: T | undefined;
-    const frame: DependencyAccessFrame = {
-        entries: [],
-        mode: "comparisons",
-        writes: [],
-    };
+    const frame = createDependencyAccessFrame("comparisons");
     dependencyAccessStack.push(frame);
     try {
         value = callback();
@@ -109,6 +303,9 @@ export function collectDependencyComparisonAccesses<T>(callback: () => T): {
     }
     const comparisons: unknown[] = [];
     for (const entry of frame.entries) {
+        if (entry === undefined) {
+            continue;
+        }
         if (isWrittenPropertyEntry(frame, entry)) {
             continue;
         }
@@ -153,15 +350,57 @@ export function trackDependencyAccess<T>(value: T): T {
                 "Retree internal invariant failed: cannot track a managed dependency value without Retree proxy metadata."
             );
         }
+        const unproxiedNode = handler[unproxiedBaseNodeKey];
+        const entryIndex = currentFrame.entries.length;
         currentFrame.entries.push({
             kind: "managed-value",
             value,
-            unproxiedNode: handler[unproxiedBaseNodeKey],
+            unproxiedNode,
         });
+        currentFrame.managedValueIndices = appendIndexEntry(
+            currentFrame.managedValueIndices,
+            unproxiedNode,
+            entryIndex
+        );
         return value;
     }
     currentFrame.entries.push({ kind: "dependency", value });
     return value;
+}
+
+function appendIndexEntry(
+    indexMap: Map<TreeNode, number[]> | null,
+    node: TreeNode,
+    entryIndex: number
+): Map<TreeNode, number[]> {
+    if (indexMap === null) {
+        return new Map([[node, [entryIndex]]]);
+    }
+    const indices = indexMap.get(node);
+    if (indices === undefined) {
+        indexMap.set(node, [entryIndex]);
+        return indexMap;
+    }
+    indices.push(entryIndex);
+    return indexMap;
+}
+
+function tombstoneIndexedEntries(
+    frame: DependencyAccessFrame,
+    indexMap: Map<TreeNode, number[]> | null,
+    node: TreeNode
+): void {
+    if (indexMap === null) {
+        return;
+    }
+    const indices = indexMap.get(node);
+    if (indices === undefined) {
+        return;
+    }
+    for (const entryIndex of indices) {
+        frame.entries[entryIndex] = undefined;
+    }
+    indexMap.delete(node);
 }
 
 export function trackDependencyOwnerAccess(value: unknown): void {
@@ -220,6 +459,7 @@ export function trackDependencyPropertyAccess<T>(
     const comparisonValue = arrayElementRead
         ? getArrayElementComparisonValue(value)
         : value;
+    const entryIndex = currentFrame.entries.length;
     currentFrame.entries.push({
         kind: "dependency",
         value: {
@@ -242,6 +482,17 @@ export function trackDependencyPropertyAccess<T>(
         isArrayElementRead: arrayElementRead,
         valueUnproxiedNode,
     });
+    if (
+        currentFrame.mode === "comparisons" &&
+        valueUnproxiedNode !== undefined &&
+        !arrayElementRead
+    ) {
+        currentFrame.propertyValueIndices = appendIndexEntry(
+            currentFrame.propertyValueIndices,
+            valueUnproxiedNode,
+            entryIndex
+        );
+    }
     if (arrayElementRead) {
         return value;
     }
@@ -272,6 +523,9 @@ export function replayDependencyComparisonAccesses(
         // Cached trapped memos can already know the current comparison cells
         // from their validation pass. Reusing those cells keeps nested @select
         // collection from re-running expensive property accessors a second time.
+        // The accessor is kept so tracked selections can re-check this read
+        // later without re-running the selector; it has no property key, so
+        // the node stays unscopeable by changed keys.
         currentFrame.entries.push({
             kind: "dependency",
             value: {
@@ -280,6 +534,7 @@ export function replayDependencyComparisonAccesses(
                     ...(comparisonValues?.[index] ?? comparison.getValues()),
                 ],
             } satisfies IReactiveDependency,
+            comparisonAccessor: comparison,
         });
     }
 }
@@ -309,7 +564,16 @@ export function trackDependencyPropertyWrite(
         );
     }
     const ownerUnproxiedNode = handler[unproxiedBaseNodeKey];
-    currentFrame.writes.push({ ownerUnproxiedNode, propertyKey });
+    currentFrame.writtenKeys ??= new Map();
+    const writtenOwnerKeys = currentFrame.writtenKeys.get(ownerUnproxiedNode);
+    if (writtenOwnerKeys === undefined) {
+        currentFrame.writtenKeys.set(
+            ownerUnproxiedNode,
+            new Set([propertyKey])
+        );
+    } else {
+        writtenOwnerKeys.add(propertyKey);
+    }
     removePendingPropertyAccess(currentFrame, ownerUnproxiedNode, propertyKey);
 }
 
@@ -360,8 +624,13 @@ function removePendingPropertyAccess(
     ownerUnproxiedNode: TreeNode,
     propertyKey: string | symbol
 ) {
+    // Linear scan is acceptable here: this only runs on writes during
+    // tracking, which are rare compared to reads.
     for (let index = frame.entries.length - 1; index >= 0; index--) {
         const entry = frame.entries[index];
+        if (entry === undefined) {
+            continue;
+        }
         if (entry.kind !== "dependency") {
             continue;
         }
@@ -371,7 +640,7 @@ function removePendingPropertyAccess(
         if (entry.propertyKey !== propertyKey) {
             continue;
         }
-        frame.entries.splice(index, 1);
+        frame.entries[index] = undefined;
     }
 }
 
@@ -388,31 +657,25 @@ function isWrittenPropertyEntry(
     if (entry.propertyKey === undefined) {
         return false;
     }
-    return frame.writes.some((write) => {
-        if (write.ownerUnproxiedNode !== entry.ownerUnproxiedNode) {
-            return false;
-        }
-        return write.propertyKey === entry.propertyKey;
-    });
+    if (frame.writtenKeys === null) {
+        return false;
+    }
+    const writtenOwnerKeys = frame.writtenKeys.get(entry.ownerUnproxiedNode);
+    if (writtenOwnerKeys === undefined) {
+        return false;
+    }
+    return writtenOwnerKeys.has(entry.propertyKey);
 }
 
 function removePendingPropertyValueAccess(
     frame: DependencyAccessFrame,
     valueUnproxiedNode: TreeNode
 ) {
-    for (let index = frame.entries.length - 1; index >= 0; index--) {
-        const entry = frame.entries[index];
-        if (entry.kind !== "dependency") {
-            continue;
-        }
-        if (entry.isArrayElementRead) {
-            continue;
-        }
-        if (entry.valueUnproxiedNode !== valueUnproxiedNode) {
-            continue;
-        }
-        frame.entries.splice(index, 1);
-    }
+    tombstoneIndexedEntries(
+        frame,
+        frame.propertyValueIndices,
+        valueUnproxiedNode
+    );
 }
 
 function getArrayElementComparisonValue(value: unknown): unknown {
@@ -462,14 +725,5 @@ function removePendingManagedValueAccess(
     frame: DependencyAccessFrame,
     unproxiedNode: TreeNode
 ) {
-    for (let index = frame.entries.length - 1; index >= 0; index--) {
-        const entry = frame.entries[index];
-        if (entry.kind !== "managed-value") {
-            continue;
-        }
-        if (entry.unproxiedNode !== unproxiedNode) {
-            continue;
-        }
-        frame.entries.splice(index, 1);
-    }
+    tombstoneIndexedEntries(frame, frame.managedValueIndices, unproxiedNode);
 }

--- a/packages/retree-core/src/internals/dependency-tracking.ts
+++ b/packages/retree-core/src/internals/dependency-tracking.ts
@@ -2,7 +2,7 @@ import { IReactiveDependency, ReactiveNode } from "../ReactiveNode";
 import { TreeNode } from "../types";
 import {
     getCustomProxyHandlerFromMetadata,
-    isCustomProxy,
+    ICustomProxyHandler,
     TCustomProxy,
     unproxiedBaseNodeKey,
 } from "./proxy-types";
@@ -343,29 +343,34 @@ export function trackDependencyAccess<T>(value: T): T {
     if (typeof value === "function") {
         return value;
     }
-    if (isCustomProxy(value)) {
-        const handler = getCustomProxyHandlerFromMetadata(value);
-        if (handler === undefined) {
-            throw new Error(
-                "Retree internal invariant failed: cannot track a managed dependency value without Retree proxy metadata."
-            );
-        }
+    // One handler read doubles as the isCustomProxy check; identity lookups
+    // dispatch through the proxy get trap, so avoid paying it twice.
+    const handler = getCustomProxyHandlerFromMetadata(value);
+    pushTrackedValueEntry(currentFrame, value, handler);
+    return value;
+}
+
+function pushTrackedValueEntry(
+    frame: DependencyAccessFrame,
+    value: unknown,
+    handler: ICustomProxyHandler<TreeNode> | undefined
+): void {
+    if (handler !== undefined) {
         const unproxiedNode = handler[unproxiedBaseNodeKey];
-        const entryIndex = currentFrame.entries.length;
-        currentFrame.entries.push({
+        const entryIndex = frame.entries.length;
+        frame.entries.push({
             kind: "managed-value",
-            value,
+            value: value as TCustomProxy<TreeNode>,
             unproxiedNode,
         });
-        currentFrame.managedValueIndices = appendIndexEntry(
-            currentFrame.managedValueIndices,
+        frame.managedValueIndices = appendIndexEntry(
+            frame.managedValueIndices,
             unproxiedNode,
             entryIndex
         );
-        return value;
+        return;
     }
-    currentFrame.entries.push({ kind: "dependency", value });
-    return value;
+    frame.entries.push({ kind: "dependency", value });
 }
 
 function appendIndexEntry(
@@ -437,44 +442,49 @@ export function trackDependencyPropertyAccess<T>(
     if (typeof value === "function") {
         return value;
     }
-    if (!isCustomProxy(owner)) {
-        return trackDependencyAccess(value);
-    }
+    // One handler read doubles as the isCustomProxy check; identity lookups
+    // dispatch through the proxy get trap, so avoid paying it twice.
     const ownerHandler = getCustomProxyHandlerFromMetadata(owner);
     if (ownerHandler === undefined) {
-        throw new Error(
-            "Retree internal invariant failed: cannot track a dependency property read without owner proxy metadata."
-        );
+        return trackDependencyAccess(value);
     }
+    // Handler presence proves `owner` is a Retree proxy.
+    const ownerProxy = owner as TCustomProxy<TreeNode>;
     const ownerUnproxiedNode = ownerHandler[unproxiedBaseNodeKey];
     removePendingManagedValueAccess(currentFrame, ownerUnproxiedNode);
     if (currentFrame.mode === "comparisons") {
         removePendingPropertyValueAccess(currentFrame, ownerUnproxiedNode);
     }
-    const valueUnproxiedNode = getValueUnproxiedNode(value);
+    // Fetch the value's handler once; it answers the unproxied-node lookup,
+    // the array-element comparison cell, and the tail value entry below.
+    const valueHandler =
+        value !== null && typeof value === "object"
+            ? getCustomProxyHandlerFromMetadata(value)
+            : undefined;
+    const valueUnproxiedNode = valueHandler?.[unproxiedBaseNodeKey];
     const arrayElementRead = isArrayElementRead(
         ownerUnproxiedNode,
         propertyKey
     );
     const comparisonValue = arrayElementRead
-        ? getArrayElementComparisonValue(value)
+        ? valueUnproxiedNode ?? value
         : value;
     const entryIndex = currentFrame.entries.length;
     currentFrame.entries.push({
         kind: "dependency",
         value: {
-            node: owner,
+            node: ownerProxy,
             comparisons: [comparisonValue],
         } satisfies IReactiveDependency,
         comparisonAccessor: createComparisonAccessor(
             () => [
                 arrayElementRead
                     ? getArrayElementComparisonValue(
-                          Reflect.get(owner, propertyKey)
+                          Reflect.get(ownerProxy, propertyKey)
                       )
-                    : Reflect.get(owner, propertyKey),
+                    : Reflect.get(ownerProxy, propertyKey),
             ],
-            owner,
+            ownerProxy,
             getComparisonAccessorSource(ownerUnproxiedNode, propertyKey)
         ),
         ownerUnproxiedNode,
@@ -499,7 +509,8 @@ export function trackDependencyPropertyAccess<T>(
     if (currentFrame.mode === "comparisons") {
         return value;
     }
-    return trackDependencyAccess(value);
+    pushTrackedValueEntry(currentFrame, value, valueHandler);
+    return value;
 }
 
 export function replayDependencyComparisonAccesses(
@@ -554,14 +565,10 @@ export function trackDependencyPropertyWrite(
     if (isRetreeInternalProperty(propertyKey)) {
         return;
     }
-    if (!isCustomProxy(owner)) {
-        return;
-    }
+    // One handler read doubles as the isCustomProxy check.
     const handler = getCustomProxyHandlerFromMetadata(owner);
     if (handler === undefined) {
-        throw new Error(
-            "Retree internal invariant failed: cannot track a dependency property write without owner proxy metadata."
-        );
+        return;
     }
     const ownerUnproxiedNode = handler[unproxiedBaseNodeKey];
     currentFrame.writtenKeys ??= new Map();
@@ -679,27 +686,12 @@ function removePendingPropertyValueAccess(
 }
 
 function getArrayElementComparisonValue(value: unknown): unknown {
-    if (!isCustomProxy(value)) {
+    if (value === null || typeof value !== "object") {
         return value;
     }
     const handler = getCustomProxyHandlerFromMetadata(value);
     if (handler === undefined) {
-        throw new Error(
-            "Retree internal invariant failed: cannot compare an array element proxy without Retree metadata."
-        );
-    }
-    return handler[unproxiedBaseNodeKey];
-}
-
-function getValueUnproxiedNode(value: unknown): TreeNode | undefined {
-    if (!isCustomProxy(value)) {
-        return undefined;
-    }
-    const handler = getCustomProxyHandlerFromMetadata(value);
-    if (handler === undefined) {
-        throw new Error(
-            "Retree internal invariant failed: cannot track a dependency value proxy without Retree metadata."
-        );
+        return value;
     }
     return handler[unproxiedBaseNodeKey];
 }

--- a/packages/retree-core/src/internals/proxy-types.ts
+++ b/packages/retree-core/src/internals/proxy-types.ts
@@ -3,6 +3,7 @@ import { TreeNode } from "../types";
 export const unproxiedBaseNodeKey = Symbol("retree-base-node");
 export const proxiedParentKey = Symbol("retree-parent");
 export const proxiedChildrenKey = Symbol("retree-children");
+export const proxyTargetKey = Symbol("retree-proxy-target");
 
 /**
  * @internal
@@ -20,6 +21,12 @@ export interface ICustomProxyHandler<TNode extends TreeNode = TreeNode> {
     [unproxiedBaseNodeKey]: TNode;
     [proxiedChildrenKey]: Record<string | symbol, any>;
     [proxiedParentKey]: IProxyParent | null;
+    /**
+     * The proxy's direct target when it differs from the raw node. Base proxy
+     * handlers omit this (their target is the raw node); reproxy handlers set
+     * it to the base proxy they wrap.
+     */
+    [proxyTargetKey]?: TNode;
 }
 
 /**
@@ -45,14 +52,13 @@ export interface ICustomProxy<TNode extends TreeNode = TreeNode> {
 export type TCustomProxy<TNode extends TreeNode = TreeNode> =
     ICustomProxy<TNode> & TNode;
 
-interface CustomProxyMetadata<TNode extends TreeNode = TreeNode> {
-    handler: ICustomProxyHandler<TNode>;
-    target: TNode;
-}
-
+// Keyed by proxy, valued by the proxy's handler. The handler already knows the
+// raw node and (for reproxies) the wrapped target, so storing it directly
+// avoids allocating a metadata record per proxy — a measurable share of
+// materialization cost.
 const customProxyMetadata = new WeakMap<
     object,
-    CustomProxyMetadata<TreeNode>
+    ICustomProxyHandler<TreeNode>
 >();
 
 export function registerCustomProxyMetadata<TNode extends TreeNode = TreeNode>(
@@ -60,7 +66,10 @@ export function registerCustomProxyMetadata<TNode extends TreeNode = TreeNode>(
     handler: ICustomProxyHandler<TNode>,
     target: TNode
 ): void {
-    customProxyMetadata.set(proxy, { handler, target });
+    if (target !== handler[unproxiedBaseNodeKey]) {
+        handler[proxyTargetKey] = target;
+    }
+    customProxyMetadata.set(proxy, handler as ICustomProxyHandler<TreeNode>);
 }
 
 export function getCustomProxyHandlerFromMetadata<
@@ -69,7 +78,7 @@ export function getCustomProxyHandlerFromMetadata<
     if (value === null || typeof value !== "object") {
         return undefined;
     }
-    return customProxyMetadata.get(value)?.handler as
+    return customProxyMetadata.get(value) as
         | ICustomProxyHandler<TNode>
         | undefined;
 }
@@ -80,7 +89,11 @@ export function getCustomProxyTargetFromMetadata<
     if (value === null || typeof value !== "object") {
         return undefined;
     }
-    return customProxyMetadata.get(value)?.target as TNode | undefined;
+    const handler = customProxyMetadata.get(value);
+    if (handler === undefined) {
+        return undefined;
+    }
+    return (handler[proxyTargetKey] ?? handler[unproxiedBaseNodeKey]) as TNode;
 }
 
 /**

--- a/packages/retree-core/src/internals/proxy-types.ts
+++ b/packages/retree-core/src/internals/proxy-types.ts
@@ -4,6 +4,14 @@ export const unproxiedBaseNodeKey = Symbol("retree-base-node");
 export const proxiedParentKey = Symbol("retree-parent");
 export const proxiedChildrenKey = Symbol("retree-children");
 export const proxyTargetKey = Symbol("retree-proxy-target");
+/**
+ * @internal
+ * Sentinel symbol intercepted first in Retree proxy get traps. Reading it on
+ * a Retree proxy returns the proxy's handler; on any other value it misses.
+ * This lets proxy-identity checks work without a per-proxy `WeakMap.set`
+ * registration, which was ~14% of large-tree materialization.
+ */
+export const proxyHandlerSentinel = Symbol("retree-proxy-sentinel");
 
 /**
  * @internal
@@ -19,7 +27,7 @@ export interface IProxyParent<T extends TreeNode = TreeNode> {
  */
 export interface ICustomProxyHandler<TNode extends TreeNode = TreeNode> {
     [unproxiedBaseNodeKey]: TNode;
-    [proxiedChildrenKey]: Record<string | symbol, any>;
+    [proxiedChildrenKey]: Record<string | symbol, any> | null;
     [proxiedParentKey]: IProxyParent | null;
     /**
      * The proxy's direct target when it differs from the raw node. Base proxy
@@ -52,24 +60,19 @@ export interface ICustomProxy<TNode extends TreeNode = TreeNode> {
 export type TCustomProxy<TNode extends TreeNode = TreeNode> =
     ICustomProxy<TNode> & TNode;
 
-// Keyed by proxy, valued by the proxy's handler. The handler already knows the
-// raw node and (for reproxies) the wrapped target, so storing it directly
-// avoids allocating a metadata record per proxy — a measurable share of
-// materialization cost.
-const customProxyMetadata = new WeakMap<
-    object,
-    ICustomProxyHandler<TreeNode>
->();
-
 export function registerCustomProxyMetadata<TNode extends TreeNode = TreeNode>(
     proxy: TCustomProxy<TNode>,
     handler: ICustomProxyHandler<TNode>,
     target: TNode
 ): void {
+    // No registry write happens here: the proxy's get trap answers
+    // proxyHandlerSentinel reads with its handler, so proxy identity is
+    // discoverable without a per-proxy WeakMap.set. Only reproxies need the
+    // wrapped target recorded (base proxies target their raw node).
     if (target !== handler[unproxiedBaseNodeKey]) {
         handler[proxyTargetKey] = target;
     }
-    customProxyMetadata.set(proxy, handler as ICustomProxyHandler<TreeNode>);
+    void proxy;
 }
 
 export function getCustomProxyHandlerFromMetadata<
@@ -78,18 +81,32 @@ export function getCustomProxyHandlerFromMetadata<
     if (value === null || typeof value !== "object") {
         return undefined;
     }
-    return customProxyMetadata.get(value) as
-        | ICustomProxyHandler<TNode>
-        | undefined;
+    let handler: unknown;
+    try {
+        // Retree proxies intercept this sentinel and return their handler.
+        // Plain objects miss. Foreign proxies see one unknown-symbol read,
+        // which well-behaved traps answer with undefined.
+        handler = (value as { [proxyHandlerSentinel]?: unknown })[
+            proxyHandlerSentinel
+        ];
+    } catch {
+        // Revoked proxies throw on any property read.
+        return undefined;
+    }
+    if (handler === undefined) {
+        return undefined;
+    }
+    // Guard against foreign proxies that answer arbitrary keys.
+    if (!isCustomProxyHandler<TNode>(handler)) {
+        return undefined;
+    }
+    return handler;
 }
 
 export function getCustomProxyTargetFromMetadata<
     TNode extends TreeNode = TreeNode
 >(value: unknown): TNode | undefined {
-    if (value === null || typeof value !== "object") {
-        return undefined;
-    }
-    const handler = customProxyMetadata.get(value);
+    const handler = getCustomProxyHandlerFromMetadata(value);
     if (handler === undefined) {
         return undefined;
     }

--- a/packages/retree-core/src/internals/proxy-types.ts
+++ b/packages/retree-core/src/internals/proxy-types.ts
@@ -30,6 +30,13 @@ export interface ICustomProxyHandler<TNode extends TreeNode = TreeNode> {
     [proxiedChildrenKey]: Record<string | symbol, any> | null;
     [proxiedParentKey]: IProxyParent | null;
     /**
+     * Map/Set child proxies keyed by map key / raw member (raw purity: raw
+     * collections store raw values only). Base handlers own this; reproxy
+     * handlers never need it because internal-slot reads delegate to the
+     * base proxy.
+     */
+    collectionProxies?: Map<any, TCustomProxy<TreeNode>> | null;
+    /**
      * The proxy's direct target when it differs from the raw node. Base proxy
      * handlers omit this (their target is the raw node); reproxy handlers set
      * it to the base proxy they wrap.

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -225,6 +225,12 @@ class BaseProxyHandler<T extends TreeNode>
         string | symbol,
         BoundFunctionCacheEntry
     > | null = null;
+    /**
+     * Raw purity: Map/Set targets store raw values only; their child proxies
+     * live here, keyed by map key (Map) or raw member (Set). Lazily
+     * allocated for collections with object values.
+     */
+    public collectionProxies: Map<any, TCustomProxy<any>> | null = null;
 
     constructor(
         object: T,
@@ -321,6 +327,7 @@ class BaseProxyHandler<T extends TreeNode>
                     MAP_MUTATING_METHODS.has(prop)
                 ) {
                     return wrapMapMutation(
+                        this,
                         prop,
                         mapObject,
                         baseProxy,
@@ -329,6 +336,7 @@ class BaseProxyHandler<T extends TreeNode>
                 }
                 if (mapObject !== undefined) {
                     return wrapMapRead(
+                        this,
                         prop,
                         mapObject,
                         baseProxy,
@@ -341,6 +349,7 @@ class BaseProxyHandler<T extends TreeNode>
                     SET_MUTATING_METHODS.has(prop)
                 ) {
                     return wrapSetMutation(
+                        this,
                         prop,
                         setObject,
                         baseProxy,
@@ -349,6 +358,7 @@ class BaseProxyHandler<T extends TreeNode>
                 }
                 if (setObject !== undefined) {
                     return wrapSetRead(
+                        this,
                         prop,
                         setObject,
                         baseProxy,
@@ -434,18 +444,29 @@ class BaseProxyHandler<T extends TreeNode>
         const baseProxy = this.baseProxy;
         const reactiveObject = this.reactiveObject;
         trackPropertyWriteIfNeeded(baseProxy, prop);
+        // Raw purity: targets store raw values only; proxies live in the
+        // children cache. Change payloads are raw on both sides.
+        const rawNewValue =
+            newValue !== null && typeof newValue === "object"
+                ? getUnproxiedNode(newValue) ?? newValue
+                : newValue;
         if (reactiveObject !== undefined) {
             const propString = String(prop);
             if (reactiveObject[LINKED_KEYS_SYMBOL].has(prop)) {
                 assertValidLinkedValue(prop, newValue);
                 const prev = Reflect.get(target, prop, target);
-                if (prev === newValue) {
+                if (prev === rawNewValue) {
                     return true;
                 }
                 let returnValue: boolean;
                 this.isApplyingSet = true;
                 try {
-                    returnValue = Reflect.set(target, prop, newValue, target);
+                    returnValue = Reflect.set(
+                        target,
+                        prop,
+                        rawNewValue,
+                        target
+                    );
                 } finally {
                     this.isApplyingSet = false;
                 }
@@ -454,7 +475,7 @@ class BaseProxyHandler<T extends TreeNode>
                     const changes = createNodeFieldChanges(
                         prop,
                         prev,
-                        newValue
+                        rawNewValue
                     );
                     this.emitter.emit(
                         "nodeChanged",
@@ -475,9 +496,10 @@ class BaseProxyHandler<T extends TreeNode>
             }
         }
         const prev = (target as any)[prop];
-        const hasChanged = prev !== newValue;
+        // Raw-to-raw comparison: reassigning the node already stored at this
+        // property (via its base proxy or any reproxy) is a no-op.
+        const hasChanged = prev !== rawNewValue;
         if (hasChanged) {
-            let valueToSet = newValue;
             const nodeRemoved = handleNodeRemoved(baseProxy, prop);
             if (newValue !== null && typeof newValue === "object") {
                 if (prop === "constructor")
@@ -491,26 +513,35 @@ class BaseProxyHandler<T extends TreeNode>
                     propName: prop,
                 };
                 if (isCustomProxy(newValue)) {
-                    valueToSet = reparentProxy(newValue, parentToSet);
-                    setProxiedChild(this, prop, valueToSet);
+                    setProxiedChild(
+                        this,
+                        prop,
+                        reparentProxy(newValue, parentToSet)
+                    );
                 } else if (
                     getManagedProxyForUnproxiedNode(newValue) !== undefined
                 ) {
-                    valueToSet = createStructuralProxyForValue(
-                        newValue,
-                        parentToSet,
-                        this.emitter
+                    setProxiedChild(
+                        this,
+                        prop,
+                        createStructuralProxyForValue(
+                            newValue,
+                            parentToSet,
+                            this.emitter
+                        )
                     );
-                    setProxiedChild(this, prop, valueToSet);
                 } else if (shouldCreatePlainObjectProxyLazily(newValue)) {
                     deleteProxiedChild(this, prop);
                 } else {
-                    valueToSet = createStructuralProxyForValue(
-                        newValue,
-                        parentToSet,
-                        this.emitter
+                    setProxiedChild(
+                        this,
+                        prop,
+                        createStructuralProxyForValue(
+                            newValue,
+                            parentToSet,
+                            this.emitter
+                        )
                     );
-                    setProxiedChild(this, prop, valueToSet);
                 }
             } else {
                 deleteProxiedChild(this, prop);
@@ -518,14 +549,14 @@ class BaseProxyHandler<T extends TreeNode>
             let returnValue: boolean;
             this.isApplyingSet = true;
             try {
-                returnValue = Reflect.set(target, prop, valueToSet, receiver);
+                returnValue = Reflect.set(target, prop, rawNewValue, receiver);
             } finally {
                 this.isApplyingSet = false;
             }
             // If in a skip reproxy transaction, do not reproxy node
             if (!Transactions.skipReproxy) {
                 const reproxy = updateReproxyNode(baseProxy);
-                const changes = createNodeFieldChanges(prop, prev, newValue);
+                const changes = createNodeFieldChanges(prop, prev, rawNewValue);
                 // Still emit here if in a `skipEmit` transaction so that parents get reproxied
                 this.emitter.emit(
                     "nodeChanged",
@@ -590,9 +621,14 @@ class BaseProxyHandler<T extends TreeNode>
         const previousValue = currentDescriptorHasValue(currentDescriptor)
             ? currentDescriptor.value
             : undefined;
-        const nextValue = descriptorHasValue(descriptor)
-            ? descriptor.value
+        // Raw purity: payload values are raw on both sides (§9.1 of the raw
+        // spec); the defined value stored in the target is raw as well.
+        const rawNextValue = descriptorHasValue(descriptor)
+            ? descriptor.value !== null && typeof descriptor.value === "object"
+                ? getUnproxiedNode(descriptor.value) ?? descriptor.value
+                : descriptor.value
             : descriptor;
+        const nextValue = rawNextValue;
         let nodeRemoved: object | undefined;
 
         if (descriptorHasValue(descriptorToDefine)) {
@@ -625,11 +661,10 @@ class BaseProxyHandler<T extends TreeNode>
                 nodeRemoved = handleNodeRemoved(baseProxy, prop);
             }
             deleteProxiedChild(this, prop);
-        } else {
-            const cachedChild = this[proxiedChildrenKey]?.[prop];
-            if (cachedChild && currentDescriptorHasValue(currentDescriptor)) {
-                descriptorToDefine.value = cachedChild;
-            }
+        } else if (currentDescriptorHasValue(currentDescriptor)) {
+            // Attribute-only redefinition of a data property: the target
+            // already stores the raw child; keep it in place.
+            descriptorToDefine.value = currentDescriptor.value;
         }
 
         const returnValue = Reflect.defineProperty(
@@ -760,7 +795,13 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     propName: mapKeyAsPropName(key),
                 };
                 const childProxy = reparentProxy(value, parentToSet);
-                Map.prototype.set.call(object, key, childProxy);
+                cacheCollectionChildProxy(proxyHandler, key, childProxy);
+                // Raw purity: the raw map stores the raw node.
+                Map.prototype.set.call(
+                    object,
+                    key,
+                    getUnproxiedNode(childProxy)
+                );
             }
         }
     } else if (object instanceof Set) {
@@ -772,10 +813,13 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     propName: null,
                 };
                 const childProxy = reparentProxy(value, parentToSet);
-                if (childProxy !== value) {
+                const rawChild = getUnproxiedNode(childProxy);
+                cacheCollectionChildProxy(proxyHandler, rawChild, childProxy);
+                // Raw purity: the raw set stores the raw node.
+                if (rawChild !== value) {
                     replacements.push({
                         previous: value,
-                        next: childProxy,
+                        next: rawChild,
                     });
                 }
             }
@@ -1012,6 +1056,10 @@ function isProxyableObject(value: unknown): value is object {
     return typeof value === "object";
 }
 
+/**
+ * Prepare a value being defined onto a node: parent/cache its proxy and
+ * return the **raw** value to store in the target (raw purity).
+ */
 function preparePropertyValue(
     value: unknown,
     prop: string | symbol,
@@ -1043,10 +1091,87 @@ function preparePropertyValue(
         emitter
     );
     setProxiedChild(proxyHandler, prop, valueToSet);
-    return valueToSet;
+    return getUnproxiedNode(valueToSet as TreeNode) ?? valueToSet;
+}
+
+/**
+ * @internal
+ * Force-materialize the direct children of a managed node by reading each
+ * object-valued child through the proxy once. Used by `useRaw`'s `toSource`
+ * to guarantee raw direct children (including Map values and Set members)
+ * resolve to managed nodes. Idempotent: already-materialized children are
+ * cache hits.
+ */
+export function materializeDirectChildren(node: TreeNode): void {
+    const baseProxy = getBaseProxy(node);
+    const rawNode = getUnproxiedNode(baseProxy);
+    if (rawNode === undefined) {
+        return;
+    }
+    if (rawNode instanceof Map) {
+        const mapProxy = baseProxy as unknown as Map<unknown, unknown>;
+        for (const key of Map.prototype.keys.call(rawNode)) {
+            void mapProxy.get(key);
+        }
+        return;
+    }
+    if (rawNode instanceof Set) {
+        const setProxy = baseProxy as unknown as Set<unknown>;
+        for (const value of setProxy.values()) {
+            void value;
+        }
+        return;
+    }
+    if (rawNode instanceof Date) {
+        return;
+    }
+    const record = baseProxy as unknown as Record<string, unknown>;
+    for (const key of Object.keys(rawNode)) {
+        const rawValue = (rawNode as Record<string, unknown>)[key];
+        if (rawValue !== null && typeof rawValue === "object") {
+            void record[key];
+        }
+    }
+}
+
+function unwrapCollectionValue(value: any): any {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+    return getUnproxiedNode(value) ?? value;
+}
+
+function resolveCollectionChildProxy(
+    handler: ICustomProxyHandler<any>,
+    cacheKey: any,
+    rawValue: unknown
+): TCustomProxy<any> | undefined {
+    const cached = handler.collectionProxies?.get(cacheKey);
+    if (
+        cached !== undefined &&
+        getUnproxiedNodeFromProxy(cached) === rawValue
+    ) {
+        return cached;
+    }
+    if (rawValue === null || typeof rawValue !== "object") {
+        return undefined;
+    }
+    return getManagedProxyForUnproxiedNode(rawValue as TreeNode);
+}
+
+function cacheCollectionChildProxy(
+    handler: ICustomProxyHandler<any>,
+    cacheKey: any,
+    childProxy: object
+): void {
+    (handler.collectionProxies ??= new Map()).set(
+        cacheKey,
+        getBaseProxy(childProxy as TreeNode)
+    );
 }
 
 function wrapMapRead(
+    handler: ICustomProxyHandler<any>,
     prop: string | symbol,
     target: Map<any, any>,
     baseProxy: TCustomProxy<any>,
@@ -1056,7 +1181,7 @@ function wrapMapRead(
         return function getWrapper(key: any) {
             const value = Map.prototype.get.call(target, key);
             return getOrCreateMapValueProxy(
-                target,
+                handler,
                 key,
                 value,
                 baseProxy,
@@ -1066,12 +1191,12 @@ function wrapMapRead(
     }
     if (prop === "values") {
         return function valuesWrapper() {
-            return mapValuesIterator(target, baseProxy, emitter);
+            return mapValuesIterator(handler, target, baseProxy, emitter);
         };
     }
     if (prop === "entries" || prop === Symbol.iterator) {
         return function entriesWrapper() {
-            return mapEntriesIterator(target, baseProxy, emitter);
+            return mapEntriesIterator(handler, target, baseProxy, emitter);
         };
     }
     if (prop === "forEach") {
@@ -1081,7 +1206,7 @@ function wrapMapRead(
         ) {
             Map.prototype.forEach.call(target, (value, key) => {
                 const valueToRead = getOrCreateMapValueProxy(
-                    target,
+                    handler,
                     key,
                     value,
                     baseProxy,
@@ -1095,16 +1220,18 @@ function wrapMapRead(
 }
 
 function* mapValuesIterator(
+    handler: ICustomProxyHandler<any>,
     target: Map<any, any>,
     baseProxy: TCustomProxy<any>,
     emitter: TreeChangeEmitter
 ) {
     for (const [key, value] of Map.prototype.entries.call(target)) {
-        yield getOrCreateMapValueProxy(target, key, value, baseProxy, emitter);
+        yield getOrCreateMapValueProxy(handler, key, value, baseProxy, emitter);
     }
 }
 
 function* mapEntriesIterator(
+    handler: ICustomProxyHandler<any>,
     target: Map<any, any>,
     baseProxy: TCustomProxy<any>,
     emitter: TreeChangeEmitter
@@ -1112,13 +1239,13 @@ function* mapEntriesIterator(
     for (const [key, value] of Map.prototype.entries.call(target)) {
         yield [
             key,
-            getOrCreateMapValueProxy(target, key, value, baseProxy, emitter),
+            getOrCreateMapValueProxy(handler, key, value, baseProxy, emitter),
         ];
     }
 }
 
 function getOrCreateMapValueProxy(
-    target: Map<any, any>,
+    handler: ICustomProxyHandler<any>,
     key: any,
     value: any,
     baseProxy: TCustomProxy<any>,
@@ -1126,6 +1253,12 @@ function getOrCreateMapValueProxy(
 ) {
     if (value === null || typeof value !== "object") {
         return value;
+    }
+    // Raw purity: the raw map stores raw values; the child proxy lives in
+    // the handler's side cache keyed by map key.
+    const cached = handler.collectionProxies?.get(key);
+    if (cached !== undefined && getUnproxiedNodeFromProxy(cached) === value) {
+        return cached;
     }
     const parentToSet: IProxyParent<any> = {
         proxyNode: baseProxy,
@@ -1136,13 +1269,12 @@ function getOrCreateMapValueProxy(
         parentToSet,
         emitter
     );
-    if (valueToRead !== value) {
-        Map.prototype.set.call(target, key, valueToRead);
-    }
+    cacheCollectionChildProxy(handler, key, valueToRead);
     return valueToRead;
 }
 
 function wrapMapMutation(
+    handler: ICustomProxyHandler<any>,
     prop: string,
     target: Map<any, any>,
     baseProxy: TCustomProxy<any>,
@@ -1151,33 +1283,52 @@ function wrapMapMutation(
     if (prop === "set") {
         return function setWrapper(key: any, value: any) {
             const previous = target.get(key);
+            const rawValue = unwrapCollectionValue(value);
             const removedNodes: object[] = [];
             // If we are replacing an existing object child of this map, detach it.
             if (
-                previous !== value &&
+                previous !== rawValue &&
                 previous !== null &&
                 typeof previous === "object"
             ) {
-                const removed = detachCollectionChild(previous, baseProxy);
-                if (removed) removedNodes.push(removed);
+                const previousProxy = resolveCollectionChildProxy(
+                    handler,
+                    key,
+                    previous
+                );
+                if (previousProxy !== undefined) {
+                    const removed = detachCollectionChild(
+                        previousProxy,
+                        baseProxy
+                    );
+                    if (removed) removedNodes.push(removed);
+                }
             }
-            let valueToStore: any = value;
             if (value !== null && typeof value === "object") {
                 const parentToSet: IProxyParent<any> = {
                     proxyNode: baseProxy,
                     propName: mapKeyAsPropName(key),
                 };
                 if (isCustomProxy(value)) {
-                    valueToStore = reparentProxy(value, parentToSet);
+                    cacheCollectionChildProxy(
+                        handler,
+                        key,
+                        reparentProxy(value, parentToSet)
+                    );
+                } else {
+                    // Plain or managed-raw values resolve lazily on read.
+                    handler.collectionProxies?.delete(key);
                 }
+            } else {
+                handler.collectionProxies?.delete(key);
             }
-            Map.prototype.set.call(target, key, valueToStore);
+            Map.prototype.set.call(target, key, rawValue);
             emitCollectionChange(
                 target,
                 baseProxy,
                 emitter,
                 removedNodes,
-                createNodeFieldChanges(key, previous, value)
+                createNodeFieldChanges(key, previous, rawValue)
             );
             // Map.prototype.set returns the map itself; return the proxy so chaining stays reactive.
             return baseProxy;
@@ -1192,11 +1343,22 @@ function wrapMapMutation(
                 previous !== undefined &&
                 typeof previous === "object"
             ) {
-                const removed = detachCollectionChild(previous, baseProxy);
-                if (removed) removedNodes.push(removed);
+                const previousProxy = resolveCollectionChildProxy(
+                    handler,
+                    key,
+                    previous
+                );
+                if (previousProxy !== undefined) {
+                    const removed = detachCollectionChild(
+                        previousProxy,
+                        baseProxy
+                    );
+                    if (removed) removedNodes.push(removed);
+                }
             }
             const result = Map.prototype.delete.call(target, key);
             if (result) {
+                handler.collectionProxies?.delete(key);
                 emitCollectionChange(
                     target,
                     baseProxy,
@@ -1212,14 +1374,25 @@ function wrapMapMutation(
         return function clearWrapper() {
             if (target.size === 0) return;
             const removedNodes: object[] = [];
-            target.forEach((value) => {
+            Map.prototype.forEach.call(target, (value, key) => {
                 if (value !== null && typeof value === "object") {
-                    const removed = detachCollectionChild(value, baseProxy);
-                    if (removed) removedNodes.push(removed);
+                    const valueProxy = resolveCollectionChildProxy(
+                        handler,
+                        key,
+                        value
+                    );
+                    if (valueProxy !== undefined) {
+                        const removed = detachCollectionChild(
+                            valueProxy,
+                            baseProxy
+                        );
+                        if (removed) removedNodes.push(removed);
+                    }
                 }
             });
             const previousSize = target.size;
             Map.prototype.clear.call(target);
+            handler.collectionProxies?.clear();
             emitCollectionChange(
                 target,
                 baseProxy,
@@ -1236,6 +1409,7 @@ function wrapMapMutation(
 }
 
 function wrapSetRead(
+    handler: ICustomProxyHandler<any>,
     prop: string | symbol,
     target: Set<any>,
     baseProxy: TCustomProxy<any>,
@@ -1246,12 +1420,12 @@ function wrapSetRead(
     }
     if (prop === "values" || prop === "keys" || prop === Symbol.iterator) {
         return function valuesWrapper() {
-            return setValuesIterator(target, baseProxy, emitter);
+            return setValuesIterator(handler, target, baseProxy, emitter);
         };
     }
     if (prop === "entries") {
         return function entriesWrapper() {
-            return setEntriesIterator(target, baseProxy, emitter);
+            return setEntriesIterator(handler, target, baseProxy, emitter);
         };
     }
     if (prop === "forEach") {
@@ -1261,7 +1435,7 @@ function wrapSetRead(
         ) {
             for (const value of Set.prototype.values.call(target)) {
                 const valueToRead = getOrCreateSetValueProxy(
-                    target,
+                    handler,
                     value,
                     baseProxy,
                     emitter
@@ -1273,26 +1447,28 @@ function wrapSetRead(
     return (Reflect.get(target, prop, target) as Function).bind(target);
 }
 
+// Raw purity removed the read-time write-backs that used to mutate the set
+// during iteration, so these iterators no longer need an Array.from copy.
 function* setValuesIterator(
+    handler: ICustomProxyHandler<any>,
     target: Set<any>,
     baseProxy: TCustomProxy<any>,
     emitter: TreeChangeEmitter
 ) {
-    const values = Array.from(Set.prototype.values.call(target));
-    for (const value of values) {
-        yield getOrCreateSetValueProxy(target, value, baseProxy, emitter);
+    for (const value of Set.prototype.values.call(target)) {
+        yield getOrCreateSetValueProxy(handler, value, baseProxy, emitter);
     }
 }
 
 function* setEntriesIterator(
+    handler: ICustomProxyHandler<any>,
     target: Set<any>,
     baseProxy: TCustomProxy<any>,
     emitter: TreeChangeEmitter
 ) {
-    const values = Array.from(Set.prototype.values.call(target));
-    for (const value of values) {
+    for (const value of Set.prototype.values.call(target)) {
         const valueToRead = getOrCreateSetValueProxy(
-            target,
+            handler,
             value,
             baseProxy,
             emitter
@@ -1302,13 +1478,19 @@ function* setEntriesIterator(
 }
 
 function getOrCreateSetValueProxy(
-    target: Set<any>,
+    handler: ICustomProxyHandler<any>,
     value: any,
     baseProxy: TCustomProxy<any>,
     emitter: TreeChangeEmitter
 ) {
     if (value === null || typeof value !== "object") {
         return value;
+    }
+    // Raw purity: the raw set stores raw members; the child proxy lives in
+    // the handler's side cache keyed by the raw member.
+    const cached = handler.collectionProxies?.get(value);
+    if (cached !== undefined) {
+        return cached;
     }
     const parentToSet: IProxyParent<any> = {
         proxyNode: baseProxy,
@@ -1319,14 +1501,12 @@ function getOrCreateSetValueProxy(
         parentToSet,
         emitter
     );
-    if (valueToRead !== value) {
-        Set.prototype.delete.call(target, value);
-        Set.prototype.add.call(target, valueToRead);
-    }
+    cacheCollectionChildProxy(handler, value, valueToRead);
     return valueToRead;
 }
 
 function wrapSetMutation(
+    handler: ICustomProxyHandler<any>,
     prop: string,
     target: Set<any>,
     baseProxy: TCustomProxy<any>,
@@ -1334,27 +1514,30 @@ function wrapSetMutation(
 ) {
     if (prop === "add") {
         return function addWrapper(value: any) {
-            const hadValue = findSetStoredValue(target, value) !== undefined;
-            if (hadValue) {
+            const rawValue = unwrapCollectionValue(value);
+            if (findSetStoredValue(target, rawValue) !== undefined) {
                 return baseProxy;
             }
-            let valueToStore = value;
             if (value !== null && typeof value === "object") {
                 const parentToSet: IProxyParent<any> = {
                     proxyNode: baseProxy,
                     propName: null,
                 };
                 if (isCustomProxy(value)) {
-                    valueToStore = reparentProxy(value, parentToSet);
+                    cacheCollectionChildProxy(
+                        handler,
+                        rawValue,
+                        reparentProxy(value, parentToSet)
+                    );
                 }
             }
-            Set.prototype.add.call(target, valueToStore);
+            Set.prototype.add.call(target, rawValue);
             emitCollectionChange(
                 target,
                 baseProxy,
                 emitter,
                 [],
-                createNodeFieldChanges("add", undefined, value)
+                createNodeFieldChanges("add", undefined, rawValue)
             );
             return baseProxy;
         };
@@ -1365,16 +1548,28 @@ function wrapSetMutation(
             const removedNodes: object[] = [];
             if (
                 valueToDelete !== undefined &&
+                valueToDelete !== null &&
                 typeof valueToDelete === "object"
             ) {
-                const removed = detachCollectionChild(valueToDelete, baseProxy);
-                if (removed) removedNodes.push(removed);
+                const valueProxy = resolveCollectionChildProxy(
+                    handler,
+                    valueToDelete,
+                    valueToDelete
+                );
+                if (valueProxy !== undefined) {
+                    const removed = detachCollectionChild(
+                        valueProxy,
+                        baseProxy
+                    );
+                    if (removed) removedNodes.push(removed);
+                }
             }
             const result =
                 valueToDelete === undefined
                     ? false
                     : Set.prototype.delete.call(target, valueToDelete);
             if (result) {
+                handler.collectionProxies?.delete(valueToDelete);
                 emitCollectionChange(
                     target,
                     baseProxy,
@@ -1390,14 +1585,25 @@ function wrapSetMutation(
         return function clearWrapper() {
             if (target.size === 0) return;
             const removedNodes: object[] = [];
-            target.forEach((value) => {
+            Set.prototype.forEach.call(target, (value) => {
                 if (value !== null && typeof value === "object") {
-                    const removed = detachCollectionChild(value, baseProxy);
-                    if (removed) removedNodes.push(removed);
+                    const valueProxy = resolveCollectionChildProxy(
+                        handler,
+                        value,
+                        value
+                    );
+                    if (valueProxy !== undefined) {
+                        const removed = detachCollectionChild(
+                            valueProxy,
+                            baseProxy
+                        );
+                        if (removed) removedNodes.push(removed);
+                    }
                 }
             });
             const previousSize = target.size;
             Set.prototype.clear.call(target);
+            handler.collectionProxies?.clear();
             emitCollectionChange(
                 target,
                 baseProxy,
@@ -1419,6 +1625,10 @@ function wrapSetHas(target: Set<any>) {
     };
 }
 
+/**
+ * Raw purity: sets store raw members, so membership checks reduce to at most
+ * two `Set.prototype.has` calls (the value as given, then its raw node).
+ */
 function findSetStoredValue(target: Set<any>, value: any) {
     if (Set.prototype.has.call(target, value)) {
         return value;
@@ -1427,17 +1637,12 @@ function findSetStoredValue(target: Set<any>, value: any) {
         return undefined;
     }
     const rawValue = getUnproxiedNode(value);
-    for (const storedValue of target.values()) {
-        if (storedValue === value) {
-            return storedValue;
-        }
-        if (
-            storedValue !== null &&
-            typeof storedValue === "object" &&
-            getUnproxiedNode(storedValue) === rawValue
-        ) {
-            return storedValue;
-        }
+    if (
+        rawValue !== undefined &&
+        rawValue !== value &&
+        Set.prototype.has.call(target, rawValue)
+    ) {
+        return rawValue;
     }
     return undefined;
 }

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -20,6 +20,8 @@ import {
     isCustomProxyHandler,
     proxiedChildrenKey,
     proxiedParentKey,
+    proxyHandlerSentinel,
+    proxyTargetKey,
     registerCustomProxyMetadata,
     TCustomProxy,
     unproxiedBaseNodeKey,
@@ -196,6 +198,535 @@ function assertValidLinkedValue(prop: string | symbol, value: unknown) {
 
 /**
  * @internal
+ * Proxy handler for a base (non-reproxy) Retree node.
+ *
+ * @remarks
+ * Trap methods live on the prototype and per-node state lives in fields, so
+ * creating a node allocates one handler instance instead of a handler object
+ * literal plus one closure per trap. Materialization of large trees is
+ * allocation-bound, so this shape matters.
+ */
+class BaseProxyHandler<T extends TreeNode>
+    implements ProxyHandler<T>, ICustomProxyHandler<T>
+{
+    public [unproxiedBaseNodeKey]: T;
+    public [proxiedChildrenKey]: Record<string | symbol, any> | null;
+    public [proxiedParentKey]: IProxyParent | null;
+    public [proxyTargetKey]?: T;
+    public baseProxy!: TCustomProxy<T>;
+    public readonly emitter: TreeChangeEmitter;
+    public readonly reactiveObject: ReactiveNode | undefined;
+    private readonly mapObject: Map<any, any> | undefined;
+    private readonly setObject: Set<any> | undefined;
+    private readonly dateObject: Date | undefined;
+    private readonly hasInternalSlots: boolean;
+    private isApplyingSet = false;
+    private boundFunctionCache: Map<
+        string | symbol,
+        BoundFunctionCacheEntry
+    > | null = null;
+
+    constructor(
+        object: T,
+        emitter: TreeChangeEmitter,
+        parent: IProxyParent<any> | null
+    ) {
+        this[unproxiedBaseNodeKey] = object;
+        // Lazily allocated: leaf nodes never cache children.
+        this[proxiedChildrenKey] = null;
+        this[proxiedParentKey] = parent;
+        this.emitter = emitter;
+        this.reactiveObject =
+            object instanceof ReactiveNode ? object : undefined;
+        this.mapObject = object instanceof Map ? object : undefined;
+        this.setObject = object instanceof Set ? object : undefined;
+        this.dateObject = object instanceof Date ? object : undefined;
+        this.hasInternalSlots =
+            this.mapObject !== undefined ||
+            this.setObject !== undefined ||
+            this.dateObject !== undefined;
+    }
+
+    private getBoundFunction<TFunction extends Function>(
+        prop: string | symbol,
+        source: TFunction,
+        thisArg: unknown
+    ): TFunction {
+        this.boundFunctionCache ??= new Map();
+        return getCachedBoundFunction(
+            this.boundFunctionCache,
+            prop,
+            source,
+            thisArg
+        );
+    }
+
+    public get(target: T, prop: string | symbol, receiver: any): any {
+        if (prop === proxyHandlerSentinel) {
+            return this;
+        }
+        if (prop === "[[Handler]]") {
+            return this;
+        }
+        if (prop === "[[Target]]") {
+            return this[unproxiedBaseNodeKey];
+        }
+        const reactiveObject = this.reactiveObject;
+        const baseProxy = this.baseProxy;
+        if (reactiveObject !== undefined) {
+            // Collected/ignore keys are always strings; symbol props skip
+            // these checks without paying a String(prop) allocation.
+            if (typeof prop === "string") {
+                if (prop.startsWith("RETREE_")) {
+                    return Reflect.get(target, prop, target);
+                }
+                if (reactiveObject[COLLECTED_KEYS_SYMBOL].has(prop)) {
+                    return trackPropertyAccessIfNeeded(
+                        baseProxy,
+                        prop,
+                        getLatestIgnoredValue(Reflect.get(target, prop, target))
+                    );
+                }
+            }
+            if (reactiveObject[LINKED_KEYS_SYMBOL].has(prop)) {
+                return trackPropertyAccessIfNeeded(
+                    baseProxy,
+                    prop,
+                    getLatestLinkedValue(Reflect.get(target, prop, target))
+                );
+            }
+        }
+        const cachedChildren = this[proxiedChildrenKey];
+        if (
+            cachedChildren !== null &&
+            typeof prop === "string" &&
+            cachedChildren[prop]
+        ) {
+            const value = cachedChildren[prop];
+            if (typeof value !== "function") {
+                return trackPropertyAccessIfNeeded(baseProxy, prop, value);
+            }
+        }
+        if (this.hasInternalSlots) {
+            // Methods on Map/Set must run with the raw target as `this` because they read
+            // internal slots that the proxy does not expose.
+            const value = Reflect.get(target, prop, target);
+            if (typeof value === "function") {
+                const mapObject = this.mapObject;
+                const setObject = this.setObject;
+                const dateObject = this.dateObject;
+                if (
+                    mapObject !== undefined &&
+                    typeof prop === "string" &&
+                    MAP_MUTATING_METHODS.has(prop)
+                ) {
+                    return wrapMapMutation(
+                        prop,
+                        mapObject,
+                        baseProxy,
+                        this.emitter
+                    );
+                }
+                if (mapObject !== undefined) {
+                    return wrapMapRead(
+                        prop,
+                        mapObject,
+                        baseProxy,
+                        this.emitter
+                    );
+                }
+                if (
+                    setObject !== undefined &&
+                    typeof prop === "string" &&
+                    SET_MUTATING_METHODS.has(prop)
+                ) {
+                    return wrapSetMutation(
+                        prop,
+                        setObject,
+                        baseProxy,
+                        this.emitter
+                    );
+                }
+                if (setObject !== undefined) {
+                    return wrapSetRead(
+                        prop,
+                        setObject,
+                        baseProxy,
+                        this.emitter
+                    );
+                }
+                if (
+                    dateObject !== undefined &&
+                    typeof prop === "string" &&
+                    isDateMutatingMethod(prop)
+                ) {
+                    return wrapDateMutation(
+                        prop,
+                        dateObject,
+                        baseProxy,
+                        this.emitter
+                    );
+                }
+                return trackAccessIfNeeded(
+                    this.getBoundFunction(prop, value, target)
+                );
+            }
+            return trackPropertyAccessIfNeeded(baseProxy, prop, value);
+        }
+        let value: any;
+        if (
+            reactiveObject !== undefined &&
+            getReactiveNodeGetter(reactiveObject, prop)
+        ) {
+            // For ReactiveNode getters, push the getter name onto the memo-getter
+            // stack so a keyless `this.memo(fn, deps)` inside the getter can derive
+            // its cache key from `prop`. Pop in `finally` so a throwing getter
+            pushMemoGetter(reactiveObject, prop);
+            try {
+                value = Reflect.get(target, prop, receiver);
+            } finally {
+                popMemoGetter(reactiveObject);
+            }
+        } else {
+            value = Reflect.get(target, prop, receiver);
+        }
+        if (typeof value === "function") {
+            if (FUNCTION_NAMES_BIND_TO_RAW.has(prop)) {
+                return trackAccessIfNeeded(
+                    this.getBoundFunction(prop, value, target)
+                );
+            }
+            return trackAccessIfNeeded(
+                this.getBoundFunction(prop, value, baseProxy)
+            );
+        }
+        if (shouldLazilyProxyProperty(target, prop, value)) {
+            const descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+            if (!descriptor || !descriptorHasValue(descriptor)) {
+                return trackPropertyAccessIfNeeded(baseProxy, prop, value);
+            }
+            // shouldLazilyProxyProperty already established the value is a
+            // proxyable non-proxy object; only the descriptor lock check
+            // from shouldKeepRawPropertyValue remains.
+            if (!descriptorRequiresExactDefinedValue(descriptor, descriptor)) {
+                return trackPropertyAccessIfNeeded(
+                    baseProxy,
+                    prop,
+                    getOrCreateProxiedChild(
+                        this,
+                        prop,
+                        value,
+                        baseProxy,
+                        this.emitter
+                    )
+                );
+            }
+        }
+        return trackPropertyAccessIfNeeded(baseProxy, prop, value);
+    }
+
+    public set(
+        target: T,
+        prop: string | symbol,
+        newValue: any,
+        receiver: any
+    ): boolean {
+        const baseProxy = this.baseProxy;
+        const reactiveObject = this.reactiveObject;
+        trackPropertyWriteIfNeeded(baseProxy, prop);
+        if (reactiveObject !== undefined) {
+            const propString = String(prop);
+            if (reactiveObject[LINKED_KEYS_SYMBOL].has(prop)) {
+                assertValidLinkedValue(prop, newValue);
+                const prev = Reflect.get(target, prop, target);
+                if (prev === newValue) {
+                    return true;
+                }
+                let returnValue: boolean;
+                this.isApplyingSet = true;
+                try {
+                    returnValue = Reflect.set(target, prop, newValue, target);
+                } finally {
+                    this.isApplyingSet = false;
+                }
+                if (!Transactions.skipReproxy) {
+                    const reproxy = updateReproxyNode(baseProxy);
+                    const changes = createNodeFieldChanges(
+                        prop,
+                        prev,
+                        newValue
+                    );
+                    this.emitter.emit(
+                        "nodeChanged",
+                        this[unproxiedBaseNodeKey],
+                        baseProxy,
+                        reproxy,
+                        changes
+                    );
+                }
+                return returnValue;
+            }
+            // Check for ignore keys
+            if (
+                propString === COLLECTED_KEYS_SYMBOL ||
+                reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)
+            ) {
+                return Reflect.set(target, prop, newValue, target);
+            }
+        }
+        const prev = (target as any)[prop];
+        const hasChanged = prev !== newValue;
+        if (hasChanged) {
+            let valueToSet = newValue;
+            const nodeRemoved = handleNodeRemoved(baseProxy, prop);
+            if (newValue !== null && typeof newValue === "object") {
+                if (prop === "constructor")
+                    return Reflect.set(target, prop, newValue, receiver);
+
+                // If already a proxied object, we simply reparent
+                // Otherwise, build a new proxy object, unless this is a plain
+                // object/array child that can be proxied lazily on first read.
+                const parentToSet: IProxyParent<any> = {
+                    proxyNode: baseProxy,
+                    propName: prop,
+                };
+                if (isCustomProxy(newValue)) {
+                    valueToSet = reparentProxy(newValue, parentToSet);
+                    setProxiedChild(this, prop, valueToSet);
+                } else if (
+                    getManagedProxyForUnproxiedNode(newValue) !== undefined
+                ) {
+                    valueToSet = createStructuralProxyForValue(
+                        newValue,
+                        parentToSet,
+                        this.emitter
+                    );
+                    setProxiedChild(this, prop, valueToSet);
+                } else if (shouldCreatePlainObjectProxyLazily(newValue)) {
+                    deleteProxiedChild(this, prop);
+                } else {
+                    valueToSet = createStructuralProxyForValue(
+                        newValue,
+                        parentToSet,
+                        this.emitter
+                    );
+                    setProxiedChild(this, prop, valueToSet);
+                }
+            } else {
+                deleteProxiedChild(this, prop);
+            }
+            let returnValue: boolean;
+            this.isApplyingSet = true;
+            try {
+                returnValue = Reflect.set(target, prop, valueToSet, receiver);
+            } finally {
+                this.isApplyingSet = false;
+            }
+            // If in a skip reproxy transaction, do not reproxy node
+            if (!Transactions.skipReproxy) {
+                const reproxy = updateReproxyNode(baseProxy);
+                const changes = createNodeFieldChanges(prop, prev, newValue);
+                // Still emit here if in a `skipEmit` transaction so that parents get reproxied
+                this.emitter.emit(
+                    "nodeChanged",
+                    this[unproxiedBaseNodeKey],
+                    baseProxy,
+                    reproxy,
+                    changes
+                );
+                // nodeRemoved events do not reproxy parents, so we skip
+                if (nodeRemoved && !Transactions.skipEmit) {
+                    const removedUnproxied = getUnproxiedNode(nodeRemoved);
+                    this.emitter.emit(
+                        "nodeRemoved",
+                        removedUnproxied ?? nodeRemoved,
+                        nodeRemoved
+                    );
+                }
+            }
+
+            return returnValue;
+        }
+        return true;
+    }
+
+    public defineProperty(
+        target: T,
+        prop: string | symbol,
+        descriptor: PropertyDescriptor
+    ): boolean {
+        const reactiveObject = this.reactiveObject;
+        if (this.isApplyingSet) {
+            return Reflect.defineProperty(target, prop, descriptor);
+        }
+        const currentProxyForWrite = isCustomProxy(target)
+            ? target
+            : getManagedProxyForUnproxiedNode(target);
+        const baseProxyForWrite = currentProxyForWrite
+            ? getBaseProxy(currentProxyForWrite)
+            : undefined;
+        if (baseProxyForWrite !== undefined) {
+            trackPropertyWriteIfNeeded(baseProxyForWrite, prop);
+        }
+        if (reactiveObject !== undefined) {
+            const propString = String(prop);
+            // Check for ignore keys
+            if (
+                propString === COLLECTED_KEYS_SYMBOL ||
+                reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)
+            ) {
+                return Reflect.defineProperty(target, prop, descriptor);
+            }
+        }
+        const currentProxy = currentProxyForWrite;
+        const baseProxy = currentProxy
+            ? getBaseProxy(currentProxy)
+            : currentProxy;
+        const descriptorToDefine: PropertyDescriptor = { ...descriptor };
+        const currentDescriptor = Reflect.getOwnPropertyDescriptor(
+            target,
+            prop
+        );
+        const previousValue = currentDescriptorHasValue(currentDescriptor)
+            ? currentDescriptor.value
+            : undefined;
+        const nextValue = descriptorHasValue(descriptor)
+            ? descriptor.value
+            : descriptor;
+        let nodeRemoved: object | undefined;
+
+        if (descriptorHasValue(descriptorToDefine)) {
+            const shouldKeepRawValue =
+                isProxyableObject(descriptorToDefine.value) &&
+                !isCustomProxy(descriptorToDefine.value) &&
+                descriptorRequiresExactDefinedValue(
+                    currentDescriptor,
+                    descriptorToDefine
+                );
+            if (
+                baseProxy &&
+                Reflect.get(baseProxy, prop) !== descriptorToDefine.value
+            ) {
+                nodeRemoved = handleNodeRemoved(baseProxy, prop);
+            }
+            if (shouldKeepRawValue) {
+                deleteProxiedChild(this, prop);
+            } else {
+                descriptorToDefine.value = preparePropertyValue(
+                    descriptorToDefine.value,
+                    prop,
+                    baseProxy,
+                    this.emitter,
+                    this
+                );
+            }
+        } else if (descriptorHasAccessor(descriptorToDefine)) {
+            if (baseProxy) {
+                nodeRemoved = handleNodeRemoved(baseProxy, prop);
+            }
+            deleteProxiedChild(this, prop);
+        } else {
+            const cachedChild = this[proxiedChildrenKey]?.[prop];
+            if (cachedChild && currentDescriptorHasValue(currentDescriptor)) {
+                descriptorToDefine.value = cachedChild;
+            }
+        }
+
+        const returnValue = Reflect.defineProperty(
+            target,
+            prop,
+            descriptorToDefine
+        );
+        // If in a skip reproxy transaction, do not reproxy node
+        if (returnValue && !Transactions.skipReproxy) {
+            if (baseProxy) {
+                const reproxy = updateReproxyNode(baseProxy);
+                // Still emit here if in a `skipEmit` transaction so that parents get reproxied
+                this.emitter.emit(
+                    "nodeChanged",
+                    this[unproxiedBaseNodeKey],
+                    baseProxy,
+                    reproxy,
+                    createNodeFieldChanges(prop, previousValue, nextValue)
+                );
+            } else {
+                console.warn(
+                    `buildProxy.defineProperty: cannot find baseProxy for target`
+                );
+            }
+            // nodeRemoved events do not reproxy parents, so we skip
+            if (nodeRemoved && !Transactions.skipEmit) {
+                const removedUnproxied = getUnproxiedNode(nodeRemoved);
+                this.emitter.emit(
+                    "nodeRemoved",
+                    removedUnproxied ?? nodeRemoved,
+                    nodeRemoved
+                );
+            }
+        }
+        return returnValue;
+    }
+
+    public deleteProperty(target: T, prop: string | symbol): boolean {
+        const reactiveObject = this.reactiveObject;
+        if (reactiveObject !== undefined) {
+            const propString = String(prop);
+            // Check for ignore keys
+            if (
+                propString === COLLECTED_KEYS_SYMBOL ||
+                reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)
+            ) {
+                return Reflect.deleteProperty(target, prop);
+            }
+        }
+        // Good example of `deleteProperty` is when an item is removed / moved in a list.
+        // `deleteProperty` does not expose the receiver...get the latest reproxy instead.
+        // TODO: should revisit this at some point...
+        const currentProxy = isCustomProxy(target)
+            ? target
+            : getManagedProxyForUnproxiedNode(target);
+        const baseProxy = currentProxy
+            ? getBaseProxy(currentProxy)
+            : currentProxy;
+        const nodeRemoved = handleNodeRemoved(baseProxy, prop);
+        const previousValue = Reflect.get(target, prop, target);
+        const returnValue = Reflect.deleteProperty(target, prop);
+        if (returnValue) {
+            deleteProxiedChild(this, prop);
+        }
+        // If in a skip reproxy transaction, do not reproxy node
+        if (!Transactions.skipReproxy) {
+            if (baseProxy) {
+                const reproxy = updateReproxyNode(baseProxy);
+                // Still emit here if in a `skipEmit` transaction so that parents get reproxied
+                this.emitter.emit(
+                    "nodeChanged",
+                    this[unproxiedBaseNodeKey],
+                    baseProxy,
+                    reproxy,
+                    createNodeFieldChanges(prop, previousValue, undefined)
+                );
+            } else {
+                console.warn(
+                    `buildProxy.deleteProperty: cannot find baseProxy for target`
+                );
+            }
+            // nodeRemoved events do not reproxy parents, so we skip
+            if (nodeRemoved && !Transactions.skipEmit) {
+                const removedUnproxied = getUnproxiedNode(nodeRemoved);
+                this.emitter.emit(
+                    "nodeRemoved",
+                    removedUnproxied ?? nodeRemoved,
+                    nodeRemoved
+                );
+            }
+        }
+        return returnValue;
+    }
+}
+
+/**
+ * @internal
  * Builds a proxied object that emits changes when any value changes.
  * Also ensures `this` references are bound properly to functions, among other things.
  *
@@ -209,494 +740,16 @@ export function buildProxy<T extends TreeNode = TreeNode>(
     emitter: TreeChangeEmitter,
     parent?: IProxyParent<any>
 ): T {
-    let isApplyingSet = false;
     if (object === null) return object;
-    const reactiveObject = object instanceof ReactiveNode ? object : undefined;
-    const mapObject = object instanceof Map ? object : undefined;
-    const setObject = object instanceof Set ? object : undefined;
-    const dateObject = object instanceof Date ? object : undefined;
-    const hasInternalSlots =
-        mapObject !== undefined ||
-        setObject !== undefined ||
-        dateObject !== undefined;
-    let boundFunctionCache: Map<
-        string | symbol,
-        BoundFunctionCacheEntry
-    > | null = null;
-    let baseProxy: TCustomProxy<T>;
-    const getBoundFunction = <TFunction extends Function>(
-        prop: string | symbol,
-        source: TFunction,
-        thisArg: unknown
-    ): TFunction => {
-        boundFunctionCache ??= new Map();
-        return getCachedBoundFunction(
-            boundFunctionCache,
-            prop,
-            source,
-            thisArg
-        );
-    };
-    const proxyHandler: ProxyHandler<T> & ICustomProxyHandler<T> = {
-        // Add some extra stuff into the handler so we can store the original TreeNode and access it later
-        // Without overriding the rest of the getters in the object.
-        [unproxiedBaseNodeKey]: object,
-        [proxiedChildrenKey]: {},
-        [proxiedParentKey]: parent ?? null,
-        get: (target, prop, receiver) => {
-            if (prop === "[[Handler]]") {
-                return proxyHandler;
-            }
-            if (prop === "[[Target]]") {
-                return object;
-            }
-            if (reactiveObject !== undefined) {
-                // Collected/ignore keys are always strings; symbol props skip
-                // these checks without paying a String(prop) allocation.
-                if (typeof prop === "string") {
-                    if (prop.startsWith("RETREE_")) {
-                        return Reflect.get(target, prop, target);
-                    }
-                    if (reactiveObject[COLLECTED_KEYS_SYMBOL].has(prop)) {
-                        return trackPropertyAccessIfNeeded(
-                            baseProxy,
-                            prop,
-                            getLatestIgnoredValue(
-                                Reflect.get(target, prop, target)
-                            )
-                        );
-                    }
-                }
-                if (reactiveObject[LINKED_KEYS_SYMBOL].has(prop)) {
-                    return trackPropertyAccessIfNeeded(
-                        baseProxy,
-                        prop,
-                        getLatestLinkedValue(Reflect.get(target, prop, target))
-                    );
-                }
-            }
-            if (
-                typeof prop === "string" &&
-                proxyHandler[proxiedChildrenKey][prop]
-            ) {
-                const value = proxyHandler[proxiedChildrenKey][prop];
-                if (typeof value !== "function") {
-                    return trackPropertyAccessIfNeeded(baseProxy, prop, value);
-                }
-            }
-            if (hasInternalSlots) {
-                // Methods on Map/Set must run with the raw target as `this` because they read
-                // internal slots that the proxy does not expose.
-                const value = Reflect.get(target, prop, target);
-                if (typeof value === "function") {
-                    if (
-                        mapObject !== undefined &&
-                        typeof prop === "string" &&
-                        MAP_MUTATING_METHODS.has(prop)
-                    ) {
-                        return wrapMapMutation(
-                            prop,
-                            mapObject,
-                            baseProxy,
-                            emitter
-                        );
-                    }
-                    if (mapObject !== undefined) {
-                        return wrapMapRead(prop, mapObject, baseProxy, emitter);
-                    }
-                    if (
-                        setObject !== undefined &&
-                        typeof prop === "string" &&
-                        SET_MUTATING_METHODS.has(prop)
-                    ) {
-                        return wrapSetMutation(
-                            prop,
-                            setObject,
-                            baseProxy,
-                            emitter
-                        );
-                    }
-                    if (setObject !== undefined) {
-                        return wrapSetRead(prop, setObject, baseProxy, emitter);
-                    }
-                    if (
-                        dateObject !== undefined &&
-                        typeof prop === "string" &&
-                        isDateMutatingMethod(prop)
-                    ) {
-                        return wrapDateMutation(
-                            prop,
-                            dateObject,
-                            baseProxy,
-                            emitter
-                        );
-                    }
-                    return trackAccessIfNeeded(
-                        getBoundFunction(prop, value, target)
-                    );
-                }
-                return trackPropertyAccessIfNeeded(baseProxy, prop, value);
-            }
-            let value: any;
-            if (
-                reactiveObject !== undefined &&
-                getReactiveNodeGetter(reactiveObject, prop)
-            ) {
-                // For ReactiveNode getters, push the getter name onto the memo-getter
-                // stack so a keyless `this.memo(fn, deps)` inside the getter can derive
-                // its cache key from `prop`. Pop in `finally` so a throwing getter
-                pushMemoGetter(reactiveObject, prop);
-                try {
-                    value = Reflect.get(target, prop, receiver);
-                } finally {
-                    popMemoGetter(reactiveObject);
-                }
-            } else {
-                value = Reflect.get(target, prop, receiver);
-            }
-            if (typeof value === "function") {
-                if (FUNCTION_NAMES_BIND_TO_RAW.has(prop)) {
-                    return trackAccessIfNeeded(
-                        getBoundFunction(prop, value, target)
-                    );
-                }
-                return trackAccessIfNeeded(
-                    getBoundFunction(prop, value, baseProxy)
-                );
-            }
-            if (shouldLazilyProxyProperty(target, prop, value)) {
-                const descriptor = Reflect.getOwnPropertyDescriptor(
-                    target,
-                    prop
-                );
-                if (!descriptor || !descriptorHasValue(descriptor)) {
-                    return trackPropertyAccessIfNeeded(baseProxy, prop, value);
-                }
-                // shouldLazilyProxyProperty already established the value is a
-                // proxyable non-proxy object; only the descriptor lock check
-                // from shouldKeepRawPropertyValue remains.
-                if (
-                    !descriptorRequiresExactDefinedValue(descriptor, descriptor)
-                ) {
-                    return trackPropertyAccessIfNeeded(
-                        baseProxy,
-                        prop,
-                        getOrCreateProxiedChild(
-                            proxyHandler,
-                            prop,
-                            value,
-                            baseProxy,
-                            emitter
-                        )
-                    );
-                }
-            }
-            return trackPropertyAccessIfNeeded(baseProxy, prop, value);
-        },
-        set(target, prop, newValue, receiver) {
-            trackPropertyWriteIfNeeded(baseProxy, prop);
-            if (reactiveObject !== undefined) {
-                const propString = String(prop);
-                if (reactiveObject[LINKED_KEYS_SYMBOL].has(prop)) {
-                    assertValidLinkedValue(prop, newValue);
-                    const prev = Reflect.get(target, prop, target);
-                    if (prev === newValue) {
-                        return true;
-                    }
-                    let returnValue: boolean;
-                    isApplyingSet = true;
-                    try {
-                        returnValue = Reflect.set(
-                            target,
-                            prop,
-                            newValue,
-                            target
-                        );
-                    } finally {
-                        isApplyingSet = false;
-                    }
-                    if (!Transactions.skipReproxy) {
-                        const reproxy = updateReproxyNode(baseProxy);
-                        const changes = createNodeFieldChanges(
-                            prop,
-                            prev,
-                            newValue
-                        );
-                        emitter.emit(
-                            "nodeChanged",
-                            proxyHandler[unproxiedBaseNodeKey],
-                            baseProxy,
-                            reproxy,
-                            changes
-                        );
-                    }
-                    return returnValue;
-                }
-                // Check for ignore keys
-                if (
-                    propString === COLLECTED_KEYS_SYMBOL ||
-                    reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)
-                ) {
-                    return Reflect.set(target, prop, newValue, target);
-                }
-            }
-            const prev = (target as any)[prop];
-            const hasChanged = prev !== newValue;
-            if (hasChanged) {
-                let valueToSet = newValue;
-                const nodeRemoved = handleNodeRemoved(baseProxy, prop);
-                if (newValue !== null && typeof newValue === "object") {
-                    if (prop === "constructor")
-                        return Reflect.set(target, prop, newValue, receiver);
-
-                    // If already a proxied object, we simply reparent
-                    // Otherwise, build a new proxy object, unless this is a plain
-                    // object/array child that can be proxied lazily on first read.
-                    const parentToSet: IProxyParent<any> = {
-                        proxyNode: baseProxy,
-                        propName: prop,
-                    };
-                    if (isCustomProxy(newValue)) {
-                        valueToSet = reparentProxy(newValue, parentToSet);
-                        proxyHandler[proxiedChildrenKey][prop] = valueToSet;
-                    } else if (
-                        getManagedProxyForUnproxiedNode(newValue) !== undefined
-                    ) {
-                        valueToSet = createStructuralProxyForValue(
-                            newValue,
-                            parentToSet,
-                            emitter
-                        );
-                        proxyHandler[proxiedChildrenKey][prop] = valueToSet;
-                    } else if (shouldCreatePlainObjectProxyLazily(newValue)) {
-                        deleteProxiedChild(proxyHandler, prop);
-                    } else {
-                        valueToSet = createStructuralProxyForValue(
-                            newValue,
-                            parentToSet,
-                            emitter
-                        );
-                        proxyHandler[proxiedChildrenKey][prop] = valueToSet;
-                    }
-                } else {
-                    deleteProxiedChild(proxyHandler, prop);
-                }
-                let returnValue: boolean;
-                isApplyingSet = true;
-                try {
-                    returnValue = Reflect.set(
-                        target,
-                        prop,
-                        valueToSet,
-                        receiver
-                    );
-                } finally {
-                    isApplyingSet = false;
-                }
-                // If in a skip reproxy transaction, do not reproxy node
-                if (!Transactions.skipReproxy) {
-                    const reproxy = updateReproxyNode(baseProxy);
-                    const changes = createNodeFieldChanges(
-                        prop,
-                        prev,
-                        newValue
-                    );
-                    // Still emit here if in a `skipEmit` transaction so that parents get reproxied
-                    emitter.emit(
-                        "nodeChanged",
-                        proxyHandler[unproxiedBaseNodeKey],
-                        baseProxy,
-                        reproxy,
-                        changes
-                    );
-                    // nodeRemoved events do not reproxy parents, so we skip
-                    if (nodeRemoved && !Transactions.skipEmit) {
-                        const removedUnproxied = getUnproxiedNode(nodeRemoved);
-                        emitter.emit(
-                            "nodeRemoved",
-                            removedUnproxied ?? nodeRemoved,
-                            nodeRemoved
-                        );
-                    }
-                }
-
-                return returnValue;
-            }
-            return true;
-        },
-        defineProperty(target, prop, descriptor) {
-            if (isApplyingSet) {
-                return Reflect.defineProperty(target, prop, descriptor);
-            }
-            const currentProxyForWrite = isCustomProxy(target)
-                ? target
-                : getManagedProxyForUnproxiedNode(target);
-            const baseProxyForWrite = currentProxyForWrite
-                ? getBaseProxy(currentProxyForWrite)
-                : undefined;
-            if (baseProxyForWrite !== undefined) {
-                trackPropertyWriteIfNeeded(baseProxyForWrite, prop);
-            }
-            if (reactiveObject !== undefined) {
-                const propString = String(prop);
-                // Check for ignore keys
-                if (
-                    propString === COLLECTED_KEYS_SYMBOL ||
-                    reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)
-                ) {
-                    return Reflect.defineProperty(target, prop, descriptor);
-                }
-            }
-            const currentProxy = currentProxyForWrite;
-            const baseProxy = currentProxy
-                ? getBaseProxy(currentProxy)
-                : currentProxy;
-            const descriptorToDefine: PropertyDescriptor = { ...descriptor };
-            const currentDescriptor = Reflect.getOwnPropertyDescriptor(
-                target,
-                prop
-            );
-            const previousValue = currentDescriptorHasValue(currentDescriptor)
-                ? currentDescriptor.value
-                : undefined;
-            const nextValue = descriptorHasValue(descriptor)
-                ? descriptor.value
-                : descriptor;
-            let nodeRemoved: object | undefined;
-
-            if (descriptorHasValue(descriptorToDefine)) {
-                const shouldKeepRawValue =
-                    isProxyableObject(descriptorToDefine.value) &&
-                    !isCustomProxy(descriptorToDefine.value) &&
-                    descriptorRequiresExactDefinedValue(
-                        currentDescriptor,
-                        descriptorToDefine
-                    );
-                if (
-                    baseProxy &&
-                    Reflect.get(baseProxy, prop) !== descriptorToDefine.value
-                ) {
-                    nodeRemoved = handleNodeRemoved(baseProxy, prop);
-                }
-                if (shouldKeepRawValue) {
-                    deleteProxiedChild(proxyHandler, prop);
-                } else {
-                    descriptorToDefine.value = preparePropertyValue(
-                        descriptorToDefine.value,
-                        prop,
-                        baseProxy,
-                        emitter,
-                        proxyHandler
-                    );
-                }
-            } else if (descriptorHasAccessor(descriptorToDefine)) {
-                if (baseProxy) {
-                    nodeRemoved = handleNodeRemoved(baseProxy, prop);
-                }
-                deleteProxiedChild(proxyHandler, prop);
-            } else {
-                const cachedChild = proxyHandler[proxiedChildrenKey][prop];
-                if (
-                    cachedChild &&
-                    currentDescriptorHasValue(currentDescriptor)
-                ) {
-                    descriptorToDefine.value = cachedChild;
-                }
-            }
-
-            const returnValue = Reflect.defineProperty(
-                target,
-                prop,
-                descriptorToDefine
-            );
-            // If in a skip reproxy transaction, do not reproxy node
-            if (returnValue && !Transactions.skipReproxy) {
-                if (baseProxy) {
-                    const reproxy = updateReproxyNode(baseProxy);
-                    // Still emit here if in a `skipEmit` transaction so that parents get reproxied
-                    emitter.emit(
-                        "nodeChanged",
-                        proxyHandler[unproxiedBaseNodeKey],
-                        baseProxy,
-                        reproxy,
-                        createNodeFieldChanges(prop, previousValue, nextValue)
-                    );
-                } else {
-                    console.warn(
-                        `buildProxy.defineProperty: cannot find baseProxy for target`
-                    );
-                }
-                // nodeRemoved events do not reproxy parents, so we skip
-                if (nodeRemoved && !Transactions.skipEmit) {
-                    const removedUnproxied = getUnproxiedNode(nodeRemoved);
-                    emitter.emit(
-                        "nodeRemoved",
-                        removedUnproxied ?? nodeRemoved,
-                        nodeRemoved
-                    );
-                }
-            }
-            return returnValue;
-        },
-        deleteProperty(target, prop) {
-            if (reactiveObject !== undefined) {
-                const propString = String(prop);
-                // Check for ignore keys
-                if (
-                    propString === COLLECTED_KEYS_SYMBOL ||
-                    reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)
-                ) {
-                    return Reflect.deleteProperty(target, prop);
-                }
-            }
-            // Good example of `deleteProperty` is when an item is removed / moved in a list.
-            // `deleteProperty` does not expose the receiver...get the latest reproxy instead.
-            // TODO: should revisit this at some point...
-            const currentProxy = isCustomProxy(target)
-                ? target
-                : getManagedProxyForUnproxiedNode(target);
-            const baseProxy = currentProxy
-                ? getBaseProxy(currentProxy)
-                : currentProxy;
-            const nodeRemoved = handleNodeRemoved(baseProxy, prop);
-            const previousValue = Reflect.get(target, prop, target);
-            const returnValue = Reflect.deleteProperty(target, prop);
-            if (returnValue) {
-                deleteProxiedChild(proxyHandler, prop);
-            }
-            // If in a skip reproxy transaction, do not reproxy node
-            if (!Transactions.skipReproxy) {
-                if (baseProxy) {
-                    const reproxy = updateReproxyNode(baseProxy);
-                    // Still emit here if in a `skipEmit` transaction so that parents get reproxied
-                    emitter.emit(
-                        "nodeChanged",
-                        proxyHandler[unproxiedBaseNodeKey],
-                        baseProxy,
-                        reproxy,
-                        createNodeFieldChanges(prop, previousValue, undefined)
-                    );
-                } else {
-                    console.warn(
-                        `buildProxy.deleteProperty: cannot find baseProxy for target`
-                    );
-                }
-                // nodeRemoved events do not reproxy parents, so we skip
-                if (nodeRemoved && !Transactions.skipEmit) {
-                    const removedUnproxied = getUnproxiedNode(nodeRemoved);
-                    emitter.emit(
-                        "nodeRemoved",
-                        removedUnproxied ?? nodeRemoved,
-                        nodeRemoved
-                    );
-                }
-            }
-            return returnValue;
-        },
-    };
     if (isCustomProxy(object)) return getBaseProxy(object);
+    const proxyHandler = new BaseProxyHandler<T>(
+        object,
+        emitter,
+        parent ?? null
+    );
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
-    baseProxy = proxy;
+    proxyHandler.baseProxy = proxy;
+    const reactiveObject = proxyHandler.reactiveObject;
     registerCustomProxyMetadata(proxy, proxyHandler, object);
     registerBaseProxy(object, proxy);
     if (object instanceof Map) {
@@ -745,7 +798,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                         reactiveObject[COLLECTED_KEYS_SYMBOL].has(prop) ||
                         reactiveObject[LINKED_KEYS_SYMBOL].has(prop)))
             ) {
-                proxyHandler[proxiedChildrenKey][prop] = value;
+                setProxiedChild(proxyHandler, prop, value);
             } else if (typeof value === "object") {
                 if (shouldCreatePlainObjectProxyLazily(value)) {
                     continue;
@@ -761,7 +814,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                     proxyNode: proxy,
                     propName: prop,
                 });
-                proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
+                setProxiedChild(proxyHandler, prop, getBaseProxy(cProxy));
             }
         }
     }
@@ -786,7 +839,19 @@ function deleteProxiedChild(
     proxyHandler: ICustomProxyHandler<any>,
     prop: string | symbol
 ) {
-    Reflect.deleteProperty(proxyHandler[proxiedChildrenKey], prop);
+    const children = proxyHandler[proxiedChildrenKey];
+    if (children === null) {
+        return;
+    }
+    Reflect.deleteProperty(children, prop);
+}
+
+function setProxiedChild(
+    proxyHandler: ICustomProxyHandler<any>,
+    prop: string | symbol,
+    value: unknown
+) {
+    (proxyHandler[proxiedChildrenKey] ??= {})[prop] = value;
 }
 
 function isReactiveNodeProxy(node: object): node is TCustomProxy<ReactiveNode> {
@@ -903,7 +968,7 @@ function getOrCreateProxiedChild(
     baseProxy: TCustomProxy<any>,
     emitter: TreeChangeEmitter
 ): object {
-    const cachedChild = proxyHandler[proxiedChildrenKey][prop];
+    const cachedChild = proxyHandler[proxiedChildrenKey]?.[prop];
     if (cachedChild) {
         return cachedChild;
     }
@@ -917,11 +982,11 @@ function getOrCreateProxiedChild(
     if (existingManagedProxy === undefined) {
         // buildProxy returns the base proxy for a fresh raw object.
         const builtChildProxy = buildProxy(value, emitter, parentToSet);
-        proxyHandler[proxiedChildrenKey][prop] = builtChildProxy;
+        setProxiedChild(proxyHandler, prop, builtChildProxy);
         return builtChildProxy;
     }
     const baseChildProxy = getBaseProxy(existingManagedProxy);
-    proxyHandler[proxiedChildrenKey][prop] = baseChildProxy;
+    setProxiedChild(proxyHandler, prop, baseChildProxy);
     return baseChildProxy;
 }
 
@@ -977,7 +1042,7 @@ function preparePropertyValue(
         parentToSet,
         emitter
     );
-    proxyHandler[proxiedChildrenKey][prop] = valueToSet;
+    setProxiedChild(proxyHandler, prop, valueToSet);
     return valueToSet;
 }
 

--- a/packages/retree-core/src/internals/proxy.ts
+++ b/packages/retree-core/src/internals/proxy.ts
@@ -39,11 +39,9 @@ import {
 } from "./dependency-tracking";
 import { Transactions } from "./transactions";
 
-export const FUNCTION_NAMES_BIND_TO_RAW: (string | symbol)[] = [
-    "valueOf",
-    "toISOString",
-    "toJSON",
-];
+export const FUNCTION_NAMES_BIND_TO_RAW: ReadonlySet<string | symbol> = new Set(
+    ["valueOf", "toISOString", "toJSON"]
+);
 
 const MAP_MUTATING_METHODS = new Set(["set", "delete", "clear"]);
 const SET_MUTATING_METHODS = new Set(["add", "delete", "clear"]);
@@ -253,17 +251,21 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 return object;
             }
             if (reactiveObject !== undefined) {
-                const propString = String(prop);
-                // Check for ignore keys
-                if (propString.startsWith("RETREE_")) {
-                    return Reflect.get(target, prop, target);
-                }
-                if (reactiveObject[COLLECTED_KEYS_SYMBOL].has(propString)) {
-                    return trackPropertyAccessIfNeeded(
-                        baseProxy,
-                        prop,
-                        getLatestIgnoredValue(Reflect.get(target, prop, target))
-                    );
+                // Collected/ignore keys are always strings; symbol props skip
+                // these checks without paying a String(prop) allocation.
+                if (typeof prop === "string") {
+                    if (prop.startsWith("RETREE_")) {
+                        return Reflect.get(target, prop, target);
+                    }
+                    if (reactiveObject[COLLECTED_KEYS_SYMBOL].has(prop)) {
+                        return trackPropertyAccessIfNeeded(
+                            baseProxy,
+                            prop,
+                            getLatestIgnoredValue(
+                                Reflect.get(target, prop, target)
+                            )
+                        );
+                    }
                 }
                 if (reactiveObject[LINKED_KEYS_SYMBOL].has(prop)) {
                     return trackPropertyAccessIfNeeded(
@@ -353,7 +355,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 value = Reflect.get(target, prop, receiver);
             }
             if (typeof value === "function") {
-                if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
+                if (FUNCTION_NAMES_BIND_TO_RAW.has(prop)) {
                     return trackAccessIfNeeded(
                         getBoundFunction(prop, value, target)
                     );
@@ -370,7 +372,12 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 if (!descriptor || !descriptorHasValue(descriptor)) {
                     return trackPropertyAccessIfNeeded(baseProxy, prop, value);
                 }
-                if (!shouldKeepRawPropertyValue(descriptor, value)) {
+                // shouldLazilyProxyProperty already established the value is a
+                // proxyable non-proxy object; only the descriptor lock check
+                // from shouldKeepRawPropertyValue remains.
+                if (
+                    !descriptorRequiresExactDefinedValue(descriptor, descriptor)
+                ) {
                     return trackPropertyAccessIfNeeded(
                         baseProxy,
                         prop,
@@ -725,28 +732,30 @@ export function buildProxy<T extends TreeNode = TreeNode>(
             Set.prototype.add.call(object, replacement.next);
         }
     } else {
-        Object.entries(object).forEach(([prop, value]) => {
-            const propString = String(prop);
+        // The children record was created empty just above, so deferred
+        // children need no bookkeeping here; they resolve through the lazy
+        // read path. Checking laziness before descriptors keeps this walk
+        // free of per-property descriptor allocations for plain data.
+        for (const prop of Object.keys(object)) {
+            const value = (object as Record<string, unknown>)[prop];
             if (
                 value === null ||
-                (object instanceof ReactiveNode &&
-                    (propString === COLLECTED_KEYS_SYMBOL ||
-                        object[COLLECTED_KEYS_SYMBOL].has(propString) ||
-                        object[LINKED_KEYS_SYMBOL].has(prop)))
+                (reactiveObject !== undefined &&
+                    (prop === COLLECTED_KEYS_SYMBOL ||
+                        reactiveObject[COLLECTED_KEYS_SYMBOL].has(prop) ||
+                        reactiveObject[LINKED_KEYS_SYMBOL].has(prop)))
             ) {
                 proxyHandler[proxiedChildrenKey][prop] = value;
             } else if (typeof value === "object") {
+                if (shouldCreatePlainObjectProxyLazily(value)) {
+                    continue;
+                }
                 const descriptor = Reflect.getOwnPropertyDescriptor(
                     object,
                     prop
                 );
                 if (shouldKeepRawPropertyValue(descriptor, value)) {
-                    deleteProxiedChild(proxyHandler, prop);
-                    return;
-                }
-                if (shouldCreatePlainObjectProxyLazily(value)) {
-                    deleteProxiedChild(proxyHandler, prop);
-                    return;
+                    continue;
                 }
                 const cProxy = buildProxy(value, emitter, {
                     proxyNode: proxy,
@@ -754,7 +763,7 @@ export function buildProxy<T extends TreeNode = TreeNode>(
                 });
                 proxyHandler[proxiedChildrenKey][prop] = getBaseProxy(cProxy);
             }
-        });
+        }
     }
     if (
         object instanceof ReactiveNode &&
@@ -877,19 +886,14 @@ function shouldCreatePlainObjectProxyLazily(value: unknown): value is object {
     if (!isProxyableObject(value)) {
         return false;
     }
-    if (isCustomProxy(value)) {
+    // Cheap shape checks first; isCustomProxy costs a WeakMap lookup.
+    if (
+        !Array.isArray(value) &&
+        Object.getPrototypeOf(value) !== Object.prototype
+    ) {
         return false;
     }
-    if (value instanceof ReactiveNode) {
-        return false;
-    }
-    if (isInternalSlotInstance(value)) {
-        return false;
-    }
-    return (
-        Array.isArray(value) ||
-        Object.getPrototypeOf(value) === Object.prototype
-    );
+    return !isCustomProxy(value);
 }
 
 function getOrCreateProxiedChild(
@@ -907,12 +911,16 @@ function getOrCreateProxiedChild(
         proxyNode: baseProxy,
         propName: prop,
     };
+    // Callers guarantee `value` is a raw (non-proxy) object, so a managed
+    // proxy can only exist if this same raw node was proxied elsewhere first.
     const existingManagedProxy = getManagedProxyForUnproxiedNode(value);
-    const childProxy =
-        existingManagedProxy === undefined
-            ? createStructuralProxyForValue(value, parentToSet, emitter)
-            : existingManagedProxy;
-    const baseChildProxy = getBaseProxy(childProxy);
+    if (existingManagedProxy === undefined) {
+        // buildProxy returns the base proxy for a fresh raw object.
+        const builtChildProxy = buildProxy(value, emitter, parentToSet);
+        proxyHandler[proxiedChildrenKey][prop] = builtChildProxy;
+        return builtChildProxy;
+    }
+    const baseChildProxy = getBaseProxy(existingManagedProxy);
     proxyHandler[proxiedChildrenKey][prop] = baseChildProxy;
     return baseChildProxy;
 }

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -25,15 +25,21 @@ import {
 import { getReactiveNodeGetter, popMemoGetter, pushMemoGetter } from "./memo";
 import {
     ICustomProxyHandler,
+    IProxyParent,
     isCustomProxy,
     proxiedChildrenKey,
     unproxiedBaseNodeKey,
     proxiedParentKey,
+    proxyHandlerSentinel,
+    proxyTargetKey,
     registerCustomProxyMetadata,
     TCustomProxy,
 } from "./proxy-types";
 
 const reproxyMap: WeakMap<TreeNode, TCustomProxy<TreeNode>> = new WeakMap();
+/**
+ * Registry mapping raw nodes to their base proxies.
+ */
 const baseProxyMap: WeakMap<TreeNode, TCustomProxy<TreeNode>> = new WeakMap();
 
 function trackAccessIfNeeded<T>(value: T): T {
@@ -58,6 +64,10 @@ export function registerBaseProxy<T extends TreeNode = TreeNode>(
     unproxiedNode: T,
     baseProxy: TCustomProxy<T>
 ): void {
+    // Note: a symbol property on the raw node was measured as 4-5x faster
+    // than WeakMap.set, but non-enumerable definitions cost the same as the
+    // WeakMap and enumerable ones leak into deep-equality assertions on raw
+    // nodes (vitest/jest toEqual compares symbol props). WeakMap stays.
     baseProxyMap.set(unproxiedNode, baseProxy);
 }
 
@@ -72,7 +82,7 @@ export function updateReproxyNode<T extends TreeNode = TreeNode>(
         );
     }
     const unproxiedNode = handler[unproxiedBaseNodeKey];
-    const reproxy = buildReproxy<T>(node);
+    const reproxy = buildReproxy<T>(node, handler);
     reproxyMap.set(unproxiedNode, reproxy);
     return reproxy;
 }
@@ -101,148 +111,203 @@ export function getManagedProxyForUnproxiedNode<T extends TreeNode = TreeNode>(
 ): TCustomProxy<T> | undefined {
     return (
         getReproxyNodeForUnproxiedNode(unproxiedNode) ??
-        (baseProxyMap.get(unproxiedNode) as TCustomProxy<T> | undefined)
+        getBaseProxyForUnproxiedNode(unproxiedNode)
     );
 }
 
+function getBaseProxyForUnproxiedNode<T extends TreeNode = TreeNode>(
+    unproxiedNode: T
+): TCustomProxy<T> | undefined {
+    return baseProxyMap.get(unproxiedNode) as TCustomProxy<T> | undefined;
+}
+
+/**
+ * @internal
+ * Proxy handler for a reproxy (fresh-identity wrapper around a base proxy).
+ *
+ * @remarks
+ * A reproxy is built on every observable mutation, so this is a write-path
+ * allocation. Trap methods live on the prototype and per-reproxy state lives
+ * in fields, mirroring the base handler class in proxy.ts.
+ */
+class ReproxyHandler<T extends TreeNode>
+    implements ProxyHandler<TCustomProxy<T>>, ICustomProxyHandler<T>
+{
+    public [unproxiedBaseNodeKey]: T;
+    public [proxiedParentKey]: IProxyParent | null;
+    public [proxyTargetKey]?: T;
+    /** The base proxy this reproxy wraps. */
+    private readonly baseProxyObject: TCustomProxy<T>;
+    private readonly baseHandler: ICustomProxyHandler<T>;
+    private boundFunctionCache: Map<
+        string | symbol,
+        { source: Function; bound: Function }
+    > | null = null;
+
+    constructor(
+        baseProxyObject: TCustomProxy<T>,
+        baseHandler: ICustomProxyHandler<T>
+    ) {
+        this[unproxiedBaseNodeKey] = baseHandler[unproxiedBaseNodeKey];
+        this[proxiedParentKey] = baseHandler[proxiedParentKey];
+        this.baseProxyObject = baseProxyObject;
+        this.baseHandler = baseHandler;
+    }
+
+    /**
+     * The children cache belongs to the base handler and is allocated lazily,
+     * so delegate instead of copying a reference at construction time.
+     */
+    public get [proxiedChildrenKey](): Record<string | symbol, any> | null {
+        return this.baseHandler[proxiedChildrenKey];
+    }
+
+    public set [proxiedChildrenKey](
+        value: Record<string | symbol, any> | null
+    ) {
+        this.baseHandler[proxiedChildrenKey] = value;
+    }
+
+    private getBoundFunction<TFunction extends Function>(
+        prop: string | symbol,
+        source: TFunction,
+        thisArg: unknown
+    ): TFunction {
+        this.boundFunctionCache ??= new Map();
+        return getCachedBoundFunction(
+            this.boundFunctionCache,
+            prop,
+            source,
+            thisArg
+        );
+    }
+
+    public get(
+        target: TCustomProxy<T>,
+        prop: string | symbol,
+        receiver: any
+    ): any {
+        if (prop === proxyHandlerSentinel) {
+            return this;
+        }
+        if (prop === "[[Handler]]") {
+            return this;
+        }
+        const object = this.baseProxyObject;
+        if (prop === "[[Target]]") {
+            return object;
+        }
+        if (target instanceof ReactiveNode) {
+            // Check for ignore keys
+            if (typeof prop === "string" && prop.startsWith("RETREE_")) {
+                return Reflect.get(target, prop, target);
+            }
+            if (target[COLLECTED_KEYS_SYMBOL].has(prop)) {
+                return getLatestIgnoredValue(Reflect.get(target, prop, target));
+            }
+            if (target[LINKED_KEYS_SYMBOL].has(prop)) {
+                return getLatestLinkedValue(Reflect.get(target, prop, target));
+            }
+        }
+        const children = this.baseHandler[proxiedChildrenKey];
+        if (
+            children !== null &&
+            typeof prop === "string" &&
+            prop !== "constructor" &&
+            children[prop]
+        ) {
+            const childProxy = children[prop];
+            if (typeof childProxy !== "function") {
+                const reproxy = getReproxyNode(childProxy);
+                return trackPropertyAccessIfNeeded(
+                    object,
+                    prop,
+                    reproxy ?? childProxy
+                );
+            }
+        }
+        const rawNode = this.baseHandler[unproxiedBaseNodeKey];
+        // Some built-in methods need internal slots on `this`. Delegate property access to the
+        // base proxy so the bind/wrap logic in buildProxy is reused (and mutations emit).
+        if (isInternalSlotInstance(rawNode)) {
+            return trackPropertyAccessIfNeeded(
+                object,
+                prop,
+                Reflect.get(object, prop, object)
+            );
+        }
+        const evalTarget = rawNode ?? target;
+
+        let value: any;
+        if (
+            evalTarget instanceof ReactiveNode &&
+            getReactiveNodeGetter(evalTarget, prop)
+        ) {
+            // Mirror proxy.ts: track the active getter for keyless `this.memo(...)`.
+            pushMemoGetter(evalTarget, prop);
+            try {
+                value = Reflect.get(evalTarget, prop, receiver);
+            } finally {
+                popMemoGetter(evalTarget);
+            }
+        } else {
+            value = Reflect.get(evalTarget, prop, receiver);
+        }
+
+        if (typeof value === "function") {
+            if (FUNCTION_NAMES_BIND_TO_RAW.has(prop)) {
+                return trackAccessIfNeeded(
+                    this.getBoundFunction(prop, value, rawNode)
+                );
+            }
+            const reproxy = getReproxyNode(object);
+            return trackAccessIfNeeded(
+                this.getBoundFunction(prop, value, reproxy)
+            );
+        }
+        if (value !== null && typeof value === "object") {
+            const baseValue = Reflect.get(object, prop, object);
+            if (isCustomProxy(baseValue)) {
+                return trackPropertyAccessIfNeeded(
+                    object,
+                    prop,
+                    getReproxyNode(baseValue) ?? baseValue
+                );
+            }
+        }
+        return trackPropertyAccessIfNeeded(object, prop, value);
+    }
+
+    public set(
+        target: TCustomProxy<T>,
+        prop: string | symbol,
+        newValue: any,
+        receiver: any
+    ): boolean {
+        if (target instanceof ReactiveNode) {
+            if (
+                prop === COLLECTED_KEYS_SYMBOL ||
+                target[COLLECTED_KEYS_SYMBOL].has(prop)
+            ) {
+                return Reflect.set(target, prop, newValue, target);
+            }
+        }
+        return Reflect.set(target, prop, newValue, receiver);
+    }
+}
+
 function buildReproxy<T extends TreeNode = TreeNode>(
-    object: TCustomProxy<T>
+    object: TCustomProxy<T>,
+    knownHandler?: ICustomProxyHandler<T>
 ): TCustomProxy<T> {
-    const handler = getCustomProxyHandler(object);
+    const handler = knownHandler ?? getCustomProxyHandler(object);
     if (!handler) {
         // @retree-throws
         throw new Error(
             "Retree internal invariant failed: cannot build a reproxy for an unproxied node. This is unexpected and likely a Retree bug if it came from a public Retree API. Fix: make sure callers pass Retree-managed proxies from Retree.root(...) or tree children; otherwise file a Retree issue with the operation that triggered this."
         );
     }
-    let boundFunctionCache: Map<
-        string | symbol,
-        { source: Function; bound: Function }
-    > | null = null;
-    const getBoundFunction = <TFunction extends Function>(
-        prop: string | symbol,
-        source: TFunction,
-        thisArg: unknown
-    ): TFunction => {
-        boundFunctionCache ??= new Map();
-        return getCachedBoundFunction(
-            boundFunctionCache,
-            prop,
-            source,
-            thisArg
-        );
-    };
-    const proxyHandler: ProxyHandler<TCustomProxy<T>> & ICustomProxyHandler<T> =
-        {
-            // Add some extra stuff into the handler so we can store the original TreeNode and access it later
-            // Without overriding the rest of the getters in the object.
-            [unproxiedBaseNodeKey]: handler[unproxiedBaseNodeKey],
-            [proxiedChildrenKey]: handler[proxiedChildrenKey],
-            [proxiedParentKey]: handler[proxiedParentKey],
-            get: (target, prop, receiver) => {
-                if (prop === "[[Handler]]") {
-                    return proxyHandler;
-                }
-                if (prop === "[[Target]]") {
-                    return object;
-                }
-                if (target instanceof ReactiveNode) {
-                    // Check for ignore keys
-                    if (
-                        typeof prop === "string" &&
-                        prop.startsWith("RETREE_")
-                    ) {
-                        return Reflect.get(target, prop, target);
-                    }
-                    if (target[COLLECTED_KEYS_SYMBOL].has(prop)) {
-                        return getLatestIgnoredValue(
-                            Reflect.get(target, prop, target)
-                        );
-                    }
-                    if (target[LINKED_KEYS_SYMBOL].has(prop)) {
-                        return getLatestLinkedValue(
-                            Reflect.get(target, prop, target)
-                        );
-                    }
-                }
-                if (
-                    typeof prop === "string" &&
-                    prop !== "constructor" &&
-                    handler[proxiedChildrenKey][prop]
-                ) {
-                    const childProxy = handler[proxiedChildrenKey][prop];
-                    if (typeof childProxy !== "function") {
-                        const reproxy = getReproxyNode(childProxy);
-                        return trackPropertyAccessIfNeeded(
-                            object,
-                            prop,
-                            reproxy ?? childProxy
-                        );
-                    }
-                }
-                const rawNode = handler[unproxiedBaseNodeKey];
-                // Some built-in methods need internal slots on `this`. Delegate property access to the
-                // base proxy so the bind/wrap logic in buildProxy is reused (and mutations emit).
-                if (isInternalSlotInstance(rawNode)) {
-                    return trackPropertyAccessIfNeeded(
-                        object,
-                        prop,
-                        Reflect.get(object, prop, object)
-                    );
-                }
-                const evalTarget = rawNode ?? target;
-
-                let value: any;
-                if (
-                    evalTarget instanceof ReactiveNode &&
-                    getReactiveNodeGetter(evalTarget, prop)
-                ) {
-                    // Mirror proxy.ts: track the active getter for keyless `this.memo(...)`.
-                    pushMemoGetter(evalTarget, prop);
-                    try {
-                        value = Reflect.get(evalTarget, prop, receiver);
-                    } finally {
-                        popMemoGetter(evalTarget);
-                    }
-                } else {
-                    value = Reflect.get(evalTarget, prop, receiver);
-                }
-
-                if (typeof value === "function") {
-                    if (FUNCTION_NAMES_BIND_TO_RAW.has(prop)) {
-                        return trackAccessIfNeeded(
-                            getBoundFunction(prop, value, rawNode)
-                        );
-                    }
-                    const reproxy = getReproxyNode(object);
-                    return trackAccessIfNeeded(
-                        getBoundFunction(prop, value, reproxy)
-                    );
-                }
-                if (value !== null && typeof value === "object") {
-                    const baseValue = Reflect.get(object, prop, object);
-                    if (isCustomProxy(baseValue)) {
-                        return trackPropertyAccessIfNeeded(
-                            object,
-                            prop,
-                            getReproxyNode(baseValue) ?? baseValue
-                        );
-                    }
-                }
-                return trackPropertyAccessIfNeeded(object, prop, value);
-            },
-            set(target, prop, newValue, receiver) {
-                if (target instanceof ReactiveNode) {
-                    if (
-                        prop === COLLECTED_KEYS_SYMBOL ||
-                        target[COLLECTED_KEYS_SYMBOL].has(prop)
-                    ) {
-                        return Reflect.set(target, prop, newValue, target);
-                    }
-                }
-                return Reflect.set(target, prop, newValue, receiver);
-            },
-        };
+    const proxyHandler = new ReproxyHandler<T>(object, handler);
     const proxy = new Proxy(object, proxyHandler) as TCustomProxy<T>;
     registerCustomProxyMetadata(proxy, proxyHandler, object);
     return proxy as TCustomProxy<T>;

--- a/packages/retree-core/src/internals/reproxy.ts
+++ b/packages/retree-core/src/internals/reproxy.ts
@@ -209,7 +209,7 @@ function buildReproxy<T extends TreeNode = TreeNode>(
                 }
 
                 if (typeof value === "function") {
-                    if (FUNCTION_NAMES_BIND_TO_RAW.includes(prop)) {
+                    if (FUNCTION_NAMES_BIND_TO_RAW.has(prop)) {
                         return trackAccessIfNeeded(
                             getBoundFunction(prop, value, rawNode)
                         );

--- a/packages/retree-core/src/internals/select.ts
+++ b/packages/retree-core/src/internals/select.ts
@@ -3,15 +3,23 @@
  * Licensed under the MIT License.
  */
 
-import { TRetreeChangedEvents, TreeNode } from "../types";
+import { ReactiveNode } from "../ReactiveNode";
+import { INodeFieldChanges, TRetreeChangedEvents, TreeNode } from "../types";
 import {
     areDependencyComparisonValuesEqual,
     areDependencyValuesEqual,
     getDependencyComparisonValues,
     normalizeDependencyEntry,
 } from "./dependencies";
-import { collectDependencyAccesses } from "./dependency-tracking";
-import { getBaseProxy, getUnproxiedNode } from "./proxy";
+import {
+    collectTrackedSelectionAccesses,
+    ITrackedNodeAccessSummary,
+} from "./dependency-tracking";
+import {
+    getBaseProxy,
+    getUnproxiedNode,
+    isInternalSlotInstance,
+} from "./proxy";
 import { getReproxyNode } from "./reproxy";
 
 export type RetreeSelectSelector<TNode extends TreeNode, TSelected> = (
@@ -25,7 +33,10 @@ export type RetreeSelectEquals<TSelected> = (
     next: TSelected
 ) => boolean;
 
-type SelectionListener<TNode extends TreeNode> = (node: TNode) => void;
+type SelectionListener<TNode extends TreeNode> = (
+    node: TNode,
+    changes?: INodeFieldChanges[]
+) => void;
 type SubscribeToNode = <TNode extends TreeNode>(
     node: TNode,
     listenerType: TRetreeChangedEvents,
@@ -41,6 +52,7 @@ interface ActiveSelectDependency {
 interface TrackedSelection<TSelected> {
     selected: TSelected;
     dependencies: readonly unknown[];
+    getAccessSummaries: () => Map<TreeNode, ITrackedNodeAccessSummary>;
 }
 
 function getTrackedDependencyComparisonValue(dependency: unknown): unknown {
@@ -69,27 +81,19 @@ function getTrackedDependencyComparisonValues(
     return comparisonValues;
 }
 
-function defaultTrackedDependenciesChanged(
+function areTrackedComparisonValuesEqual(
     previous: readonly unknown[],
     next: readonly unknown[]
 ): boolean {
-    const previousComparisonValues =
-        getTrackedDependencyComparisonValues(previous);
-    const nextComparisonValues = getTrackedDependencyComparisonValues(next);
-    if (previousComparisonValues.length !== nextComparisonValues.length) {
-        return true;
+    if (previous.length !== next.length) {
+        return false;
     }
-    for (let index = 0; index < previousComparisonValues.length; index++) {
-        if (
-            !Object.is(
-                previousComparisonValues[index],
-                nextComparisonValues[index]
-            )
-        ) {
-            return true;
+    for (let index = 0; index < previous.length; index++) {
+        if (!Object.is(previous[index], next[index])) {
+            return false;
         }
     }
-    return false;
+    return true;
 }
 
 function defaultTrackedSelectedChanged<TSelected>(
@@ -373,7 +377,7 @@ export function createRetreeTrackedSelectionObserver<TSelected>(options: {
                 unsubscribe: options.subscribeToNode(
                     dependencySlot.baseProxy,
                     "nodeChanged",
-                    evaluate
+                    (_node, changes) => evaluateForDependency(rawNode, changes)
                 ),
             };
             nextDependencies.push(nextDependency);
@@ -387,6 +391,26 @@ export function createRetreeTrackedSelectionObserver<TSelected>(options: {
         }
         activeDependencies = nextDependencies;
         activeDependencyMap = nextDependencyMap;
+    };
+
+    let previousComparisonValues = getTrackedDependencyComparisonValues(
+        previous.dependencies
+    );
+
+    const evaluateForDependency = (
+        changedRawNode: TreeNode,
+        changes?: INodeFieldChanges[]
+    ) => {
+        if (
+            canSkipTrackedDependencyChange(
+                changedRawNode,
+                previous.getAccessSummaries().get(changedRawNode),
+                changes
+            )
+        ) {
+            return;
+        }
+        evaluate();
     };
 
     const evaluate = () => {
@@ -403,22 +427,23 @@ export function createRetreeTrackedSelectionObserver<TSelected>(options: {
                       previous.selected,
                       nextSelected
                   );
-        const dependenciesChanged = defaultTrackedDependenciesChanged(
-            previous.dependencies,
+        const nextComparisonValues = getTrackedDependencyComparisonValues(
             next.dependencies
         );
-        if (!selectedChanged && !dependenciesChanged) {
-            previous = {
-                selected: nextSelected,
-                dependencies: next.dependencies,
-            };
-            return;
-        }
+        const dependenciesChanged = !areTrackedComparisonValuesEqual(
+            previousComparisonValues,
+            nextComparisonValues
+        );
+        previousComparisonValues = nextComparisonValues;
         const previousToEmit = previous;
         previous = {
             selected: nextSelected,
             dependencies: next.dependencies,
+            getAccessSummaries: next.getAccessSummaries,
         };
+        if (!selectedChanged && !dependenciesChanged) {
+            return;
+        }
         options.onChange(nextSelected, previousToEmit.selected);
     };
 
@@ -436,12 +461,66 @@ export function createRetreeTrackedSelectionObserver<TSelected>(options: {
 export function runTrackedSelection<TSelected>(
     selector: RetreeTrackedSelectSelector<TSelected>
 ): TrackedSelection<TSelected> {
-    let selected: TSelected | undefined;
-    const dependencies = collectDependencyAccesses(() => {
-        selected = selector();
-    });
+    const accesses = collectTrackedSelectionAccesses(selector);
     return {
-        selected: selected as TSelected,
-        dependencies,
+        selected: accesses.value,
+        dependencies: accesses.dependencies,
+        getAccessSummaries: accesses.getAccessSummaries,
     };
+}
+
+/**
+ * Decide whether a dependency's `nodeChanged` can be skipped without
+ * re-running the tracked selector.
+ *
+ * A change is skippable when every value the selector read from the changed
+ * node re-reads equal. For plain-object nodes the emitted field changes can
+ * short-circuit that check entirely when none of the changed keys were read.
+ * Arrays are excluded from key scoping because an index write (e.g. `push`)
+ * implicitly changes `length` without emitting a `length` change record.
+ * ReactiveNodes are excluded because dependency-driven emissions forward the
+ * dependency's change records, whose keys do not describe the node's own
+ * fields.
+ */
+function canSkipTrackedDependencyChange(
+    changedRawNode: TreeNode,
+    summary: ITrackedNodeAccessSummary | undefined,
+    changes: INodeFieldChanges[] | undefined
+): boolean {
+    if (summary === undefined) {
+        return false;
+    }
+    if (summary.wholeNodeRead) {
+        return false;
+    }
+    const keyScopingAllowed =
+        summary.keyScopable &&
+        !Array.isArray(changedRawNode) &&
+        !(changedRawNode instanceof ReactiveNode) &&
+        !isInternalSlotInstance(changedRawNode);
+    if (
+        keyScopingAllowed &&
+        changes !== undefined &&
+        changes.length > 0 &&
+        !changes.some((change) => summary.propertyKeys.has(change.key))
+    ) {
+        return true;
+    }
+    for (const validator of summary.validators) {
+        const currentValues = validator.accessor.getValues();
+        if (currentValues.length !== validator.capturedValues.length) {
+            return false;
+        }
+        for (let index = 0; index < currentValues.length; index++) {
+            if (
+                !areDependencyValuesEqual(
+                    validator.capturedValues[index],
+                    currentValues[index]
+                )
+            ) {
+                return false;
+            }
+        }
+    }
+    return true;
 }

--- a/packages/retree-core/src/perf-probe.spec.ts
+++ b/packages/retree-core/src/perf-probe.spec.ts
@@ -108,7 +108,7 @@ describe("perf probe", () => {
             throw new Error("perf-probe: expected managed tree to unwrap");
         }
         time("scan via getUnproxiedNode", () => scan(raw), 5);
-        time("scan via Retree.peek", () => scan(Retree.peek(tree)), 5);
+        time("scan via Retree.raw", () => scan(Retree.raw(tree)), 5);
     });
 
     it("dependency-tracked scan scaling", () => {

--- a/packages/retree-core/src/perf-probe.spec.ts
+++ b/packages/retree-core/src/perf-probe.spec.ts
@@ -1,0 +1,224 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Targeted perf probe used during the July 2026 performance work.
+ * Prints timings with `--disable-console-intercept`; assertions are
+ * intentionally loose sanity bounds so this never gates CI on machine speed.
+ * See benchmarks/findings-jul-10-2026.md for context.
+ */
+import { describe, expect, it } from "vitest";
+import { ReactiveNode } from "./ReactiveNode";
+import { Retree } from "./Retree";
+import {
+    collectDependencyComparisonAccesses,
+    getUnproxiedNode,
+} from "./internals";
+
+interface Item {
+    id: number;
+    name: string;
+    score: number;
+    tags: { label: string; weight: number }[];
+}
+
+interface Group {
+    title: string;
+    items: Item[];
+}
+
+function makeTree(groups: number, itemsPerGroup: number): { groups: Group[] } {
+    const result: { groups: Group[] } = { groups: [] };
+    for (let g = 0; g < groups; g++) {
+        const items: Item[] = [];
+        for (let i = 0; i < itemsPerGroup; i++) {
+            items.push({
+                id: g * itemsPerGroup + i,
+                name: `item-${g}-${i}`,
+                score: (g * 31 + i * 7) % 100,
+                tags: [
+                    { label: "a", weight: i % 5 },
+                    { label: "b", weight: g % 3 },
+                ],
+            });
+        }
+        result.groups.push({ title: `group-${g}`, items });
+    }
+    return result;
+}
+
+function scan(root: { groups: Group[] }): number {
+    let total = 0;
+    for (const group of root.groups) {
+        for (const item of group.items) {
+            if (item.score > 50) {
+                total += item.tags[0].weight + item.tags[1].weight;
+            }
+            total += item.id % 3;
+        }
+    }
+    return total;
+}
+
+function time(label: string, fn: () => unknown, iterations = 1): number {
+    fn(); // warmup
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) fn();
+    const ms = (performance.now() - start) / iterations;
+
+    console.log(`${label}: ${ms.toFixed(3)} ms`);
+    return ms;
+}
+
+function timeOnce(label: string, fn: () => unknown): number {
+    const start = performance.now();
+    fn();
+    const ms = performance.now() - start;
+
+    console.log(`${label}: ${ms.toFixed(3)} ms`);
+    return ms;
+}
+
+describe("perf probe", () => {
+    it("read paths: raw vs proxy first-touch vs proxy steady-state", () => {
+        const GROUPS = 100;
+        const ITEMS = 100; // 10k items, ~30k+ nested nodes
+
+        const rawTree = makeTree(GROUPS, ITEMS);
+        const rawExpected = scan(rawTree);
+        time("raw scan steady", () => scan(rawTree), 5);
+
+        let tree!: { groups: Group[] };
+        timeOnce("Retree.root()", () => {
+            tree = Retree.root(makeTree(GROUPS, ITEMS));
+        });
+
+        let firstTouchTotal = 0;
+        timeOnce("proxied scan FIRST touch (materialization)", () => {
+            firstTouchTotal = scan(tree);
+        });
+        expect(firstTouchTotal).toBe(rawExpected);
+
+        time("proxied scan steady-state", () => scan(tree), 5);
+
+        const raw = getUnproxiedNode(tree);
+        if (raw === undefined) {
+            throw new Error("perf-probe: expected managed tree to unwrap");
+        }
+        time("scan via getUnproxiedNode", () => scan(raw), 5);
+        time("scan via Retree.peek", () => scan(Retree.peek(tree)), 5);
+    });
+
+    it("dependency-tracked scan scaling", () => {
+        const timings: { items: number; ms: number }[] = [];
+        for (const items of [250, 500, 1000, 2000]) {
+            const tree = Retree.root(makeTree(10, items / 10));
+            scan(tree); // materialize first
+            const ms = time(
+                `tracked scan, ${items} items`,
+                () => collectDependencyComparisonAccesses(() => scan(tree)),
+                1
+            );
+            timings.push({ items, ms });
+        }
+        const first = timings[0];
+        const last = timings[timings.length - 1];
+        const scale = last.ms / first.ms;
+        const itemScale = last.items / first.items;
+
+        console.log(
+            `tracked scan scaling factor for ${itemScale}x items: ${scale.toFixed(
+                1
+            )}x time`
+        );
+    });
+
+    it("tracked Retree.select initial + write cost", () => {
+        const tree = Retree.root(makeTree(10, 100)); // 1k items
+        scan(tree);
+        timeOnce("Retree.select(tracked) subscribe, 1k items", () => {
+            const unsubscribe = Retree.select(
+                () => scan(tree),
+                () => {}
+            );
+            (globalThis as { __probeUnsub?: () => void }).__probeUnsub =
+                unsubscribe;
+        });
+        timeOnce("scalar write w/ tracked select active", () => {
+            tree.groups[0].items[0].score = 999;
+        });
+        timeOnce("second scalar write w/ tracked select active", () => {
+            tree.groups[5].items[5].score = 998;
+        });
+        timeOnce("unrelated write (name) w/ tracked select active", () => {
+            tree.groups[3].items[3].name = "renamed";
+        });
+        timeOnce("100 unrelated writes w/ tracked select active", () => {
+            for (let i = 0; i < 100; i++) {
+                tree.groups[4].items[i % 100].name = `renamed-${i}`;
+            }
+        });
+        (globalThis as { __probeUnsub?: () => void }).__probeUnsub?.();
+        delete (globalThis as { __probeUnsub?: () => void }).__probeUnsub;
+    });
+
+    it("reactive node with many dependency edges on one node", () => {
+        class ManyEdges extends ReactiveNode {
+            public items: number[] = [];
+
+            constructor() {
+                super();
+                for (let i = 0; i < 50; i++) {
+                    this.items.push(i);
+                }
+            }
+
+            get dependencies() {
+                const edges: ReturnType<typeof this.dependency>[] = [];
+                for (let i = 0; i < 50; i++) {
+                    edges.push(this.dependency(this.items, [this.items[i]]));
+                }
+                return edges;
+            }
+        }
+
+        const node = Retree.root(new ManyEdges());
+        let notifications = 0;
+        const off = Retree.on(node, "nodeChanged", () => {
+            notifications++;
+        });
+        timeOnce("first write w/ 50 edges on one dependency", () => {
+            node.items[0] = 1000;
+        });
+        timeOnce("100 writes w/ 50 edges on one dependency", () => {
+            for (let i = 0; i < 100; i++) {
+                node.items[i % 50] = 2000 + i;
+            }
+        });
+        expect(notifications).toBeGreaterThan(0);
+        off();
+    });
+
+    it("write path: push N items, with and without listener", () => {
+        const tree = Retree.root({ list: [] as { v: number }[] });
+        timeOnce("push 1000 items (no listeners)", () => {
+            for (let i = 0; i < 1000; i++) tree.list.push({ v: i });
+        });
+
+        const tree2 = Retree.root({ list: [] as { v: number }[] });
+        const off = Retree.on(tree2, "treeChanged", () => {});
+        timeOnce("push 1000 items (treeChanged on root)", () => {
+            for (let i = 0; i < 1000; i++) tree2.list.push({ v: i });
+        });
+        off();
+
+        const tree3 = Retree.root({ list: [] as { v: number }[] });
+        timeOnce("push 1000 items in runTransaction (no listeners)", () => {
+            Retree.runTransaction(() => {
+                for (let i = 0; i < 1000; i++) tree3.list.push({ v: i });
+            });
+        });
+    });
+});

--- a/packages/retree-core/src/raw-purity.spec.ts
+++ b/packages/retree-core/src/raw-purity.spec.ts
@@ -1,0 +1,324 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Raw purity invariant (specs/retree-raw.md §3.2): proxies are reachable only
+ * through proxies. Walking `Retree.raw(root)` — including into raw Maps and
+ * Sets — finds zero values with proxy metadata, under every write path.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ReactiveNode } from "./ReactiveNode";
+import { Retree } from "./Retree";
+import { ignore, link } from "./decorators";
+import { getCustomProxyHandler } from "./internals";
+import { COLLECTED_KEYS_SYMBOL, LINKED_KEYS_SYMBOL } from "./ReactiveNode";
+import { INodeFieldChanges, TreeNode } from "./types";
+
+/**
+ * Deep-walks a raw tree and returns the paths of every value that carries
+ * Retree proxy metadata. Skips `@ignore`/collected and linked keys — those
+ * fields are outside the purity domain (users may store managed nodes there
+ * deliberately; links point at nodes owned elsewhere).
+ */
+function findProxiesInRaw(rawRoot: object): string[] {
+    const found: string[] = [];
+    const seen = new WeakSet<object>();
+    const visit = (value: unknown, path: string) => {
+        if (value === null || typeof value !== "object") {
+            return;
+        }
+        if (getCustomProxyHandler(value as TreeNode) !== undefined) {
+            found.push(path);
+            return;
+        }
+        if (seen.has(value)) {
+            return;
+        }
+        seen.add(value);
+        if (value instanceof Map) {
+            for (const [key, entryValue] of value.entries()) {
+                visit(entryValue, `${path}.get(${String(key)})`);
+            }
+            return;
+        }
+        if (value instanceof Set) {
+            let index = 0;
+            for (const entryValue of value.values()) {
+                visit(entryValue, `${path}[Set:${index++}]`);
+            }
+            return;
+        }
+        if (value instanceof Date) {
+            return;
+        }
+        const collected =
+            value instanceof ReactiveNode
+                ? value[COLLECTED_KEYS_SYMBOL]
+                : undefined;
+        const linked =
+            value instanceof ReactiveNode
+                ? value[LINKED_KEYS_SYMBOL]
+                : undefined;
+        for (const key of Object.keys(value)) {
+            if (key.startsWith("RETREE_")) {
+                continue;
+            }
+            if (collected?.has(key) || linked?.has(key)) {
+                continue;
+            }
+            visit((value as Record<string, unknown>)[key], `${path}.${key}`);
+        }
+    };
+    visit(rawRoot, "$");
+    return found;
+}
+
+function expectPure(node: TreeNode) {
+    expect(findProxiesInRaw(Retree.raw(node))).toEqual([]);
+}
+
+describe("raw purity invariant", () => {
+    it("plain writes and pushes stay pure", () => {
+        const root = Retree.root({ list: [] as { v: number }[], child: {} });
+        root.list.push({ v: 1 });
+        (root.child as { nested?: object }).nested = { deep: { v: 2 } };
+        void root.list[0].v; // materialize
+        expectPure(root);
+    });
+
+    it("assigning an already-managed node (reparent) stays pure", () => {
+        const detached = Retree.root({ v: 2, inner: { x: 1 } });
+        const root = Retree.root({ list: [] as { v: number }[] });
+        root.list.push(detached);
+        void root.list[0].v;
+        expectPure(root);
+        // The reparented child is still managed: mutating it emits.
+        const changed = vi.fn();
+        const off = Retree.on(root.list[0], "nodeChanged", changed);
+        root.list[0].v = 3;
+        expect(changed).toHaveBeenCalledTimes(1);
+        off();
+    });
+
+    it("Retree.move stays pure on both parents", () => {
+        const ws = Retree.root({
+            todo: [{ v: 3 }],
+            done: [] as { v: number }[],
+        });
+        void ws.todo[0];
+        Retree.move(ws.todo[0], ws.done);
+        expectPure(ws);
+        expect(Retree.raw(ws).done[0]).toEqual({ v: 3 });
+    });
+
+    it("post-construction assignment of non-plain values stays pure", () => {
+        class Thing {
+            public v = 5;
+        }
+        const root = Retree.root({
+            m: null as Map<string, number> | null,
+            s: null as Set<number> | null,
+            d: null as Date | null,
+            t: null as Thing | null,
+        });
+        root.m = new Map([["k", 1]]);
+        root.s = new Set([1, 2]);
+        root.d = new Date(0);
+        root.t = new Thing();
+        expectPure(root);
+        // Managed reads still return managed children.
+        expect(getCustomProxyHandler(root.m!)).toBeDefined();
+        expect(getCustomProxyHandler(root.t!)).toBeDefined();
+    });
+
+    it("defineProperty with a managed node stays pure", () => {
+        const detached = Retree.root({ v: 7 });
+        const root = Retree.root({} as { child?: { v: number } });
+        Object.defineProperty(root, "child", {
+            value: detached,
+            enumerable: true,
+            writable: true,
+            configurable: true,
+        });
+        expectPure(root);
+        expect(Retree.raw(root).child).toEqual({ v: 7 });
+        expect(getCustomProxyHandler(root.child!)).toBeDefined();
+    });
+
+    it("linked fields store raw pointers", () => {
+        class Owner extends ReactiveNode {
+            @link public target: { v: number } | null = null;
+            get dependencies() {
+                return [];
+            }
+        }
+        const root = Retree.root({
+            data: { v: 9 },
+            owner: new Owner(),
+        });
+        void root.data.v; // materialize target
+        root.owner.target = root.data;
+        const rawOwner = Retree.raw(root.owner);
+        expect(
+            getCustomProxyHandler(
+                (rawOwner as unknown as { target: object }).target
+            )
+        ).toBeUndefined();
+        // Linked reads still resolve to the managed node.
+        expect(getCustomProxyHandler(root.owner.target!)).toBeDefined();
+        root.owner.target.v = 10;
+        expect(root.data.v).toBe(10);
+    });
+
+    it("stays pure through transactions and runSilent", () => {
+        const detached = Retree.root({ v: 1 });
+        const root = Retree.root({
+            list: [] as { v: number }[],
+            child: null as { v: number } | null,
+        });
+        Retree.runTransaction(() => {
+            root.list.push(detached);
+            root.child = { v: 2 };
+        });
+        Retree.runSilent(() => {
+            root.list.push(Retree.root({ v: 3 }));
+        }, false);
+        void root.list[0];
+        void root.list[1];
+        expectPure(root);
+    });
+
+    it("Map value reads and writes stay pure", () => {
+        const root = Retree.root({
+            map: new Map<string, { v: number }>([["a", { v: 1 }]]),
+        });
+        // Read-materialize the value, iterate, then write more values.
+        void root.map.get("a");
+        for (const value of root.map.values()) {
+            void value;
+        }
+        root.map.set("b", { v: 2 });
+        const managed = Retree.root({ v: 3 });
+        root.map.set("c", managed);
+        void root.map.get("c");
+        expectPure(root);
+        // Managed reads still resolve, and mutations still emit.
+        const changed = vi.fn();
+        const off = Retree.on(root.map.get("c")!, "nodeChanged", changed);
+        root.map.get("c")!.v = 4;
+        expect(changed).toHaveBeenCalledTimes(1);
+        off();
+    });
+
+    it("Map values present at root() time stay pure", () => {
+        const managed = Retree.root({ v: 5 });
+        const inner = new Map<string, { v: number }>([["k", managed]]);
+        const root = Retree.root({ map: inner });
+        expectPure(root);
+        expect(Retree.raw(root.map).get("k")).toBe(Retree.raw(managed));
+        expect(Retree.parent(root.map.get("k")!)).toBe(root.map);
+    });
+
+    it("Set members stay pure across add, iterate, and root() time", () => {
+        const managed = Retree.root({ v: 6 });
+        const root = Retree.root({ set: new Set<{ v: number }>([managed]) });
+        root.set.add({ v: 7 });
+        root.set.add(Retree.root({ v: 8 }));
+        for (const member of root.set) {
+            void member;
+        }
+        expectPure(root);
+        // Membership works with both raw and managed arguments.
+        expect(root.set.has(Retree.raw(managed))).toBe(true);
+        for (const member of root.set) {
+            expect(root.set.has(member)).toBe(true);
+        }
+    });
+
+    it("structuredClone(Retree.raw(root)) succeeds after reparents and map reads", () => {
+        const detached = Retree.root({ v: 2, inner: { x: 1 } });
+        const root = Retree.root({
+            list: [] as object[],
+            map: new Map<string, { v: number }>([["a", { v: 9 }]]),
+        });
+        root.list.push(detached);
+        void root.list[0];
+        void root.map.get("a"); // materialize the map value
+        const cloned = structuredClone(Retree.raw(root));
+        expect(cloned.list).toEqual([{ v: 2, inner: { x: 1 } }]);
+        expect(cloned.map.get("a")).toEqual({ v: 9 });
+    });
+});
+
+describe("raw change payloads (§9.1: consistently raw)", () => {
+    it("previous and new are raw for reparented children", () => {
+        const first = Retree.root({ v: 1 });
+        const second = Retree.root({ v: 2 });
+        const root = Retree.root({ child: null as { v: number } | null });
+        root.child = first;
+        let captured: INodeFieldChanges[] = [];
+        const off = Retree.on(root, "nodeChanged", (_node, changes) => {
+            captured = changes;
+        });
+        root.child = second;
+        off();
+        expect(captured).toHaveLength(1);
+        expect(captured[0].key).toBe("child");
+        expect(getCustomProxyHandler(captured[0].previous as TreeNode)).toBe(
+            undefined
+        );
+        expect(getCustomProxyHandler(captured[0].new as TreeNode)).toBe(
+            undefined
+        );
+        expect(captured[0].previous).toBe(Retree.raw(first));
+        expect(captured[0].new).toBe(Retree.raw(second));
+    });
+
+    it("previous and new are raw for eager non-plain values", () => {
+        const root = Retree.root({ m: null as Map<string, number> | null });
+        root.m = new Map([["a", 1]]);
+        let captured: INodeFieldChanges[] = [];
+        const off = Retree.on(root, "nodeChanged", (_node, changes) => {
+            captured = changes;
+        });
+        const nextMap = new Map([["b", 2]]);
+        root.m = nextMap;
+        off();
+        expect(getCustomProxyHandler(captured[0].previous as TreeNode)).toBe(
+            undefined
+        );
+        expect(captured[0].new).toBe(nextMap);
+    });
+
+    it("a listener can opt back into the managed node via Retree.source", () => {
+        const first = Retree.root({ v: 1 });
+        const root = Retree.root({ child: null as { v: number } | null });
+        root.child = first;
+        let previousRaw: unknown;
+        const off = Retree.on(root, "nodeChanged", (_node, changes) => {
+            previousRaw = changes[0].previous;
+        });
+        root.child = { v: 99 };
+        off();
+        const managed = Retree.source(previousRaw as TreeNode);
+        expect(managed).toBeDefined();
+        expect(Retree.raw(managed!)).toBe(previousRaw);
+    });
+});
+
+describe("same-node reassignment", () => {
+    it("assigning the node already stored at a property is a no-op", () => {
+        const detached = Retree.root({ v: 1 });
+        const root = Retree.root({ child: null as { v: number } | null });
+        root.child = detached;
+        const changed = vi.fn();
+        const off = Retree.on(root, "nodeChanged", changed);
+        root.child = detached; // same base proxy
+        const readBack = root.child; // latest managed identity
+        root.child = readBack; // read-back assignment
+        expect(changed).not.toHaveBeenCalled();
+        off();
+    });
+});

--- a/packages/retree-core/src/types.ts
+++ b/packages/retree-core/src/types.ts
@@ -29,6 +29,13 @@ export type TRetreeEvents = TRetreeChangedEvents | "nodeRemoved";
 
 /**
  * Field-level change metadata passed to Retree change listeners.
+ *
+ * @remarks
+ * `previous` and `new` are **raw values, always** — change records are
+ * descriptions of the past, not live handles. Listeners that need the
+ * managed node for an object value opt in with `Retree.source(value)`.
+ * Identity comparisons against payload values should be raw-to-raw:
+ * `change.previous === Retree.raw(candidate)`.
  */
 export interface INodeFieldChanges<TValue = unknown> {
     key: string;

--- a/packages/retree-react-convex/package.json
+++ b/packages/retree-react-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react-convex",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "Use ConvexReactClient with Retree Convex nodes.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -15,13 +15,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/convex": "0.4.13",
+        "@retreejs/convex": "0.4.14",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/convex": "0.4.13",
+        "@retreejs/convex": "0.4.14",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-react-convex/package.json
+++ b/packages/retree-react-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react-convex",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "description": "Use ConvexReactClient with Retree Convex nodes.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -15,13 +15,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/convex": "0.4.15",
+        "@retreejs/convex": "0.4.16",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/convex": "0.4.15",
+        "@retreejs/convex": "0.4.16",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-react-convex/package.json
+++ b/packages/retree-react-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react-convex",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "Use ConvexReactClient with Retree Convex nodes.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -15,13 +15,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/convex": "0.4.14",
+        "@retreejs/convex": "0.4.15",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/convex": "0.4.14",
+        "@retreejs/convex": "0.4.15",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-react/README.md
+++ b/packages/retree-react/README.md
@@ -24,6 +24,7 @@ yarn add @retreejs/core @retreejs/react
 -   [`useNode`](#usenode-hook) subscribes to direct `nodeChanged` events. Use it for focused components that own one node.
 -   [`useTree`](#usetree-hook) subscribes to `treeChanged` events from a node and descendants. Use it for small subtrees that should re-render together.
 -   [`useSelect`](#useselect-hook) subscribes to a selected value or ordered dependency list and re-renders only when it changes. Use it for counts, totals, booleans, labels, and other narrow projections.
+-   [`useRaw`](#useraw-hook) subscribes like `useNode` but returns `[raw, toSource]` for native-speed, proxy-free reads. Use it for components that read wide during render.
 -   [`@select`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#reactive-dependencies) decorates a getter with an ordered dependency list. Use it when VM logic should stay in the `ReactiveNode` while `useNode(node)` stays selective.
 -   [`ReactiveNode.dependencies`](#reactivenode) can make a node emit `nodeChanged` from narrow dependencies. Return raw reactive nodes/primitives directly, or wrap one slot with `this.dependency(node, comparisons)`.
 -   [`memo`, `@memo`, and `@fnMemo`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#memoize-computed-getters) cache expensive computed values. They do not trigger renders by themselves.
@@ -386,6 +387,51 @@ greatGrandparent1.grandparent_1.name = "Beth";
 While `useTree` is powerful and can make things a lot easier, it is important to ensure its usage doesn't have negative performance. As your component tree gets more complicated, you should take care to only `useTree` sparingly (e.g., lower down in your view tree hierarchy).
 
 **Tip:** Always use React Dev Tools' profile tab to measure render performance when using `useTree`.
+
+### useRaw hook
+
+Use `useRaw` when a component reads wide during render — big tables, canvas
+layers, subtree serialization — and per-property proxy reads show up in
+profiles. It subscribes exactly like `useNode` (`nodeChanged` by default) but
+returns `[raw, toSource]`: the live raw object for native-speed reads plus a
+resolver back to managed nodes.
+
+```tsx
+import React from "react";
+import { useNode, useRaw } from "@retreejs/react";
+
+function TaskListView({ list }: { list: TaskList }) {
+    // Re-renders only when the array itself changes: add / remove / reorder.
+    const [tasksRaw, toSource] = useRaw(list.tasks);
+    return (
+        <ul>
+            {tasksRaw.map((rawTask) => (
+                <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+            ))}
+        </ul>
+    );
+}
+
+const TaskRow = React.memo(function TaskRow({ task }: { task: Task }) {
+    const t = useNode(task); // node prop: own subscription, write surface
+    return <li onClick={() => (t.isComplete = !t.isComplete)}>{t.title}</li>;
+});
+```
+
+-   The prop passed to children is the **node** (`toSource(rawTask)`), never
+    the raw value. Nodes carry subscriptions, writes, navigation, and
+    identity; raw is a local read view.
+-   `toSource` always resolves direct children of the subscribed node —
+    object/array children, Map values, and Set members — materializing them
+    on demand.
+-   Invalidation matches `useNode`: deep changes re-render only when declared
+    — via the node's `dependencies` / `@select`, via `useSelect` for derived
+    views, or via the `listenerType: "treeChanged"` opt-in. Raw is live, so
+    any render (including parent-triggered ones) reads current state.
+-   Do not filter or aggregate raw content inline when membership must stay
+    in lockstep with deep fields — that is derived state; use `useSelect`.
+-   Never write to raw values, and never use raw references as `React.memo`
+    props or `useMemo` deps.
 
 ## React performance guide
 

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -15,14 +15,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.4.15",
+        "@retreejs/core": "0.4.16",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.15",
+        "@retreejs/core": "0.4.16",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -15,14 +15,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.4.14",
+        "@retreejs/core": "0.4.15",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.14",
+        "@retreejs/core": "0.4.15",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -15,14 +15,14 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.8",
-        "@retreejs/core": "0.4.13",
+        "@retreejs/core": "0.4.14",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "babel-loader": "^9.1.2",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.4.13",
+        "@retreejs/core": "0.4.14",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },

--- a/packages/retree-react/src/index.ts
+++ b/packages/retree-react/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./useNode";
+export * from "./useRaw";
 export * from "./useSelect";
 export * from "./useTree";
 export * from "./useRoot";

--- a/packages/retree-react/src/internals/subscriptionHub.ts
+++ b/packages/retree-react/src/internals/subscriptionHub.ts
@@ -3,9 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { Retree, TRetreeChangedEvents, TreeNode } from "@retreejs/core";
+import {
+    INodeFieldChanges,
+    Retree,
+    TRetreeChangedEvents,
+    TreeNode,
+} from "@retreejs/core";
 
-type HubListener<T extends TreeNode = TreeNode> = (node: T) => void;
+type HubListener<T extends TreeNode = TreeNode> = (
+    node: T,
+    changes?: INodeFieldChanges[]
+) => void;
 
 interface SubscriptionHubEntry<T extends TreeNode = TreeNode> {
     listeners: Set<HubListener<T>>;
@@ -34,9 +42,9 @@ export function subscribeToNode<T extends TreeNode = TreeNode>(
         const unsubscribeRetree = Retree.on<T>(
             baseProxy,
             listenerType,
-            (reproxy) => {
+            (reproxy, changes) => {
                 for (const callback of [...listeners]) {
-                    callback(reproxy);
+                    callback(reproxy, changes);
                 }
             }
         );

--- a/packages/retree-react/src/useRaw.perf.spec.tsx
+++ b/packages/retree-react/src/useRaw.perf.spec.tsx
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Wide-table render measurement for the raw-purity spec's performance gates
+ * (specs/retree-raw.md §6): `useRaw` vs `useNode` for read-wide renders, and
+ * `useRaw` mount with `toSource` per row vs the `useNode` equivalent.
+ * Prints timings with `--disable-console-intercept`; assertions are loose
+ * sanity bounds so machine speed never gates CI.
+ */
+import { render } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { Retree } from "@retreejs/core";
+import { useNode } from "./useNode";
+import { useRaw } from "./useRaw";
+
+interface WideRow {
+    id: number;
+    cells: number[];
+}
+
+function makeRows(rows: number, cells: number): WideRow[] {
+    const result: WideRow[] = [];
+    for (let r = 0; r < rows; r++) {
+        const rowCells: number[] = [];
+        for (let c = 0; c < cells; c++) {
+            rowCells.push(r * cells + c);
+        }
+        result.push({ id: r, cells: rowCells });
+    }
+    return result;
+}
+
+function time(label: string, fn: () => void): number {
+    const start = performance.now();
+    fn();
+    const ms = performance.now() - start;
+
+    console.log(`${label}: ${ms.toFixed(1)} ms`);
+    return ms;
+}
+
+describe("useRaw perf probe", () => {
+    it("wide-table render: useRaw vs useNode", () => {
+        const ROWS = 200;
+        const CELLS = 40;
+
+        const nodeRoot = Retree.root({ rows: makeRows(ROWS, CELLS) });
+        function NodeTable() {
+            const rows = useNode(nodeRoot.rows);
+            let total = 0;
+            for (const row of rows) {
+                for (const cell of row.cells) {
+                    total += cell;
+                }
+            }
+            return <div>{total}</div>;
+        }
+        const nodeMs = time("useNode wide table (200x40 reads)", () => {
+            render(<NodeTable />);
+        });
+
+        const rawRoot = Retree.root({ rows: makeRows(ROWS, CELLS) });
+        function RawTable() {
+            const [rows] = useRaw(rawRoot.rows);
+            let total = 0;
+            for (const row of rows) {
+                for (const cell of row.cells) {
+                    total += cell;
+                }
+            }
+            return <div>{total}</div>;
+        }
+        const rawMs = time("useRaw wide table (200x40 reads)", () => {
+            render(<RawTable />);
+        });
+
+        // Loose gate: raw reads must not be slower than trapped reads.
+        expect(rawMs).toBeLessThanOrEqual(nodeMs * 1.5);
+    });
+
+    it("useRaw mount with toSource per row vs useNode list", () => {
+        const ROWS = 2000;
+
+        const nodeRoot = Retree.root({ rows: makeRows(ROWS, 1) });
+        function NodeList() {
+            const rows = useNode(nodeRoot.rows);
+            return <div>{rows.map((row) => row.id).join("")}</div>;
+        }
+        const nodeMs = time("useNode list mount (2000 rows)", () => {
+            render(<NodeList />);
+        });
+
+        const rawRoot = Retree.root({ rows: makeRows(ROWS, 1) });
+        let resolvedCount = 0;
+        function RawList() {
+            const [rows, toSource] = useRaw(rawRoot.rows);
+            return (
+                <div>
+                    {rows
+                        .map((row) => {
+                            const source = toSource(row);
+                            if (source !== undefined) {
+                                resolvedCount++;
+                            }
+                            return row.id;
+                        })
+                        .join("")}
+                </div>
+            );
+        }
+        const rawMs = time(
+            "useRaw list mount + toSource all (2000 rows)",
+            () => {
+                render(<RawList />);
+            }
+        );
+
+        expect(resolvedCount).toBe(ROWS);
+        // Gate (specs/retree-raw.md §6): ≤ the useNode equivalent, with slack
+        // for jsdom noise.
+        expect(rawMs).toBeLessThanOrEqual(nodeMs * 1.5);
+    });
+});

--- a/packages/retree-react/src/useRaw.spec.tsx
+++ b/packages/retree-react/src/useRaw.spec.tsx
@@ -1,0 +1,234 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { act, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ReactiveNode, Retree, select } from "@retreejs/core";
+import { getCustomProxyHandler } from "@retreejs/core/internal";
+import { useNode } from "./useNode";
+import { useRaw } from "./useRaw";
+
+interface Task {
+    id: string;
+    title: string;
+    isComplete: boolean;
+}
+
+function makeTasks(): Task[] {
+    return [
+        { id: "a", title: "Alpha", isComplete: false },
+        { id: "b", title: "Beta", isComplete: true },
+    ];
+}
+
+describe("useRaw", () => {
+    it("returns the raw node and re-renders on own changes only", () => {
+        const root = Retree.root({ tasks: makeTasks() });
+        const listRenders = vi.fn();
+
+        function List() {
+            const [tasksRaw] = useRaw(root.tasks);
+            listRenders();
+            expect(getCustomProxyHandler(tasksRaw)).toBeUndefined();
+            return <div data-testid="count">{tasksRaw.length}</div>;
+        }
+
+        render(<List />);
+        expect(listRenders).toHaveBeenCalledTimes(1);
+
+        // Deep change: a task's own field. The list must NOT re-render.
+        act(() => {
+            root.tasks[0].isComplete = true;
+        });
+        expect(listRenders).toHaveBeenCalledTimes(1);
+
+        // Structural change: the array itself. The list re-renders.
+        act(() => {
+            root.tasks.push({ id: "c", title: "Gamma", isComplete: false });
+        });
+        expect(listRenders).toHaveBeenCalledTimes(2);
+        expect(screen.getByTestId("count").textContent).toBe("3");
+    });
+
+    it("rows own their content; memo rows bail on structural changes", () => {
+        const root = Retree.root({ tasks: makeTasks() });
+        const rowRenders = vi.fn();
+
+        const Row = React.memo(function Row({ task }: { task: Task }) {
+            const t = useNode(task);
+            rowRenders(t.id);
+            return <li data-testid={`row-${t.id}`}>{t.title}</li>;
+        });
+
+        function List() {
+            const [tasksRaw, toSource] = useRaw(root.tasks);
+            return (
+                <ul>
+                    {tasksRaw.map((rawTask) => (
+                        <Row key={rawTask.id} task={toSource(rawTask)!} />
+                    ))}
+                </ul>
+            );
+        }
+
+        render(<List />);
+        expect(rowRenders).toHaveBeenCalledTimes(2);
+
+        // A row's own change re-renders that row alone.
+        act(() => {
+            root.tasks[0].title = "Alpha 2";
+        });
+        expect(rowRenders).toHaveBeenCalledTimes(3);
+        expect(rowRenders).toHaveBeenLastCalledWith("a");
+        expect(screen.getByTestId("row-a").textContent).toBe("Alpha 2");
+
+        // A structural change re-renders the list. toSource hands each row
+        // the LATEST node identity (same semantics as a useNode list): new
+        // row "c" renders, row "a" re-renders once because its identity
+        // advanced when its title changed, and untouched row "b" bails.
+        act(() => {
+            root.tasks.push({ id: "c", title: "Gamma", isComplete: false });
+        });
+        expect(rowRenders).toHaveBeenCalledTimes(5);
+        const renderedIds = rowRenders.mock.calls.map(([id]) => id);
+        expect(renderedIds.filter((id) => id === "b")).toHaveLength(1);
+        expect(renderedIds).toContain("c");
+    });
+
+    it("toSource resolves never-materialized direct children", () => {
+        // Fresh tree: no traversal has happened through the proxy.
+        const root = Retree.root({ tasks: makeTasks() });
+        let resolved: Task | undefined;
+
+        function List() {
+            const [tasksRaw, toSource] = useRaw(root.tasks);
+            resolved = toSource(tasksRaw[0]);
+            return null;
+        }
+
+        render(<List />);
+        expect(resolved).toBeDefined();
+        expect(getCustomProxyHandler(resolved!)).toBeDefined();
+        expect(Retree.raw(resolved!)).toBe(Retree.raw(root.tasks)[0]);
+    });
+
+    it("toSource resolves never-materialized Map values and Set members", () => {
+        const root = Retree.root({
+            map: new Map<string, { v: number }>([["k", { v: 1 }]]),
+            set: new Set<{ v: number }>([{ v: 2 }]),
+        });
+        let mapResolved: { v: number } | undefined;
+        let setResolved: { v: number } | undefined;
+
+        function MapReader() {
+            const [rawMap, toSource] = useRaw(root.map);
+            mapResolved = toSource(rawMap.get("k")!);
+            return null;
+        }
+        function SetReader() {
+            const [rawSet, toSource] = useRaw(root.set);
+            setResolved = toSource([...rawSet][0]);
+            return null;
+        }
+
+        render(
+            <>
+                <MapReader />
+                <SetReader />
+            </>
+        );
+        expect(getCustomProxyHandler(mapResolved!)).toBeDefined();
+        expect(getCustomProxyHandler(setResolved!)).toBeDefined();
+        expect(Retree.parent(mapResolved!)).toBe(root.map);
+        expect(Retree.parent(setResolved!)).toBe(root.set);
+    });
+
+    it("reads current raw data on renders triggered by a parent", () => {
+        const root = Retree.root({ tasks: makeTasks() });
+
+        function List({ label }: { label: string }) {
+            const [tasksRaw] = useRaw(root.tasks);
+            return (
+                <div data-testid="view">
+                    {label}:{tasksRaw[0].title}
+                </div>
+            );
+        }
+
+        const view = render(<List label="one" />);
+        // Deep change with no list re-render: rendered output is stale.
+        act(() => {
+            root.tasks[0].title = "Fresh";
+        });
+        expect(screen.getByTestId("view").textContent).toBe("one:Alpha");
+        // Parent-triggered re-render reads current raw data.
+        view.rerender(<List label="two" />);
+        expect(screen.getByTestId("view").textContent).toBe("two:Fresh");
+    });
+
+    it("re-renders on declared deep dependencies via @select owners", () => {
+        class TaskList extends ReactiveNode {
+            public tasks: Task[] = makeTasks();
+
+            @select()
+            get incompleteIds() {
+                return this.tasks.filter((t) => !t.isComplete).map((t) => t.id);
+            }
+
+            get dependencies() {
+                return [];
+            }
+        }
+        const list = Retree.root(new TaskList());
+        const renders = vi.fn();
+
+        function Incomplete() {
+            const [rawList] = useRaw(list); // default nodeChanged
+            renders();
+            const ids = rawList.tasks
+                .filter((t) => !t.isComplete)
+                .map((t) => t.id)
+                .join(",");
+            return <div data-testid="ids">{ids}</div>;
+        }
+
+        render(<Incomplete />);
+        expect(renders).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId("ids").textContent).toBe("a");
+
+        // Declared deep dependency: the owner emits nodeChanged for itself.
+        act(() => {
+            list.tasks[0].isComplete = true;
+        });
+        expect(renders).toHaveBeenCalledTimes(2);
+        expect(screen.getByTestId("ids").textContent).toBe("");
+
+        // Undeclared deep change: title is not part of the @select getter.
+        act(() => {
+            list.tasks[0].title = "Renamed";
+        });
+        expect(renders).toHaveBeenCalledTimes(2);
+    });
+
+    it("treeChanged opt-in re-renders on any deep change", () => {
+        const root = Retree.root({ tasks: makeTasks() });
+        const renders = vi.fn();
+
+        function List() {
+            const [tasksRaw] = useRaw(root.tasks, {
+                listenerType: "treeChanged",
+            });
+            renders();
+            return <div>{tasksRaw.length}</div>;
+        }
+
+        render(<List />);
+        expect(renders).toHaveBeenCalledTimes(1);
+        act(() => {
+            root.tasks[0].title = "Deep";
+        });
+        expect(renders).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/retree-react/src/useRaw.ts
+++ b/packages/retree-react/src/useRaw.ts
@@ -1,0 +1,134 @@
+/*!
+ * Copyright (c) Ryan Bliss. All rights reserved.
+ * Licensed under the MIT License.
+ */
+"use no memo";
+
+import { Retree, TreeNode } from "@retreejs/core";
+import {
+    getBaseProxy,
+    getUnproxiedNode,
+    materializeDirectChildren,
+} from "@retreejs/core/internal";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { subscribeToNode } from "./internals/subscriptionHub";
+import { NodeFactory } from "./types";
+
+/**
+ * Resolves a raw value back to its Retree-managed node.
+ *
+ * @remarks
+ * Returned by {@link useRaw}. Direct children of the subscribed node are
+ * guaranteed to resolve (they are materialized on demand); deeper raw values
+ * resolve when they have been materialized.
+ */
+export type ToSource = <T extends TreeNode>(rawValue: T) => T | undefined;
+
+export interface UseRawOptions {
+    /**
+     * Listener type for re-render invalidation. Defaults to `"nodeChanged"`,
+     * exactly like `useNode`: the component re-renders when the node's own
+     * data changes. Pass `"treeChanged"` to opt in to subtree invalidation.
+     */
+    listenerType?: "nodeChanged" | "treeChanged";
+}
+
+function getNode<T extends TreeNode = TreeNode>(node: T | NodeFactory<T>) {
+    if (typeof node === "function") {
+        return node();
+    }
+    return node;
+}
+
+/**
+ * Subscribe to a node like `useNode`, but read its data raw — native-speed,
+ * proxy-free reads for render bodies that read wide.
+ *
+ * @remarks
+ * Returns `[raw, toSource]`:
+ *
+ * - `raw` is the live raw object behind the node ({@link Retree.raw}) —
+ *   zero-copy and guaranteed proxy-free. Treat it as **read-only**: writes go
+ *   through nodes. Raw references keep the same identity across changes, so
+ *   never use them as `React.memo` props, `useMemo` deps, or equality
+ *   tokens — nodes remain the identity currency.
+ * - `toSource` resolves a raw value back to its managed node. Direct children
+ *   of the subscribed node always resolve (object/array children, Map
+ *   values, and Set members are materialized on demand); use it to pass
+ *   nodes to child components while mapping raw content.
+ *
+ * Invalidation follows the same contract as `useNode`: the component
+ * re-renders when the node's own data changes (`nodeChanged` default). Deep
+ * changes re-render only when declared — via the node's `dependencies` /
+ * `@select`, via `useSelect` for derived views, or via the `treeChanged`
+ * opt-in. Because `raw` is live, any render (including renders triggered by
+ * a parent) reads current state.
+ *
+ * @param node Retree-managed node or node factory to observe.
+ * @param options Optional listener type.
+ * @returns `[raw, toSource]` tuple.
+ *
+ * @example
+ * ```tsx
+ * function TaskListView({ list }: { list: TaskList }) {
+ *     // Re-renders only when the array itself changes.
+ *     const [tasksRaw, toSource] = useRaw(list.tasks);
+ *     return (
+ *         <ul>
+ *             {tasksRaw.map((rawTask) => (
+ *                 <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+ *             ))}
+ *         </ul>
+ *     );
+ * }
+ *
+ * const TaskRow = React.memo(function TaskRow({ task }: { task: Task }) {
+ *     const t = useNode(task); // node prop: own subscription, write surface
+ *     return <li onClick={() => (t.isComplete = !t.isComplete)}>{t.title}</li>;
+ * });
+ * ```
+ */
+export function useRaw<TNode extends TreeNode>(
+    node: TNode | NodeFactory<TNode>,
+    options?: UseRawOptions
+): [TNode, ToSource] {
+    const memoNode = useMemo(() => {
+        return getNode(node);
+    }, [node]);
+    const baseProxy = getBaseProxy(memoNode);
+    const listenerType = options?.listenerType ?? "nodeChanged";
+
+    const [, setRenderCount] = useState(0);
+    useEffect(() => {
+        const unsubscribe = subscribeToNode(baseProxy, listenerType, () => {
+            setRenderCount((count) => count + 1);
+        });
+        return () => {
+            unsubscribe();
+        };
+    }, [baseProxy, listenerType]);
+
+    // At most one materialization pass per render: a second miss in the same
+    // render means the value is not a direct child of this node.
+    const materializedThisRender = useRef(false);
+    materializedThisRender.current = false;
+
+    const toSource: ToSource = useCallback(
+        <T extends TreeNode>(rawValue: T) => {
+            const existing = Retree.source(rawValue);
+            if (existing !== undefined) {
+                return existing;
+            }
+            if (materializedThisRender.current) {
+                return undefined;
+            }
+            materializedThisRender.current = true;
+            materializeDirectChildren(baseProxy);
+            return Retree.source(rawValue);
+        },
+        [baseProxy]
+    );
+
+    const raw = getUnproxiedNode(baseProxy) as TNode;
+    return useMemo(() => [raw, toSource], [raw, toSource]);
+}

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.14"
+        "@retreejs/core": "0.4.15"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.15"
+        "@retreejs/core": "0.4.16"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/01.core-example/package.json
+++ b/samples/01.core-example/package.json
@@ -13,7 +13,7 @@
         "doctor": "node ../../node_modules/eslint/bin/eslint.js src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.13"
+        "@retreejs/core": "0.4.14"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.4.13",
-        "@retreejs/react": "0.4.13"
+        "@retreejs/core": "0.4.14",
+        "@retreejs/react": "0.4.14"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.4.14",
-        "@retreejs/react": "0.4.14"
+        "@retreejs/core": "0.4.15",
+        "@retreejs/react": "0.4.15"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/02.react-example/package.json
+++ b/samples/02.react-example/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "@retreejs/core": "0.4.15",
-        "@retreejs/react": "0.4.15"
+        "@retreejs/core": "0.4.16",
+        "@retreejs/react": "0.4.16"
     },
     "devDependencies": {
         "@types/react": "^19.2.3",

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.15",
-        "@retreejs/react": "0.4.15",
+        "@retreejs/core": "0.4.16",
+        "@retreejs/react": "0.4.16",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.14",
-        "@retreejs/react": "0.4.14",
+        "@retreejs/core": "0.4.15",
+        "@retreejs/react": "0.4.15",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/03.react-recursion/package.json
+++ b/samples/03.react-recursion/package.json
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@retreejs/core": "0.4.13",
-        "@retreejs/react": "0.4.13",
+        "@retreejs/core": "0.4.14",
+        "@retreejs/react": "0.4.14",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uuid": "^9.0.0"

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.13",
+                "@retreejs/core": "0.4.14",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -836,7 +836,7 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.13",
+            "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
@@ -909,7 +909,7 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.13",
+            "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
@@ -975,7 +975,7 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.13",
+            "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
@@ -5085,7 +5085,7 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.13",
+            "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
@@ -5158,7 +5158,7 @@
             }
         },
         "node_modules/levn": {
-            "version": "0.4.13",
+            "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
@@ -6831,7 +6831,7 @@
             "license": "0BSD"
         },
         "node_modules/type-check": {
-            "version": "0.4.13",
+            "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.15",
+            "version": "0.4.16",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.15",
+                "@retreejs/core": "0.4.16",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -836,7 +836,7 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.15",
+            "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
@@ -909,7 +909,7 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.15",
+            "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
@@ -975,7 +975,7 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.15",
+            "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
@@ -5085,7 +5085,7 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.15",
+            "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
@@ -5158,7 +5158,7 @@
             }
         },
         "node_modules/levn": {
-            "version": "0.4.15",
+            "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
@@ -6831,7 +6831,7 @@
             "license": "0BSD"
         },
         "node_modules/type-check": {
-            "version": "0.4.15",
+            "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,

--- a/samples/04.convex-react-nextjs/package-lock.json
+++ b/samples/04.convex-react-nextjs/package-lock.json
@@ -30,21 +30,21 @@
         },
         "../../packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "convex": "^1.39.1",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "convex": "^1.39.1"
             }
         },
         "../../packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "dependencies": {
                 "events": "^3.0.0"
@@ -60,18 +60,18 @@
         },
         "../../packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.4.14",
+            "version": "0.4.15",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.21.8",
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "babel-loader": "^9.1.2",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.4.14",
+                "@retreejs/core": "0.4.15",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
@@ -836,7 +836,7 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.14",
+            "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
@@ -909,7 +909,7 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.14",
+            "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
@@ -975,7 +975,7 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.14",
+            "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
@@ -5085,7 +5085,7 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.14",
+            "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
@@ -5158,7 +5158,7 @@
             }
         },
         "node_modules/levn": {
-            "version": "0.4.14",
+            "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
@@ -6831,7 +6831,7 @@
             "license": "0BSD"
         },
         "node_modules/type-check": {
-            "version": "0.4.14",
+            "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,

--- a/skills/retree/SKILL.md
+++ b/skills/retree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retree
-description: Build, debug, or review Retree code for object-tree state management, React hooks, and Convex integration. Use when working with @retreejs/core, @retreejs/react, @retreejs/convex, @retreejs/react-convex, Retree.root, ReactiveNode, useNode, useTree, useSelect, useRoot, Retree.select, Retree.move, Retree.link, memo decorators, or Retree Convex query nodes.
+description: Build, debug, or review Retree code for object-tree state management, React hooks, and Convex integration. Use when working with @retreejs/core, @retreejs/react, @retreejs/convex, @retreejs/react-convex, Retree.root, ReactiveNode, useNode, useTree, useSelect, useRoot, useRaw, Retree.select, Retree.raw, Retree.peekInto, Retree.source, Retree.untracked, Retree.move, Retree.link, memo decorators, or Retree Convex query nodes.
 ---
 
 # Retree
@@ -105,6 +105,24 @@ const doneCount = useSelect(
 
 Whole Retree-managed values read by an inferred selector subscribe broadly. Property reads subscribe to the owner and compare that property value.
 
+Use `useRaw` for components that read wide during render (big tables, canvas layers, serialization). It subscribes exactly like `useNode` (`nodeChanged` default) but returns `[raw, toSource]` — the live raw object for native-speed, proxy-free reads, plus a resolver back to managed nodes:
+
+```tsx
+function TaskListView({ list }: { list: TaskList }) {
+    // Re-renders only when the array itself changes: add / remove / reorder.
+    const [tasksRaw, toSource] = useRaw(list.tasks);
+    return (
+        <ul>
+            {tasksRaw.map((rawTask) => (
+                <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+            ))}
+        </ul>
+    );
+}
+```
+
+Pass **nodes** to children via `toSource`, never raw values. `toSource` always resolves direct children of the subscribed node (object/array children, Map values, Set members). Deep changes re-render only when declared — via the node's `dependencies` / `@select`, via `useSelect` for derived views, or via `listenerType: "treeChanged"`. Never write to raw values or use raw references as `React.memo` props or `useMemo` deps.
+
 ## Core APIs
 
 Use `Retree.on(node, listenerType, callback)` outside React or inside integrations. Listener types are `nodeChanged`, `treeChanged`, and `nodeRemoved`.
@@ -142,6 +160,27 @@ Retree.runTransaction(() => {
 ```
 
 Use `Retree.runSilent(...)` for non-rendered bookkeeping writes that should skip listener emissions.
+
+## Raw Reads
+
+Reads through Retree proxies pay a per-property trap cost. For wide, read-only scans, read raw:
+
+```ts
+const rawTasks = Retree.raw(project.tasks); // proxy-free, native-speed reads
+const found = Retree.peekInto(project.tasks, (raw) =>
+    raw.find((task) => task.id === id)
+); // raw query, managed result
+const managed = Retree.source(rawTasks[0]); // raw value → managed node
+const total = Retree.untracked(() => scan(project)); // no dependency tracking
+```
+
+Rules:
+
+-   **Raw purity guarantee:** `Retree.raw(node)` subtrees contain zero proxies under every write path; `structuredClone(Retree.raw(node))` is a valid point-in-time copy.
+-   Raw values are **read-only** — writes go through managed nodes, or they silently skip emission.
+-   Raw references never change identity; do not use them as memo/equality tokens. Nodes are the identity currency.
+-   Change payloads (`changes[].previous` / `changes[].new`) are always raw values; use `Retree.source(value)` to opt back into the managed node.
+-   `ReactiveNode` exposes instance forms: `this.raw()`, `this.untracked(fn)`, `this.peekInto(fn)`.
 
 ## Ownership
 
@@ -198,6 +237,8 @@ Use `memo`, `@memo`, and `@fnMemo` to cache computed values. Prefer bare or empt
 
 Do not start subscriptions, network work, or synchronization inside the `dependencies` getter. Use lifecycle methods such as `onObserved()`, `onUnobserved()`, and `onChanged()` for side effects.
 
+Methods on `ReactiveNode` can read their own data raw via `this.raw()`, run untracked bulk reads via `this.untracked(fn)`, and query raw data while returning managed nodes via `this.peekInto(fn)` — all delegating to the equivalent `Retree` statics.
+
 ## Convex Integration
 
 Use `ConvexNode` when a Retree app-state class should own a Convex client and create query, paginated query, connection-state, action, mutation, and one-off query helpers.
@@ -239,6 +280,8 @@ Use `ConvexConnectionStateNode` and `this.connectionState()` when UI should obse
 
 Use `reconcileConvexDocuments` or `reconcileArrayById` when server lists refresh by stable IDs. Reconciliation preserves child object identity so row components using `useNode(item)` stay narrow.
 
+Custom reconcilers receive a third `rawCurrent` argument (the proxy-free raw view of `current`). Read from `rawCurrent` at native speed, write diffs to `current` so changed rows emit. The built-in reconcilers already do this internally.
+
 Dispose query, paginated query, and connection-state nodes when their owner is torn down. With `@retreejs/react-convex`, query children created by `ConvexNode` helpers can subscribe when observed and clean up when the owning Retree node loses its final active observer.
 
 ## React Convex Adapter
@@ -275,6 +318,9 @@ Pass the same client into Retree state that extends `ConvexNode`.
 -   Do not use React index keys for rows if a list can reorder and stable IDs exist.
 -   Do not put expensive side effects in React render through `ReactiveNode` getters or functions.
 -   Do not expect Convex action, mutation, or query-once helpers to emit unless their results mutate Retree state.
+-   Do not write to values returned by `Retree.raw` / `useRaw`; raw is a read-only view and raw writes skip emission.
+-   Do not use raw references as `React.memo` props, `useMemo` deps, or equality tokens; resolve to nodes with `Retree.source` / `toSource`.
+-   Do not expect `changes[].previous` / `changes[].new` payload values to be managed nodes; they are always raw.
 
 ## Documentation Lookup
 

--- a/skills/retree/references/convex.md
+++ b/skills/retree/references/convex.md
@@ -258,6 +258,30 @@ this.tasks = this.query(api.tasks.listByProject, {
 });
 ```
 
+Custom reconcilers receive a third `rawCurrent` argument — the proxy-free raw
+view of `current` (`Retree.raw`). Reconciliation is read-dominated, so **read
+from `rawCurrent`, write to `current`**: comparisons run at native speed and
+writes through `current` emit `nodeChanged` for changed rows while keeping
+item identity stable. Writing to `rawCurrent` skips emission — never do it.
+
+```ts
+const reconcileTasks: IStateReconciler<Task[]> = {
+    reconcile(current, next, rawCurrent) {
+        if (current === undefined) return next;
+        for (let index = 0; index < next.length; index++) {
+            if (rawCurrent?.[index]?.text !== next[index]!.text) {
+                current[index]!.text = next[index]!.text; // ✅ emits
+            }
+        }
+        current.length = next.length;
+        return current;
+    },
+};
+```
+
+The built-in reconcilers (`reconcileConvexDocuments`, `reconcileArrayById`)
+already read raw and write through `current` internally.
+
 ## Docs
 
 Docs are hosted at https://ryanbliss.github.io/retree/.

--- a/skills/retree/references/core.md
+++ b/skills/retree/references/core.md
@@ -29,6 +29,10 @@ Use this as a quick map before choosing an API:
 -   [`Retree.on`](#listen-to-nodechanged-treechanged-and-noderemoved) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React or inside lower-level integrations.
 -   [`Retree.select`](#select-derived-values) subscribes to a selected value or ordered dependency list. Use it to narrow notifications; it is not a cache.
 -   [`Retree.parent`](#find-a-parent) returns the structural parent of a node. Use it for tree-local actions like deleting yourself from an array.
+-   [`Retree.raw`](#read-fast-with-raw) returns the raw, proxy-free object behind a node for native-speed, read-only access. Use it for algorithms that scan large trees.
+-   [`Retree.source`](#read-fast-with-raw) resolves a raw value back to its managed node. Use it to recover the write surface after a raw scan or from a change payload.
+-   [`Retree.peekInto`](#read-fast-with-raw) runs a read-only query against a node's raw object and resolves the result to its managed node when one exists.
+-   [`Retree.untracked`](#read-fast-with-raw) pauses dependency tracking during a synchronous callback. Use it for bulk reads inside tracked selectors and memo getters.
 -   [`Retree.move`](#move-link-or-clone-existing-nodes) transfers an existing node to a new structural parent. Use it when ownership should change.
 -   [`Retree.link` and `@link`](#move-link-or-clone-existing-nodes) store a reactive pointer to a node without reparenting it. Use it for selected items and cross-references.
 -   [`Retree.clone`](#move-link-or-clone-existing-nodes) creates a detached copy. Use it when two places need independent state.
@@ -282,6 +286,54 @@ class Task {
 ```
 
 Links are not structural parents: if `editor.selectedTask` is a `@link` field pointing at `project.tasks[0]`, `Retree.parent(editor.selectedTask)` still returns `project.tasks`.
+
+## Read fast with raw
+
+Reads through Retree proxies pay a per-property trap cost. For algorithms and
+render paths that read wide (large lists, deep scans, serialization), read the
+raw object instead:
+
+```ts
+const project = Retree.root({ items: [{ id: "a", score: 1 }] });
+
+// Native-speed, read-only view. Guaranteed proxy-free at any depth.
+const rawItems = Retree.raw(project.items);
+const total = rawItems.reduce((sum, item) => sum + item.score, 0);
+
+// Resolve a raw value back to its managed node when you need to write.
+const item = Retree.source(rawItems[0]);
+if (item) item.score = 2; // ✅ emits normally
+
+// Query raw and resolve the returned value to its managed node in one call.
+const found = Retree.peekInto(project.items, (raw) =>
+    raw.find((candidate) => candidate.id === "a")
+);
+
+// Pause dependency tracking for bulk reads inside tracked selectors/memos.
+const count = Retree.untracked(() => project.items.length);
+```
+
+Rules that keep raw reads safe:
+
+-   **Raw purity guarantee:** `Retree.raw(node)` subtrees contain zero Retree
+    proxies under every write path — reparenting assignments, `Retree.move`,
+    Map/Set value reads, and post-construction assignment of class instances
+    or collections. Every read is native speed, and
+    `structuredClone(Retree.raw(node))` is a valid point-in-time copy.
+-   Treat raw values as **read-only**. Writes go through managed nodes;
+    writing to raw skips emission entirely.
+-   Raw references keep the same identity across changes. Never use them as
+    memo/equality tokens — nodes are the identity currency.
+-   Raw reads are invisible to reactivity: they are not trapped by
+    `useSelect`/`Retree.select` selectors or `@memo` dependency collection.
+-   Change payloads (`INodeFieldChanges.previous` / `.new`) are always raw
+    values; use `Retree.source(change.previous)` to opt back into the managed
+    node.
+-   `Retree.source` returns `undefined` for values never materialized as
+    nodes; traverse the path once (or use `useRaw`'s `toSource` in React)
+    when a managed result is required.
+-   `ReactiveNode` exposes instance conveniences: `this.raw()`,
+    `this.untracked(fn)`, and `this.peekInto(fn)`.
 
 ## Reactive dependencies
 

--- a/skills/retree/references/llms.md
+++ b/skills/retree/references/llms.md
@@ -32,6 +32,10 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 -   DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
 -   DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
 -   DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
+-   DO use `Retree.raw(node)` / `Retree.peekInto(node, fn)` (or React's `useRaw`) for wide, read-only scans. Raw subtrees are guaranteed proxy-free and read at native speed.
+-   DO resolve raw values back to managed nodes with `Retree.source(rawValue)` (or `useRaw`'s `toSource`) before writing, subscribing, or passing them as component props.
+-   DO use `Retree.untracked(fn)` for bulk reads inside tracked selectors/memo getters that should not become dependencies.
+-   DO read `rawCurrent` and write `current` inside custom Convex reconcilers (`reconcile(current, next, rawCurrent)`).
 -   DO dispose Convex query, paginated query, and connection-state nodes when their owner is torn down.
 -   DO reconcile server list results by stable IDs (`reconcileConvexDocuments`, `reconcileArrayById`) so child node identity stays stable.
 -   DO set the lowest-level value and/or primitive that changed.
@@ -47,6 +51,9 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 -   DON'T expect `useSelect(...)` or `Retree.select(...)` dependency lists to reproxy the node passed to the selector. They are observational; use `@select` when a `ReactiveNode` owner should emit.
 -   DON'T pass selector-only `useSelect(() => ...)` or `Retree.select(() => ..., callback)` when you need a fixed root listener with `listenerType: "treeChanged"`. The selector-only forms trap Retree-managed reads and subscribe to those nodes automatically.
 -   DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
+-   DON'T write to values from `Retree.raw` / `useRaw`. Writes must go through managed nodes to emit; raw is a read-only view.
+-   DON'T use raw references as `React.memo` props, `useMemo` deps, or equality tokens. Raw identity never changes; nodes are the identity currency.
+-   DON'T expect `changes[].previous` / `changes[].new` in listener payloads to be managed nodes. Payload values are always raw; use `Retree.source(value)` to opt back in.
 -   DON'T rely on dependency reordering being silent. If `ReactiveNode.dependencies` or `@select` entries are added, removed, or reordered, Retree treats that as changed and emits when the owner is observed.
 -   DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
 -   DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
@@ -63,6 +70,10 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 -   `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
 -   `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use `Retree.select(node, selector, callback)` for an explicit root, or `Retree.select(() => value, callback)` for automatic dependency trapping. It is not a cache.
 -   `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+-   `Retree.raw`: Returns the raw, proxy-free object behind a node for native-speed, read-only access. Guaranteed proxy-free at any depth (raw purity); `structuredClone(Retree.raw(node))` is a valid point-in-time copy. `ReactiveNode` exposes `this.raw()`.
+-   `Retree.source`: Resolves a raw value back to its managed node (the inverse of `Retree.raw`). Returns `undefined` for values never materialized as nodes.
+-   `Retree.peekInto`: Runs a read-only query against a node's raw object and resolves the returned value to its managed node when one exists. `ReactiveNode` exposes `this.peekInto(fn)`.
+-   `Retree.untracked`: Pauses dependency tracking during a synchronous callback. Use it for bulk reads inside tracked selectors and memo getters. `ReactiveNode` exposes `this.untracked(fn)`.
 -   `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
 -   `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
 -   `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
@@ -77,13 +88,14 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 -   `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
 -   `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
 -   `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use `useSelect(node, selector)` for an explicit root, or `useSelect(() => value)` for automatic dependency trapping. Good for counts, totals, booleans, labels, and VM dependency arrays.
+-   `useRaw`: Subscribes like `useNode` (`nodeChanged` default) but returns `[raw, toSource]` for native-speed, proxy-free render reads. Use it for components that read wide (tables, canvas, serialization). Pass nodes to children via `toSource`, never raw values.
 -   `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
 -   `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
 -   `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.
 -   `ConvexPaginatedQueryNode`: Stores one live paginated Convex query and exposes `loadMore(...)`.
 -   `ConvexConnectionStateNode`: Stores the Convex client's connection state in Retree state.
 -   `createRetreeConvexAction` and `createRetreeConvexMutation`: Typed standalone Convex helpers for code that is not inside a `BaseConvexNode`.
--   `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow.
+-   `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow. They read raw and write through the managed state internally; custom reconcilers receive `rawCurrent` as a third argument (read `rawCurrent`, write `current`).
 -   `RetreeConvexReactClient`: Extends Convex's `ConvexReactClient` with the Retree Convex subscription methods used by `ConvexNode` query, paginated query, and connection-state helpers.
 
 ## Documentation
@@ -106,6 +118,7 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 -   [useNode](https://ryanbliss.github.io/retree/functions/_retreejs_react.useNode.html): React hook for subscribing to direct node changes with fine-grained re-rendering.
 -   [useTree](https://ryanbliss.github.io/retree/functions/_retreejs_react.useTree.html): React hook for subscribing to node and descendant-tree changes.
 -   [useRoot](https://ryanbliss.github.io/retree/functions/_retreejs_react.useRoot.html): React hook for creating and retaining a Retree root in a component.
+-   [useRaw](https://ryanbliss.github.io/retree/functions/_retreejs_react.useRaw.html): React hook returning `[raw, toSource]` for native-speed, proxy-free render reads with `useNode`-style invalidation.
 -   [@retreejs/convex API](https://ryanbliss.github.io/retree/modules/_retreejs_convex.html): Convex exports for `BaseConvexNode`, `ConvexNode`, `ConvexQueryNode`, `ConvexPaginatedQueryNode`, `ConvexConnectionStateNode`, action and mutation helpers, optimistic update contexts, and reconcilers.
 -   [BaseConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.BaseConvexNode.html): Base Retree node for classes that own a Convex client and need protected action, mutation, and one-off query helpers.
 -   [ConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexNode.html): Base class for Retree nodes that own a Convex client and create typed query, paginated query, action, mutation, query-once, and connection-state helpers.

--- a/skills/retree/references/llms.md
+++ b/skills/retree/references/llms.md
@@ -17,117 +17,117 @@ Read the full [Retree Docs Home](https://ryanbliss.github.io/retree/) or the [Re
 
 ### DO
 
-- DO create one Retree root at the state boundary with `Retree.root(...)` or React's `useRoot(...)`.
-- DO mutate Retree-managed objects directly (`node.title = "New"`, `list.push(item)`) instead of replacing whole app state objects.
-- DO subscribe as narrowly as possible: prefer `useNode(child)` or `Retree.on(child, "nodeChanged", ...)` for focused UI and hot paths.
-- DO use `useSelect(...)`, `Retree.select(...)`, or `@select` for ordered dependency lists. Reactive entries are subscribed to; primitive entries are compared. Use `useSelect(() => ...)`, `Retree.select(() => ..., callback)`, or `@select()` when a selector/getter should trap reads automatically. Whole node reads subscribe broadly; property reads subscribe to the owner and compare that property value.
-- DO pass `listenerType: "treeChanged"` to `useSelect(...)` / `Retree.select(...)` when the selector reads descendant nodes.
-- DO use `Retree.move(...)` or `node.moveTo(...)` when an existing node should move to a new structural parent.
-- DO use `Retree.link(...)` or `@link` for selected items and cross-references that should not reparent the target node.
-- DO use `Retree.clone(...)` when two places need independent copies of the same current data.
-- DO keep `ReactiveNode.dependencies` and `@select` arrays deterministic when possible. Length/order may change at runtime; Retree treats that as an invalidation and refreshes subscriptions.
-- DO return raw reactive nodes and primitives directly from `ReactiveNode.dependencies`; wrap a slot with `this.dependency(node, comparisons)` when you need custom comparison cells.
-- DO prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when selected items or selected order changes.
-- DO prefer bare `@memo` / `@fnMemo` for cached computed getters and deterministic methods; pass comparison functions only when you need finer cache-key control.
-- DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
-- DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
-- DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
-- DO dispose Convex query, paginated query, and connection-state nodes when their owner is torn down.
-- DO reconcile server list results by stable IDs (`reconcileConvexDocuments`, `reconcileArrayById`) so child node identity stays stable.
-- DO set the lowest-level value and/or primitive that changed.
+-   DO create one Retree root at the state boundary with `Retree.root(...)` or React's `useRoot(...)`.
+-   DO mutate Retree-managed objects directly (`node.title = "New"`, `list.push(item)`) instead of replacing whole app state objects.
+-   DO subscribe as narrowly as possible: prefer `useNode(child)` or `Retree.on(child, "nodeChanged", ...)` for focused UI and hot paths.
+-   DO use `useSelect(...)`, `Retree.select(...)`, or `@select` for ordered dependency lists. Reactive entries are subscribed to; primitive entries are compared. Use `useSelect(() => ...)`, `Retree.select(() => ..., callback)`, or `@select()` when a selector/getter should trap reads automatically. Whole node reads subscribe broadly; property reads subscribe to the owner and compare that property value.
+-   DO pass `listenerType: "treeChanged"` to `useSelect(...)` / `Retree.select(...)` when the selector reads descendant nodes.
+-   DO use `Retree.move(...)` or `node.moveTo(...)` when an existing node should move to a new structural parent.
+-   DO use `Retree.link(...)` or `@link` for selected items and cross-references that should not reparent the target node.
+-   DO use `Retree.clone(...)` when two places need independent copies of the same current data.
+-   DO keep `ReactiveNode.dependencies` and `@select` arrays deterministic when possible. Length/order may change at runtime; Retree treats that as an invalidation and refreshes subscriptions.
+-   DO return raw reactive nodes and primitives directly from `ReactiveNode.dependencies`; wrap a slot with `this.dependency(node, comparisons)` when you need custom comparison cells.
+-   DO prefer `@select` for hot filtered lists where one getter should listen to a broad collection but only emit when selected items or selected order changes.
+-   DO prefer bare `@memo` / `@fnMemo` for cached computed getters and deterministic methods; pass comparison functions only when you need finer cache-key control.
+-   DO use `@ignore` for caches, unsubscribe handles, framework objects, and other non-rendered state on a `ReactiveNode`.
+-   DO use `Retree.runTransaction(...)` for several synchronous writes that represent one logical update.
+-   DO use `Retree.runSilent(...)` for synchronous writes that should skip emitting change events.
+-   DO dispose Convex query, paginated query, and connection-state nodes when their owner is torn down.
+-   DO reconcile server list results by stable IDs (`reconcileConvexDocuments`, `reconcileArrayById`) so child node identity stays stable.
+-   DO set the lowest-level value and/or primitive that changed.
 
 ### DON'T
 
-- DON'T assign the same Retree-managed object into a second structural parent. Retree is a pure tree: a node can have one structural parent.
-- DON'T use `@ignore` as a reactive reference mechanism. Ignored fields skip Retree emissions; use `@link` or `Retree.link(...)` for reactive pointers.
-- DON'T expect `Retree.link(...)` / `@link` to make the linked target a child of the owner. Links point to a node owned elsewhere.
-- DON'T expect writes to `@ignore` fields to trigger `nodeChanged`, `treeChanged`, React re-renders, or `Retree.parent(...)` for nested plain objects.
-- DON'T use `useTree(...)` on broad app roots by default. It subscribes to descendant changes and can re-render too much.
-- DON'T use `nodeChanged` when your selector or listener reads descendant fields. Use `treeChanged` or subscribe to the narrower child node.
-- DON'T expect `useSelect(...)` or `Retree.select(...)` dependency lists to reproxy the node passed to the selector. They are observational; use `@select` when a `ReactiveNode` owner should emit.
-- DON'T pass selector-only `useSelect(() => ...)` or `Retree.select(() => ..., callback)` when you need a fixed root listener with `listenerType: "treeChanged"`. The selector-only forms trap Retree-managed reads and subscribe to those nodes automatically.
-- DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
-- DON'T rely on dependency reordering being silent. If `ReactiveNode.dependencies` or `@select` entries are added, removed, or reordered, Retree treats that as changed and emits when the owner is observed.
-- DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
-- DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
-- DON'T call `Retree.parent(...)`, `Retree.on(...)`, `Retree.move(...)`, `Retree.link(...)`, or `Retree.clone(...)` with plain unrooted objects.
-- DON'T expect Convex `action(...)`, `mutation(...)`, or `queryOnce(...)` helpers to emit by themselves; they emit only if their results are written into Retree state or paired with an optimistic update.
-- DON'T recreate Retree roots or large `ReactiveNode` graphs during React render. Create them once, or use `useRoot`, `useMemo`, or `useState` initialization.
-- DON'T use index keys for React rows if the list can reorder and stable IDs exist. Stable keys pair best with Retree's child-node identity model.
-- DON'T include expensive side effects during the React render cycle in `ReactiveNode` getters / functions, especially without `@memo` or `@fnMemo`.
-- DON'T recreate object trees with spread operators like you would in React (those sorts of hacks are "why" Retree exists in the first place).
+-   DON'T assign the same Retree-managed object into a second structural parent. Retree is a pure tree: a node can have one structural parent.
+-   DON'T use `@ignore` as a reactive reference mechanism. Ignored fields skip Retree emissions; use `@link` or `Retree.link(...)` for reactive pointers.
+-   DON'T expect `Retree.link(...)` / `@link` to make the linked target a child of the owner. Links point to a node owned elsewhere.
+-   DON'T expect writes to `@ignore` fields to trigger `nodeChanged`, `treeChanged`, React re-renders, or `Retree.parent(...)` for nested plain objects.
+-   DON'T use `useTree(...)` on broad app roots by default. It subscribes to descendant changes and can re-render too much.
+-   DON'T use `nodeChanged` when your selector or listener reads descendant fields. Use `treeChanged` or subscribe to the narrower child node.
+-   DON'T expect `useSelect(...)` or `Retree.select(...)` dependency lists to reproxy the node passed to the selector. They are observational; use `@select` when a `ReactiveNode` owner should emit.
+-   DON'T pass selector-only `useSelect(() => ...)` or `Retree.select(() => ..., callback)` when you need a fixed root listener with `listenerType: "treeChanged"`. The selector-only forms trap Retree-managed reads and subscribe to those nodes automatically.
+-   DON'T treat `memo`, `@memo`, or `@fnMemo` as subscriptions. They cache values only; they do not emit or re-render by themselves.
+-   DON'T rely on dependency reordering being silent. If `ReactiveNode.dependencies` or `@select` entries are added, removed, or reordered, Retree treats that as changed and emits when the owner is observed.
+-   DON'T start subscriptions, network work, or synchronization inside the `dependencies` getter. Use `onObserved()`, `onUnobserved()`, and `onChanged()`.
+-   DON'T manually delete a node from its old parent before calling `Retree.move(...)`; `move` finds the current parent and removes it safely.
+-   DON'T call `Retree.parent(...)`, `Retree.on(...)`, `Retree.move(...)`, `Retree.link(...)`, or `Retree.clone(...)` with plain unrooted objects.
+-   DON'T expect Convex `action(...)`, `mutation(...)`, or `queryOnce(...)` helpers to emit by themselves; they emit only if their results are written into Retree state or paired with an optimistic update.
+-   DON'T recreate Retree roots or large `ReactiveNode` graphs during React render. Create them once, or use `useRoot`, `useMemo`, or `useState` initialization.
+-   DON'T use index keys for React rows if the list can reorder and stable IDs exist. Stable keys pair best with Retree's child-node identity model.
+-   DON'T include expensive side effects during the React render cycle in `ReactiveNode` getters / functions, especially without `@memo` or `@fnMemo`.
+-   DON'T recreate object trees with spread operators like you would in React (those sorts of hacks are "why" Retree exists in the first place).
 
 ## Feature Glossary
 
-- `Retree.root`: Makes one object the root of a Retree-managed tree. Use it once where plain state enters Retree.
-- `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
-- `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use `Retree.select(node, selector, callback)` for an explicit root, or `Retree.select(() => value, callback)` for automatic dependency trapping. It is not a cache.
-- `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
-- `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
-- `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
-- `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
-- `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use `@select()` with no selector for MobX-style dependency trapping: whole Retree-managed values read by the getter subscribe broadly, property reads subscribe to the owner and compare that property value, and primitive values read by the getter compare. Pass `@select((self) => [...])` when you want explicit dependency slots. Pass `@select({ equals })` or `@select((self) => [...], { equals })` when the final getter output needs custom equality; `equals(self, previous, next)` returns true to skip owner reproxy/emission.
-- `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Dynamic dependency arrays are allowed; shape changes emit and refresh subscriptions.
-- `ReactiveNode.memo`, `@memo`, `@memo()`, `@fnMemo`, and `@fnMemo()`: Cache computed values. Prefer bare/empty decorator forms for automatic dependency trapping; pass comparison functions for finer cache-key control. They do not emit `nodeChanged` or trigger React renders by themselves.
-- `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
-- `Retree.runTransaction`: Batches synchronous writes into one listener flush per changed node.
-- `Retree.runSilent`: Performs writes without emitting listeners. Use it for non-rendered bookkeeping.
-- `ReactiveNode.prepareTree`: Warms lazy child proxies. Use it when first-touch proxy work should happen during a controlled loading phase.
-- `useRoot`: Creates one Retree root for a React component lifetime.
-- `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
-- `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
-- `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use `useSelect(node, selector)` for an explicit root, or `useSelect(() => value)` for automatic dependency trapping. Good for counts, totals, booleans, labels, and VM dependency arrays.
-- `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
-- `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
-- `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.
-- `ConvexPaginatedQueryNode`: Stores one live paginated Convex query and exposes `loadMore(...)`.
-- `ConvexConnectionStateNode`: Stores the Convex client's connection state in Retree state.
-- `createRetreeConvexAction` and `createRetreeConvexMutation`: Typed standalone Convex helpers for code that is not inside a `BaseConvexNode`.
-- `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow.
-- `RetreeConvexReactClient`: Extends Convex's `ConvexReactClient` with the Retree Convex subscription methods used by `ConvexNode` query, paginated query, and connection-state helpers.
+-   `Retree.root`: Makes one object the root of a Retree-managed tree. Use it once where plain state enters Retree.
+-   `Retree.on`: Subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
+-   `Retree.select`: Subscribes to a selected value or ordered dependency list. Reactive entries are subscribed to and primitive entries are compared. Use `Retree.select(node, selector, callback)` for an explicit root, or `Retree.select(() => value, callback)` for automatic dependency trapping. It is not a cache.
+-   `Retree.parent`: Returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+-   `Retree.move`: Transfers an existing node to a new structural parent. Use it when ownership should change.
+-   `Retree.link` and `@link`: Store a reactive pointer without reparenting the target. Use them for selected items and cross-references.
+-   `Retree.clone`: Creates a detached copy. Use it when two places need independent state.
+-   `@select`: Decorates a `ReactiveNode` getter with an ordered dependency list. Use `@select()` with no selector for MobX-style dependency trapping: whole Retree-managed values read by the getter subscribe broadly, property reads subscribe to the owner and compare that property value, and primitive values read by the getter compare. Pass `@select((self) => [...])` when you want explicit dependency slots. Pass `@select({ equals })` or `@select((self) => [...], { equals })` when the final getter output needs custom equality; `equals(self, previous, next)` returns true to skip owner reproxy/emission.
+-   `ReactiveNode.dependencies`: Makes one node emit when another node changes. Return raw reactive nodes/primitives directly, or use `this.dependency(node, comparisons)` for custom comparison cells. Dynamic dependency arrays are allowed; shape changes emit and refresh subscriptions.
+-   `ReactiveNode.memo`, `@memo`, `@memo()`, `@fnMemo`, and `@fnMemo()`: Cache computed values. Prefer bare/empty decorator forms for automatic dependency trapping; pass comparison functions for finer cache-key control. They do not emit `nodeChanged` or trigger React renders by themselves.
+-   `@ignore`: Keeps a `ReactiveNode` field out of Retree emissions. Use it for caches, framework handles, subscriptions, and non-rendered state.
+-   `Retree.runTransaction`: Batches synchronous writes into one listener flush per changed node.
+-   `Retree.runSilent`: Performs writes without emitting listeners. Use it for non-rendered bookkeeping.
+-   `ReactiveNode.prepareTree`: Warms lazy child proxies. Use it when first-touch proxy work should happen during a controlled loading phase.
+-   `useRoot`: Creates one Retree root for a React component lifetime.
+-   `useNode`: Re-renders for direct `nodeChanged` events on one node. Use it for focused components and child rows.
+-   `useTree`: Re-renders for `treeChanged` events from a node or descendants. Use it sparingly for small subtrees.
+-   `useSelect`: Re-renders only when a selected value or ordered dependency list changes. Use `useSelect(node, selector)` for an explicit root, or `useSelect(() => value)` for automatic dependency trapping. Good for counts, totals, booleans, labels, and VM dependency arrays.
+-   `ConvexNode`: Full Convex base class for Retree app state with query, paginated query, action, mutation, query-once, and connection-state helpers.
+-   `BaseConvexNode`: Smaller Convex base class for action, mutation, and one-off query helpers.
+-   `ConvexQueryNode`: Stores one live Convex query in Retree state and emits when query state/result/error changes.
+-   `ConvexPaginatedQueryNode`: Stores one live paginated Convex query and exposes `loadMore(...)`.
+-   `ConvexConnectionStateNode`: Stores the Convex client's connection state in Retree state.
+-   `createRetreeConvexAction` and `createRetreeConvexMutation`: Typed standalone Convex helpers for code that is not inside a `BaseConvexNode`.
+-   `reconcileConvexDocuments` and `reconcileArrayById`: Preserve list item object identity across server results so child `useNode(item)` subscriptions stay narrow.
+-   `RetreeConvexReactClient`: Extends Convex's `ConvexReactClient` with the Retree Convex subscription methods used by `ConvexNode` query, paginated query, and connection-state helpers.
 
 ## Documentation
 
-- [Retree Docs Home](https://ryanbliss.github.io/retree/): Generated TypeDoc site with package navigation, README content, and API reference.
-- [Repository README](https://github.com/ryanbliss/retree#readme): Installation, quick-start examples, React usage, core usage, and sample links.
-- [@retreejs/core README](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#readme): Core package guide for object-tree reactivity, events, `ReactiveNode`, memoization, and decorators.
-- [@retreejs/react README](https://github.com/ryanbliss/retree/tree/main/packages/retree-react#readme): React package guide for `useNode`, `useTree`, `useRoot`, and rendering behavior.
-- [@retreejs/convex README](https://github.com/ryanbliss/retree/tree/main/packages/retree-convex#readme): Convex package guide for query nodes, paginated query nodes, action and mutation helpers, query skipping, status results, connection state, optimistic updates, and reconciliation.
-- [@retreejs/react-convex README](https://github.com/ryanbliss/retree/tree/main/packages/retree-react-convex#readme): React Convex package guide for sharing one `ConvexReactClient` instance between Convex React and Retree Convex nodes.
+-   [Retree Docs Home](https://ryanbliss.github.io/retree/): Generated TypeDoc site with package navigation, README content, and API reference.
+-   [Repository README](https://github.com/ryanbliss/retree#readme): Installation, quick-start examples, React usage, core usage, and sample links.
+-   [@retreejs/core README](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#readme): Core package guide for object-tree reactivity, events, `ReactiveNode`, memoization, and decorators.
+-   [@retreejs/react README](https://github.com/ryanbliss/retree/tree/main/packages/retree-react#readme): React package guide for `useNode`, `useTree`, `useRoot`, and rendering behavior.
+-   [@retreejs/convex README](https://github.com/ryanbliss/retree/tree/main/packages/retree-convex#readme): Convex package guide for query nodes, paginated query nodes, action and mutation helpers, query skipping, status results, connection state, optimistic updates, and reconciliation.
+-   [@retreejs/react-convex README](https://github.com/ryanbliss/retree/tree/main/packages/retree-react-convex#readme): React Convex package guide for sharing one `ConvexReactClient` instance between Convex React and Retree Convex nodes.
 
 ## API Reference
 
-- [@retreejs/core API](https://ryanbliss.github.io/retree/modules/_retreejs_core.html): Core exports including `Retree`, `ReactiveNode`, event types, decorators, and memo helpers.
-- [Retree class](https://ryanbliss.github.io/retree/classes/_retreejs_core.Retree.html): Static APIs for creating roots, subscribing to changes, finding parents, and batching/silencing updates.
-- [ReactiveNode class](https://ryanbliss.github.io/retree/classes/_retreejs_core.ReactiveNode.html): Base class for derived dependencies, dependency comparison, and memoized computed values.
-- [Core README ownership section](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#move-link-or-clone-existing-nodes): Examples for `Retree.move`, `Retree.link`, `@link`, `ReactiveNode.moveTo`, and `Retree.clone`.
-- [Core README select section](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#select-derived-values): Examples for `Retree.select`, including when to use `listenerType: "treeChanged"`.
-- [@retreejs/react API](https://ryanbliss.github.io/retree/modules/_retreejs_react.html): React exports for stateful Retree nodes and trees.
-- [useNode](https://ryanbliss.github.io/retree/functions/_retreejs_react.useNode.html): React hook for subscribing to direct node changes with fine-grained re-rendering.
-- [useTree](https://ryanbliss.github.io/retree/functions/_retreejs_react.useTree.html): React hook for subscribing to node and descendant-tree changes.
-- [useRoot](https://ryanbliss.github.io/retree/functions/_retreejs_react.useRoot.html): React hook for creating and retaining a Retree root in a component.
-- [@retreejs/convex API](https://ryanbliss.github.io/retree/modules/_retreejs_convex.html): Convex exports for `BaseConvexNode`, `ConvexNode`, `ConvexQueryNode`, `ConvexPaginatedQueryNode`, `ConvexConnectionStateNode`, action and mutation helpers, optimistic update contexts, and reconcilers.
-- [BaseConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.BaseConvexNode.html): Base Retree node for classes that own a Convex client and need protected action, mutation, and one-off query helpers.
-- [ConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexNode.html): Base class for Retree nodes that own a Convex client and create typed query, paginated query, action, mutation, query-once, and connection-state helpers.
-- [ConvexQueryNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexQueryNode.html): Reactive query node that subscribes to Convex query updates and exposes `state`, structured `result`, `updateArgs(...)`, skipping, errors, and optimistic updates.
-- [ConvexPaginatedQueryNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexPaginatedQueryNode.html): Reactive paginated query node with aggregate page state and `loadMore(...)`.
-- [ConvexConnectionStateNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexConnectionStateNode.html): Reactive node for Convex client connection state.
-- [@retreejs/react-convex API](https://ryanbliss.github.io/retree/modules/_retreejs_react_convex.html): React Convex adapter exports including `RetreeConvexReactClient`.
+-   [@retreejs/core API](https://ryanbliss.github.io/retree/modules/_retreejs_core.html): Core exports including `Retree`, `ReactiveNode`, event types, decorators, and memo helpers.
+-   [Retree class](https://ryanbliss.github.io/retree/classes/_retreejs_core.Retree.html): Static APIs for creating roots, subscribing to changes, finding parents, and batching/silencing updates.
+-   [ReactiveNode class](https://ryanbliss.github.io/retree/classes/_retreejs_core.ReactiveNode.html): Base class for derived dependencies, dependency comparison, and memoized computed values.
+-   [Core README ownership section](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#move-link-or-clone-existing-nodes): Examples for `Retree.move`, `Retree.link`, `@link`, `ReactiveNode.moveTo`, and `Retree.clone`.
+-   [Core README select section](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#select-derived-values): Examples for `Retree.select`, including when to use `listenerType: "treeChanged"`.
+-   [@retreejs/react API](https://ryanbliss.github.io/retree/modules/_retreejs_react.html): React exports for stateful Retree nodes and trees.
+-   [useNode](https://ryanbliss.github.io/retree/functions/_retreejs_react.useNode.html): React hook for subscribing to direct node changes with fine-grained re-rendering.
+-   [useTree](https://ryanbliss.github.io/retree/functions/_retreejs_react.useTree.html): React hook for subscribing to node and descendant-tree changes.
+-   [useRoot](https://ryanbliss.github.io/retree/functions/_retreejs_react.useRoot.html): React hook for creating and retaining a Retree root in a component.
+-   [@retreejs/convex API](https://ryanbliss.github.io/retree/modules/_retreejs_convex.html): Convex exports for `BaseConvexNode`, `ConvexNode`, `ConvexQueryNode`, `ConvexPaginatedQueryNode`, `ConvexConnectionStateNode`, action and mutation helpers, optimistic update contexts, and reconcilers.
+-   [BaseConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.BaseConvexNode.html): Base Retree node for classes that own a Convex client and need protected action, mutation, and one-off query helpers.
+-   [ConvexNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexNode.html): Base class for Retree nodes that own a Convex client and create typed query, paginated query, action, mutation, query-once, and connection-state helpers.
+-   [ConvexQueryNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexQueryNode.html): Reactive query node that subscribes to Convex query updates and exposes `state`, structured `result`, `updateArgs(...)`, skipping, errors, and optimistic updates.
+-   [ConvexPaginatedQueryNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexPaginatedQueryNode.html): Reactive paginated query node with aggregate page state and `loadMore(...)`.
+-   [ConvexConnectionStateNode class](https://ryanbliss.github.io/retree/classes/_retreejs_convex.ConvexConnectionStateNode.html): Reactive node for Convex client connection state.
+-   [@retreejs/react-convex API](https://ryanbliss.github.io/retree/modules/_retreejs_react_convex.html): React Convex adapter exports including `RetreeConvexReactClient`.
 
 ## Samples
 
-- [Core example](https://github.com/ryanbliss/retree/tree/main/samples/01.core-example): Minimal non-React Retree sample.
-- [React example](https://github.com/ryanbliss/retree/tree/main/samples/02.react-example): React sample app using Retree state.
-- [React recursion example](https://github.com/ryanbliss/retree/tree/main/samples/03.react-recursion): Recursive React tree sample using Retree.
+-   [Core example](https://github.com/ryanbliss/retree/tree/main/samples/01.core-example): Minimal non-React Retree sample.
+-   [React example](https://github.com/ryanbliss/retree/tree/main/samples/02.react-example): React sample app using Retree state.
+-   [React recursion example](https://github.com/ryanbliss/retree/tree/main/samples/03.react-recursion): Recursive React tree sample using Retree.
 
 ## Packages
 
-- [@retreejs/core on npm](https://www.npmjs.com/package/@retreejs/core): Core state-management package.
-- [@retreejs/react on npm](https://www.npmjs.com/package/@retreejs/react): React hooks package.
-- [@retreejs/convex on npm](https://www.npmjs.com/package/@retreejs/convex): Convex query and mutation bindings package.
-- [@retreejs/react-convex on npm](https://www.npmjs.com/package/@retreejs/react-convex): Convex React client adapter for Retree Convex nodes.
+-   [@retreejs/core on npm](https://www.npmjs.com/package/@retreejs/core): Core state-management package.
+-   [@retreejs/react on npm](https://www.npmjs.com/package/@retreejs/react): React hooks package.
+-   [@retreejs/convex on npm](https://www.npmjs.com/package/@retreejs/convex): Convex query and mutation bindings package.
+-   [@retreejs/react-convex on npm](https://www.npmjs.com/package/@retreejs/react-convex): Convex React client adapter for Retree Convex nodes.
 
 ## Optional
 
-- [GitHub repository](https://github.com/ryanbliss/retree): Source code, issues, package workspace, and samples.
-- [Fluid Framework SharedTree](https://fluidframework.com/docs/data-structures/tree/): Related inspiration mentioned in the Retree docs.
+-   [GitHub repository](https://github.com/ryanbliss/retree): Source code, issues, package workspace, and samples.
+-   [Fluid Framework SharedTree](https://fluidframework.com/docs/data-structures/tree/): Related inspiration mentioned in the Retree docs.

--- a/skills/retree/references/react.md
+++ b/skills/retree/references/react.md
@@ -29,6 +29,7 @@ yarn add @retreejs/core @retreejs/react
 -   [`useNode`](#usenode-hook) subscribes to direct `nodeChanged` events. Use it for focused components that own one node.
 -   [`useTree`](#usetree-hook) subscribes to `treeChanged` events from a node and descendants. Use it for small subtrees that should re-render together.
 -   [`useSelect`](#useselect-hook) subscribes to a selected value or ordered dependency list and re-renders only when it changes. Use it for counts, totals, booleans, labels, and other narrow projections.
+-   [`useRaw`](#useraw-hook) subscribes like `useNode` but returns `[raw, toSource]` for native-speed, proxy-free reads. Use it for components that read wide during render.
 -   [`@select`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#reactive-dependencies) decorates a getter with an ordered dependency list. Use it when VM logic should stay in the `ReactiveNode` while `useNode(node)` stays selective.
 -   [`ReactiveNode.dependencies`](#reactivenode) can make a node emit `nodeChanged` from narrow dependencies. Return raw reactive nodes/primitives directly, or wrap one slot with `this.dependency(node, comparisons)`.
 -   [`memo`, `@memo`, and `@fnMemo`](https://github.com/ryanbliss/retree/tree/main/packages/retree-core#memoize-computed-getters) cache expensive computed values. They do not trigger renders by themselves.
@@ -391,6 +392,51 @@ greatGrandparent1.grandparent_1.name = "Beth";
 While `useTree` is powerful and can make things a lot easier, it is important to ensure its usage doesn't have negative performance. As your component tree gets more complicated, you should take care to only `useTree` sparingly (e.g., lower down in your view tree hierarchy).
 
 **Tip:** Always use React Dev Tools' profile tab to measure render performance when using `useTree`.
+
+### useRaw hook
+
+Use `useRaw` when a component reads wide during render — big tables, canvas
+layers, subtree serialization — and per-property proxy reads show up in
+profiles. It subscribes exactly like `useNode` (`nodeChanged` by default) but
+returns `[raw, toSource]`: the live raw object for native-speed reads plus a
+resolver back to managed nodes.
+
+```tsx
+import React from "react";
+import { useNode, useRaw } from "@retreejs/react";
+
+function TaskListView({ list }: { list: TaskList }) {
+    // Re-renders only when the array itself changes: add / remove / reorder.
+    const [tasksRaw, toSource] = useRaw(list.tasks);
+    return (
+        <ul>
+            {tasksRaw.map((rawTask) => (
+                <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+            ))}
+        </ul>
+    );
+}
+
+const TaskRow = React.memo(function TaskRow({ task }: { task: Task }) {
+    const t = useNode(task); // node prop: own subscription, write surface
+    return <li onClick={() => (t.isComplete = !t.isComplete)}>{t.title}</li>;
+});
+```
+
+-   The prop passed to children is the **node** (`toSource(rawTask)`), never
+    the raw value. Nodes carry subscriptions, writes, navigation, and
+    identity; raw is a local read view.
+-   `toSource` always resolves direct children of the subscribed node —
+    object/array children, Map values, and Set members — materializing them
+    on demand.
+-   Invalidation matches `useNode`: deep changes re-render only when declared
+    — via the node's `dependencies` / `@select`, via `useSelect` for derived
+    views, or via the `listenerType: "treeChanged"` opt-in. Raw is live, so
+    any render (including parent-triggered ones) reads current state.
+-   Do not filter or aggregate raw content inline when membership must stay
+    in lockstep with deep fields — that is derived state; use `useSelect`.
+-   Never write to raw values, and never use raw references as `React.memo`
+    props or `useMemo` deps.
 
 ## React performance guide
 

--- a/skills/retree/references/repository.md
+++ b/skills/retree/references/repository.md
@@ -45,6 +45,11 @@ npx skills use ryanbliss/retree@retree
 -   [`Retree.on`](#core-api-examples) subscribes to `nodeChanged`, `treeChanged`, or `nodeRemoved`. Use it outside React and inside integrations.
 -   [`Retree.select`](#core-api-examples) is the non-React version of `useSelect`. Use it to narrow notifications; it is not a cache.
 -   [`Retree.parent`](#core-api-examples) returns the structural parent of a node. Use it for tree-local operations like deleting yourself from a list.
+-   [`Retree.raw`](#core-api-examples) returns the raw, proxy-free object behind a node for native-speed, read-only access. Raw subtrees are guaranteed proxy-free.
+-   [`Retree.source`](#core-api-examples) resolves a raw value back to its managed node — the inverse of `Retree.raw`.
+-   [`Retree.peekInto`](#core-api-examples) runs a read-only query against a node's raw object and resolves the result to its managed node when one exists.
+-   [`Retree.untracked`](#core-api-examples) pauses dependency tracking during a synchronous callback, for bulk reads inside tracked selectors and memo getters.
+-   [`useRaw`](#useraw-hook) subscribes like `useNode` but returns `[raw, toSource]` for native-speed, proxy-free render reads. Use it for components that read wide.
 -   [`Retree.move`](#core-api-examples) transfers an existing node to a new structural parent. Use it when ownership should change.
 -   [`Retree.link` and `@link`](#core-api-examples) store a reactive pointer without reparenting. Use them for selected items and cross-references.
 -   [`Retree.clone`](#core-api-examples) makes a detached copy. Use it when two places need independent state.
@@ -275,6 +280,43 @@ const [, , attribute] = useSelect(row, (self) => [
 Dependency-list subscriptions in `useSelect` are observational: selected dependency changes can re-render the component, but they do not force the node passed to `useSelect` to receive a fresh reproxy. Use `@select` when a `ReactiveNode` owner should emit `nodeChanged`.
 
 `useSelect` is a subscription primitive, not a memo cache. Use `memo`, `@memo`, or `@fnMemo` for expensive computation you want to cache, then select the cached value when you want narrower renders.
+
+#### useRaw hook
+
+Use `useRaw` when a component reads wide during render — big tables, canvas
+layers, subtree serialization. It subscribes exactly like `useNode`
+(`nodeChanged` by default) but returns `[raw, toSource]`: the live raw object
+for native-speed, proxy-free reads plus a resolver back to managed nodes.
+
+```tsx
+import React from "react";
+import { useNode, useRaw } from "@retreejs/react";
+
+function TaskListView({ list }: { list: TaskList }) {
+    // Re-renders only when the array itself changes: add / remove / reorder.
+    const [tasksRaw, toSource] = useRaw(list.tasks);
+    return (
+        <ul>
+            {tasksRaw.map((rawTask) => (
+                <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+            ))}
+        </ul>
+    );
+}
+
+const TaskRow = React.memo(function TaskRow({ task }: { task: Task }) {
+    const t = useNode(task); // node prop: own subscription, write surface
+    return <li onClick={() => (t.isComplete = !t.isComplete)}>{t.title}</li>;
+});
+```
+
+Pass **nodes** to children via `toSource`, never raw values — nodes carry
+subscriptions, writes, and identity; raw is a local read view. `toSource`
+always resolves direct children of the subscribed node (object/array
+children, Map values, Set members). Deep changes re-render only when declared
+— via the node's `dependencies` / `@select`, via `useSelect` for derived
+views, or via the `treeChanged` opt-in. Never write to raw values or use raw
+references as `React.memo` props or `useMemo` deps.
 
 #### useTree hook
 
@@ -990,6 +1032,28 @@ class ProjectState extends ReactiveNode {
 const root = Retree.root(new ProjectState());
 root.prepareTree({ depth: 1 });
 ```
+
+Use `Retree.raw` for native-speed, read-only scans; `Retree.source` to
+resolve raw values back to managed nodes; `Retree.peekInto` to query raw and
+get the managed result in one call; and `Retree.untracked` to pause
+dependency tracking during bulk reads:
+
+```ts
+const rawTasks = Retree.raw(tree.todos); // ✅ proxy-free, native-speed reads
+const found = Retree.peekInto(tree.todos, (raw) =>
+    raw.find((todo) => todo.id === id)
+);
+found?.toggle(); // ✅ peekInto resolved the managed node
+
+const managed = Retree.source(rawTasks[0]); // raw → managed node
+```
+
+Raw subtrees are guaranteed proxy-free under every write path (raw purity),
+so `structuredClone(Retree.raw(node))` is a valid point-in-time copy. Treat
+raw values as read-only, never use raw references as memo/equality tokens,
+and note that change payloads (`INodeFieldChanges.previous` / `.new`) are
+always raw values — `Retree.source(change.previous)` opts back into the
+managed node.
 
 ### Core samples
 

--- a/specs/retree-raw.md
+++ b/specs/retree-raw.md
@@ -1,0 +1,396 @@
+# Spec: Raw purity and `useRaw`
+
+Status: **implemented** (2026-07-10), including resolved decision §9.1 (raw
+change payloads). Measured results are recorded in §6; the purity invariant
+is enforced by `packages/retree-core/src/raw-purity.spec.ts` and the `useRaw`
+contract by `packages/retree-react/src/useRaw.spec.tsx`.
+Supersedes the earlier `Retree.snapshot` draft in this file: there is **no
+snapshot concept** in this design. `Retree.raw` is the one native-speed read
+view, `useRaw` is its React hook, and the prerequisite making both honest is
+**raw purity** — the guarantee that raw storage never contains proxies.
+
+Context: `benchmarks/findings-jul-10-2026.md` (both passes). Measured claims
+reference the probe in `packages/retree-core/src/perf-probe.spec.ts` and the
+esbuild bundle harness described in the findings doc.
+
+## 1. Problem
+
+### 1.1 Wide reads pay trap dispatch
+
+Components that read _wide_ during render (virtualized tables, canvas layers,
+subtree serialization) pay a proxy trap per property read: a 10k-item scan
+measures ~5.4 ms through proxies vs ~0.25 ms via `Retree.raw`. `raw` and
+`peekInto` cover imperative/algorithmic reads; React rendering has no
+equivalent — `useNode`/`useTree` reads are all trapped.
+
+### 1.2 Raw storage is not actually pure today
+
+`Retree.raw`'s promise is "plain data, native reads." Today that holds for
+trees built from plain data and mutated in place, but four long-standing
+write paths store **proxies inside raw storage** (verified on `a02ebd8`,
+predating the 2026-07 perf passes):
+
+| Path                                                                                                           | Raw storage holds a proxy?   |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `list.push({ plain })` / `obj.child = { plain }` (lazy path)                                                   | no                           |
+| assigning an **already-managed node** (reparent), `Retree.move`                                                | **yes**                      |
+| `map.get(k)` / Set iteration materializing an object **value**                                                 | **yes** (write-back on read) |
+| assigning a **fresh non-plain value** post-construction (`Map`, `Set`, `Date`, class instance, `ReactiveNode`) | **yes**                      |
+
+(Construction-time non-plain children stay raw; only the post-construction
+set/defineProperty paths and collection read write-backs are impure.)
+
+Consequences: `raw`/`peekInto` performance is probabilistic — consumers must
+guess or check whether any given value is a proxy; `cloneValue` must unwrap
+at every level; `findSetStoredValue` needs a linear scan; and
+`structuredClone(Retree.raw(n))` can throw on a proxy value.
+
+Why Map/Set differ from objects: the handler's children cache is a
+`Record<string | symbol>` keyed by property names. Map keys are arbitrary
+values and Set members are identity-keyed, so the original implementation
+reused the raw collection itself as the proxy cache. A storage convenience,
+not a semantic necessity — same for the eager set-trap branch writing built
+proxies into targets.
+
+## 2. Design principles
+
+1. **Nodes are the currency; raw is the local read view.** Raw values are
+   never the prop-passing medium between subscribed components. A component
+   with behavior receives the node (read + write + navigate at any depth);
+   raw is what a component reads _inside_ its own render or algorithm.
+2. **One read concept, not two.** No snapshots, no clones, no frozen copies:
+   `raw` is the live underlying data, read-only by contract. Developers grok
+   exactly one thing: proxies are for writing and subscribing; raw is for
+   reading fast. Point-in-time copies remain `Retree.clone`'s job — and with
+   purity, `structuredClone(Retree.raw(n))` becomes a valid cheap alternative
+   for workers/serialization.
+3. **Purity is an invariant, not a caveat.** Proxies are reachable only
+   _through_ proxies. `Retree.raw(node)` returns a subtree containing zero
+   proxies, under every write path, guaranteed by tests. This is what makes
+   the performance promise of `raw`/`peekInto`/`useRaw` unconditional.
+4. **Invalidation stays explicit and narrow; freshness is per-render.**
+   `useRaw` follows the same contract as `useNode`: subscription is
+   `nodeChanged` by default — a component re-renders only when data it
+   explicitly subscribed to changes, never because an irrelevant part of the
+   tree moved. Raw content is live, so any render reads current state.
+   Between renders, rendered output may be stale for undeclared deep data —
+   the deliberate, explicit trade; `useSelect` / `@select` / `dependencies` /
+   `useTree` are the tools for declaring deep invalidation.
+5. **Zero migration.** `useNode`/`useTree`/`useSelect`/`Retree.raw`/
+   `peekInto` keep their APIs. Raw purity is a storage-representation change
+   with no public API change; `useRaw` is additive.
+
+## 3. Priority 1: raw purity
+
+### 3.1 Storage convention
+
+Raw targets and raw collections hold **raw values only**. Proxies live
+exclusively in handler-owned caches.
+
+-   **Objects/arrays** (set trap and `defineProperty`): always write the raw
+    node into the target (`getUnproxiedNode(valueToSet)`); store the proxy only
+    in the children cache. The lazy plain path already does this; the reparent
+    and eager (non-plain value) branches change.
+-   **Map**: add a handler-owned side cache `Map<mapKey, childProxy>`.
+    `getOrCreateMapValueProxy` consults/populates the side cache and **stops
+    writing proxies back into the raw map**. Mutating wrappers (`set`,
+    `delete`, `clear`) keep raw values in the raw map and maintain the side
+    cache. Map keys are never proxied (unchanged).
+-   **Set**: side cache `Map<rawValue, childProxy>`; the raw set holds raw
+    values. `findSetStoredValue`'s linear scan collapses to
+    unwrap-then-`Set.prototype.has`.
+-   Side caches follow the children-cache lifecycle (lazy allocation, entries
+    dropped on delete/clear/removal), mirroring `deleteProxiedChild`.
+
+### 3.2 The invariant and its tests
+
+After **any** sequence of: plain writes, reparenting assignments,
+`Retree.move`, `Retree.link` targets, Map/Set reads and iteration, post-
+construction assignment of `Map`/`Set`/`Date`/class/`ReactiveNode` values,
+deletes, and `defineProperty` — walking `Retree.raw(root)` (including into
+raw Maps/Sets) finds **zero** values with proxy metadata
+(`getCustomProxyHandler(value) === undefined` for every reachable value).
+
+Plus behavior-preservation tests: reads through proxies still return managed
+children; reproxy identity semantics unchanged; `Retree.parent`/`move`/
+`clone` unchanged; `structuredClone(Retree.raw(n))` succeeds on a tree
+containing reparented children and read Maps.
+
+### 3.3 Direct-target reader audit (known ripple points)
+
+-   `deleteProperty` / change payloads: `previous` values for reparented/eager
+    children become **raw nodes instead of proxies** in `INodeFieldChanges`,
+    and `new` is unwrapped at capture. Approved contract per §9.1: payload
+    values are consistently raw; payload docs updated.
+-   `getLatestLinkedValue` / linked-key reads already normalize raw values via
+    `getManagedProxyForUnproxiedNode` — unchanged.
+-   `handleNodeRemoved` reads via the base proxy (cache hit) — unchanged.
+-   `@retreejs/convex` `reconcile` and query-node internals: audited for
+    direct-target reads that assume managed values.
+-   `cloneValue`'s per-level unwrap becomes redundant but stays (cheap,
+    defensive).
+
+### 3.4 Performance gates
+
+Purity must be ~free: one metadata read per reparent/eager write; side-cache
+allocation only for collections with object values (replacing today's
+write-back sets). Gates: existing probe suite and bundle harness within
+noise; Map/Set-heavy specs unchanged; `findSetStoredValue` micro-case equal
+or faster.
+
+## 4. Priority 2: `useRaw` (`@retreejs/react`)
+
+### 4.1 API
+
+```ts
+function useRaw<TNode extends TreeNode>(
+    node: TNode | NodeFactory<TNode>,
+    options?: { listenerType?: TRetreeChangedEvents }
+): [TNode, ToSource];
+
+type ToSource = <T extends TreeNode>(rawValue: T) => T | undefined;
+```
+
+-   Returns a **tuple** `[raw, toSource]`.
+-   `raw` is `Retree.raw(node)` — the live raw subtree, zero-copy, native
+    reads, guaranteed proxy-free by §3. Read-only by contract (writes go
+    through nodes; writing raw skips emission and is the documented
+    corruption hazard).
+-   **Default subscription is `"nodeChanged"`, exactly like `useNode`**
+    (principle 4). `listenerType: "treeChanged"` is an explicit opt-in.
+    Implementation mirrors `useNode`'s listener + state-bump (raw's stable
+    identity cannot satisfy `useSyncExternalStore`'s changed-value contract,
+    and doesn't need to).
+-   **Freshness:** raw is live, so any render — own-node change, new node
+    prop, unrelated parent re-render — reads current state. Between renders,
+    undeclared deep data may be stale in rendered output; same contract as
+    `useNode`. Tearing exposure under concurrent rendering is the same as
+    `useNode` today (live reads during render).
+
+### 4.2 `Retree.source` and `toSource`
+
+```ts
+static source<TNode extends TreeNode>(rawValue: TNode): TNode | undefined;
+```
+
+`Retree.source` is **public API** (resolved): it resolves a raw value back to
+its managed node — the latest managed proxy, the same resolution `peekInto`
+uses for return values. O(1); returns `undefined` when the value has never
+been materialized or is not Retree data (a miss is a normal query outcome,
+not an error).
+
+`toSource` (from the hook) is `Retree.source` plus a materialization
+guarantee scoped to the subscribed node:
+
+-   **Guarantee for the canonical pattern (resolved: applies to collections
+    too):** direct children of the hook's subscribed node always resolve —
+    object/array children, **Map values, and Set members** alike. On a lookup
+    miss, the hook materializes the subscribed node's direct children once
+    (memoized per version of the node) and retries — so mapping `raw`
+    children and calling `toSource` per item never returns `undefined` for
+    them, even for never-touched children.
+-   Deeper raw values resolve iff they have been materialized; in the intended
+    composition they belong to child components' own hooks, which materialize
+    them by receiving the node prop.
+
+### 4.3 Canonical usage
+
+```tsx
+function TaskListView({ list }: { list: TaskList }) {
+    // Re-renders only when the array itself changes: add / remove / reorder.
+    const [tasksRaw, toSource] = useRaw(list.tasks);
+    return (
+        <ul>
+            {tasksRaw.map((rawTask) => (
+                <TaskRow key={rawTask.id} task={toSource(rawTask)!} />
+            ))}
+        </ul>
+    );
+}
+
+const TaskRow = React.memo(function TaskRow({ task }: { task: Task }) {
+    const t = useNode(task); // node prop: own subscription, write surface
+    return <li onClick={() => (t.isComplete = !t.isComplete)}>{t.title}</li>;
+});
+```
+
+Granularity: the list re-renders on structural changes only; rows re-render
+on their own content via their own subscription; memo'd rows bail because
+`toSource` returns stable node references. A task's `isComplete` flip
+re-renders that row and nothing else.
+
+### 4.4 Opting in to deep invalidation
+
+Deep changes _can_ invalidate a `useRaw` consumer — deliberately, with the
+same tools as everywhere else in Retree, in preferred order:
+
+1. **Declare it on the node (idiomatic).** A `ReactiveNode` owner with
+   `dependencies` / `@select` emits `nodeChanged` _for itself_ when declared
+   deep dependencies change — plain default `useRaw(node)` re-renders, no
+   option needed. The invalidation contract lives on the node, visible to
+   every consumer:
+
+    ```ts
+    class TaskList extends ReactiveNode {
+        public tasks: Task[] = [];
+
+        @select()
+        get incompleteIds() {
+            return this.tasks.filter((t) => !t.isComplete).map((t) => t.id);
+        }
+
+        get dependencies() {
+            return [];
+        }
+    }
+    ```
+
+2. **Select the derived view.** `useSelect` for membership/order/aggregates;
+   raw reads for the rows. Select decides _which_ nodes, raw decides _how to
+   read_ them.
+3. **`listenerType: "treeChanged"`** — the blunt instrument.
+
+Deliberate consequence, documented loudly: filtering or aggregating raw
+content inline under the `nodeChanged` default renders stale membership until
+the node itself emits or the component re-renders for another reason. That is
+explicit invalidation working as designed.
+
+### 4.5 Convex reconciler integration (resolved)
+
+`ConvexQueryNode.restoreState` invokes reconcilers as
+`this.reconciler.reconcile(this.state, next)` — and because methods run with
+`this` bound to the base proxy, `current` arrives as the **managed proxy**.
+That is half-right by design: reconcilers _write_ in place through the proxy
+(that is what emits `nodeChanged` on changed rows and keeps item identity
+stable for `useNode` rows), but today they also _read_ through it — and
+reconciliation is read-dominated (compare every field of every item; write
+only the diffs).
+
+Split the two:
+
+1. **Built-in reconcilers read raw, write proxied** (`reconcileArray`,
+   `reconcileObject`, `tryReconcileConvexDocuments`, and the id-map built
+   from `item[idKey]`): comparisons run against `Retree.raw(current)` at
+   native speed; assignments go through `current` so emission and identity
+   semantics are untouched. Zero API change; covers the default path and
+   `reconcileArrayById`/`reconcileConvexDocuments` users.
+2. **Dev-provided reconcilers get raw handed to them** via a
+   backward-compatible third parameter:
+
+    ```ts
+    interface IStateReconciler<TState> {
+        reconcile(
+            current: TState | undefined,
+            next: TState,
+            rawCurrent?: TState // Retree.raw(current); undefined on first load
+        ): TState;
+    }
+    ```
+
+    Existing two-parameter implementations keep working. The documented
+    contract is "**read `rawCurrent`, write `current`**" — the write half
+    cannot be hidden because in-place reconciliation _must_ go through the
+    managed node to emit; handing devs only raw would trade a performance
+    footgun for a correctness one.
+
+### 4.6 What `useRaw` values are not for
+
+-   **Not a prop currency between subscribed components** — pass nodes;
+    `toSource` closes the loop when mapping raw content.
+-   **Not identity/memo tokens** — raw references are stable across changes by
+    design. Use nodes (reproxy identity) for `React.memo` props, `useMemo`
+    deps, and equality checks.
+-   **Not for writes** — including in event handlers; use the node.
+-   **Not derived-state lockstep** — that is `useSelect` / `@select`.
+-   **Not point-in-time values** — raw mutates live. Holding across `await`,
+    diffing before/after, or history requires a copy: `Retree.clone(node)` or
+    (post-purity) `structuredClone(Retree.raw(node))`.
+
+## 5. Testing plan
+
+Core (purity):
+
+-   §3.2 invariant walk across every impure path in the §1.2 table, plus
+    combinations inside `runTransaction`/`runSilent`.
+-   Behavior preservation: proxy reads return managed children after the
+    storage change; Map/Set wrapper reads/iteration serve proxies from side
+    caches; Set `has`/`delete` with proxy and raw arguments; change-payload
+    `previous` documented shape.
+-   `structuredClone(Retree.raw(root))` succeeds after reparents/moves/map
+    reads.
+
+React (`useRaw.spec.tsx`):
+
+-   list/row granularity per §4.3: deep change does **not** re-render the
+    list; structural change does; memo'd rows bail; row updates via own
+    `useNode`.
+-   deliberate deep invalidation (§4.4 mechanism 1): `ReactiveNode` owner with
+    `@select` — deep dependency change re-renders the default-`nodeChanged`
+    `useRaw` consumer; an undeclared deep change does not.
+-   `toSource` resolves never-materialized direct children (fresh tree, no
+    prior traversal); stable node identity across re-renders.
+-   freshness-on-render: after a deep change with no re-render, a
+    parent-triggered re-render reads current raw data.
+
+## 6. Performance gates (probe + bundle harness, medians)
+
+| Measurement                                        | Gate                               | Measured (2026-07-10)                                                      |
+| -------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------- |
+| Existing probe suite after purity change           | within noise                       | ✅ within noise (materialize/steady improved: Map/Set write-backs removed) |
+| 20k scalar writes / 10k pushes                     | within noise                       | ✅ ~15.5 ms / ~14 ms (was ~16 / ~14)                                       |
+| 10k-item scan via `Retree.raw` post-purity         | ≈ native (~0.25 ms), no proxy hits | ✅ 0.25 ms                                                                 |
+| Wide-table render: `useRaw` vs `useNode` (200×40)  | faster                             | ✅ 1.1 ms vs 9.2 ms (~8×) — `useRaw.perf.spec.tsx`                         |
+| `useRaw` mount, 2k-row list (`toSource` every row) | ≤ `useNode` list equivalent        | ✅ 3.0 ms vs 3.0 ms (parity)                                               |
+
+The wide-table measurement lives in
+`packages/retree-react/src/useRaw.perf.spec.tsx` (loose sanity bounds so CI
+never gates on machine speed); a benchmark-CLI scenario remains an optional
+follow-up.
+
+## 7. Implementation slices
+
+1. Raw purity — objects/arrays (unwrap on set/defineProperty), invariant
+   tests for those paths, probe gates.
+2. Raw purity — Map/Set side caches, `findSetStoredValue` simplification,
+   remaining invariant tests, Convex audit.
+3. `Retree.source` (public) + `useRaw`/`toSource` with the direct-children
+   guarantee (object/array/Map/Set), React tests, wide-table benchmark.
+4. Convex reconcilers (§4.5): built-ins read raw / write proxied; add the
+   backward-compatible `rawCurrent` third parameter to `IStateReconciler`;
+   reconcile benchmark on a large document array.
+5. Docs: `Retree.raw`/`peekInto` caveat paragraphs replaced by the purity
+   guarantee; README section from §4.3/§4.4; reconciler docs updated to the
+   "read `rawCurrent`, write `current`" contract.
+
+## 8. Explicitly cut (from the superseded snapshot draft)
+
+`Retree.snapshot`, `Snapshot<T>`, structural sharing, version counters and
+bump walks, dev-mode freezing, fragment→node WeakMaps. Rationale: raw purity
+delivers the same native-speed reads with zero copies and one concept;
+point-in-time needs are served by `Retree.clone` / `structuredClone(raw)`.
+If per-change value identity is ever needed (undo history, diffing), a
+version/snapshot layer can be revisited on top of a pure raw substrate —
+purity is a prerequisite for that design too, so no work here is wasted.
+
+## 9. Resolved decisions
+
+1. **Change payloads are consistently raw (approved).** Today
+   `INodeFieldChanges.previous` is inconsistent — raw for lazily-proxied
+   plain children, a proxy for reparented/eagerly-proxied children (it echoes
+   whatever the raw target held) — and `new` echoes whatever the caller
+   assigned. The approved contract: **both `previous` and `new` are raw
+   values, always** (`previous` naturally post-purity; `new` unwrapped at
+   capture when it is a managed proxy). Change records are descriptions of
+   the past — data, not handles; listeners that want a live node opt in with
+   `Retree.source(change.previous)`. Rationale: this is the only option that
+   yields a uniform contract (normalize-to-managed still returns raw for
+   never-materialized values), it is free on the write path, it avoids
+   handing listeners reproxy identities that churn by design, and it matches
+   the doctrine everywhere else in this spec: nodes are handles, raw is data,
+   records are data. Identity comparisons on payload values are raw-to-raw:
+   `change.previous === Retree.raw(candidate)`.
+2. `Retree.source` is public (§4.2).
+3. The `toSource` materialize-on-miss guarantee covers Map values and Set
+   members (§4.2).
+4. Convex reconcilers read raw and write proxied, with a backward-compatible
+   `rawCurrent` parameter for dev-provided reconcilers (§4.5).


### PR DESCRIPTION
- Significantly improved performance.
- New APIs for sensitive performance scenarios (eg `Retree.raw`, `Retree.peekInto`, and `useRaw`)
- Bump to 0.4.16