### PR TITLE
release 0.7.1 (OIDC publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
                   cache: npm
                   registry-url: https://registry.npmjs.org
 
+            - name: Install latest npm for trusted publishing
+              run: npm install -g npm@latest
+
             - name: Install dependencies
               run: npm ci
 
@@ -32,5 +35,3 @@ jobs:
 
             - name: Publish packages (lockstep, with provenance)
               run: node scripts/publish-packages.mjs --provenance
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17532,8 +17532,8 @@
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0",
-                "@retreejs/core": "0.7.0",
-                "@retreejs/react": "0.7.0",
+                "@retreejs/core": "0.7.1",
+                "@retreejs/react": "0.7.1",
                 "jsdom": "^26.1.0",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5"
@@ -17550,24 +17550,24 @@
         },
         "packages/retree-convex": {
             "name": "@retreejs/convex",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.7.0",
-                "@retreejs/query": "0.7.0",
+                "@retreejs/core": "0.7.1",
+                "@retreejs/query": "0.7.1",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.7.0",
-                "@retreejs/query": "0.7.0",
+                "@retreejs/core": "0.7.1",
+                "@retreejs/query": "0.7.1",
                 "convex": "^1.39.1"
             }
         },
         "packages/retree-core": {
             "name": "@retreejs/core",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/assert": "^1.5.6",
@@ -17580,7 +17580,7 @@
         },
         "packages/retree-create": {
             "name": "@retreejs/create",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.0.0"
@@ -17596,33 +17596,33 @@
         },
         "packages/retree-devtools": {
             "name": "@retreejs/devtools",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.7.0",
+                "@retreejs/core": "0.7.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.7.0"
+                "@retreejs/core": "0.7.1"
             }
         },
         "packages/retree-query": {
             "name": "@retreejs/query",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/core": "0.7.0",
+                "@retreejs/core": "0.7.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.7.0"
+                "@retreejs/core": "0.7.1"
             }
         },
         "packages/retree-react": {
             "name": "@retreejs/react",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "dependencies": {
                 "use-sync-external-store": "^1.6.0"
@@ -17631,7 +17631,7 @@
                 "@babel/core": "^7.29.0",
                 "@babel/plugin-transform-modules-commonjs": "^7.28.0",
                 "@babel/preset-react": "^7.27.0",
-                "@retreejs/core": "0.7.0",
+                "@retreejs/core": "0.7.1",
                 "@types/react": "^19.2.3",
                 "@types/react-dom": "^19.2.3",
                 "@types/use-sync-external-store": "^1.5.0",
@@ -17640,23 +17640,23 @@
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/core": "0.7.0",
+                "@retreejs/core": "0.7.1",
                 "react": "^16.8.0 || ^17 || ^18 || ^19",
                 "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "packages/retree-react-convex": {
             "name": "@retreejs/react-convex",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "devDependencies": {
-                "@retreejs/convex": "0.7.0",
+                "@retreejs/convex": "0.7.1",
                 "convex": "^1.39.1",
                 "dotenv-cli": "^11.0.0",
                 "typescript": "^6.0.2"
             },
             "peerDependencies": {
-                "@retreejs/convex": "0.7.0",
+                "@retreejs/convex": "0.7.1",
                 "convex": "^1.39.1"
             }
         },

--- a/packages/retree-benchmark-cli/package.json
+++ b/packages/retree-benchmark-cli/package.json
@@ -19,8 +19,8 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@retreejs/core": "0.7.0",
-        "@retreejs/react": "0.7.0",
+        "@retreejs/core": "0.7.1",
+        "@retreejs/react": "0.7.1",
         "jsdom": "^26.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"

--- a/packages/retree-convex/package.json
+++ b/packages/retree-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/convex",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Sync Convex queries into Retree reactive nodes.",
     "author": "Ryan Bliss",
     "private": false,
@@ -15,15 +15,15 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.7.0",
-        "@retreejs/query": "0.7.0",
+        "@retreejs/core": "0.7.1",
+        "@retreejs/query": "0.7.1",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.7.0",
-        "@retreejs/query": "0.7.0",
+        "@retreejs/core": "0.7.1",
+        "@retreejs/query": "0.7.1",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-core/package.json
+++ b/packages/retree-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/core",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "React to changes in your object trees.",
     "author": "Ryan Bliss",
     "private": false,

--- a/packages/retree-create/package.json
+++ b/packages/retree-create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/create",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Interactive installer that adds Retree packages to an existing project.",
     "author": "Ryan Bliss",
     "license": "MIT",

--- a/packages/retree-devtools/package.json
+++ b/packages/retree-devtools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/devtools",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Redux DevTools bridge and structured change-log taps for Retree reactive state.",
     "author": "Ryan Bliss",
     "private": false,
@@ -16,12 +16,12 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.7.0",
+        "@retreejs/core": "0.7.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.7.0"
+        "@retreejs/core": "0.7.1"
     },
     "repository": {
         "directory": "packages/retree-devtools",

--- a/packages/retree-query/package.json
+++ b/packages/retree-query/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/query",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Backend-agnostic async query nodes for Retree reactive state.",
     "author": "Ryan Bliss",
     "private": false,
@@ -16,12 +16,12 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/core": "0.7.0",
+        "@retreejs/core": "0.7.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.7.0"
+        "@retreejs/core": "0.7.1"
     },
     "repository": {
         "directory": "packages/retree-query",

--- a/packages/retree-react-convex/package.json
+++ b/packages/retree-react-convex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react-convex",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Use ConvexReactClient with Retree Convex nodes.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -16,13 +16,13 @@
         "publish:package": "dotenv -e .env -- npm publish --access public"
     },
     "devDependencies": {
-        "@retreejs/convex": "0.7.0",
+        "@retreejs/convex": "0.7.1",
         "convex": "^1.39.1",
         "dotenv-cli": "^11.0.0",
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/convex": "0.7.0",
+        "@retreejs/convex": "0.7.1",
         "convex": "^1.39.1"
     },
     "repository": {

--- a/packages/retree-react/package.json
+++ b/packages/retree-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@retreejs/react",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Easily build stateful React applications using familiar JavaScript patterns.",
     "author": "Ryan Bliss",
     "license": "MIT",
@@ -18,7 +18,7 @@
         "@babel/core": "^7.29.0",
         "@babel/plugin-transform-modules-commonjs": "^7.28.0",
         "@babel/preset-react": "^7.27.0",
-        "@retreejs/core": "0.7.0",
+        "@retreejs/core": "0.7.1",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "@types/use-sync-external-store": "^1.5.0",
@@ -27,7 +27,7 @@
         "typescript": "^6.0.2"
     },
     "peerDependencies": {
-        "@retreejs/core": "0.7.0",
+        "@retreejs/core": "0.7.1",
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
     },


### PR DESCRIPTION
Ships Retree 0.7.1 across all seven publishable packages with exact intra-family 0.7.1 pins. Refreshes the workspace lockfile and benchmark workspace pins. Migrates the release workflow from NPM_TOKEN to npm Trusted Publishing by upgrading npm after setup-node and relying on GitHub Actions OIDC with provenance.