### PR TITLE
fix release package build order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Build packages
+              run: npm run build:packages
+
             - name: Typecheck
               run: npm run typecheck
 


### PR DESCRIPTION
Adds the package build step before release typechecking so a clean GitHub Actions checkout has generated workspace declarations. The first 0.7.1 workflow dispatch failed at typecheck before any publish or OIDC exchange; this mirrors the already-green CI build order.