### PR TITLE
Fix flaky useRaw perf test and guard release from no-op publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,44 @@ jobs:
             - name: Install latest npm for trusted publishing
               run: npm install -g npm@latest
 
+            # Skip everything when the lockstep version is already fully
+            # published — a run without a version bump should be a no-op,
+            # not a publish attempt.
+            - name: Check whether the lockstep version needs publishing
+              id: version
+              run: |
+                  VERSION=$(node -p "require('./packages/retree-core/package.json').version")
+                  echo "Lockstep version: ${VERSION}"
+                  PUBLISH=false
+                  for pkg in @retreejs/core @retreejs/query @retreejs/react @retreejs/devtools @retreejs/convex @retreejs/react-convex @retreejs/create; do
+                      if npm view "${pkg}@${VERSION}" version > /dev/null 2>&1; then
+                          echo "${pkg}@${VERSION} is already on npm."
+                      else
+                          echo "${pkg}@${VERSION} is not on npm yet."
+                          PUBLISH=true
+                      fi
+                  done
+                  echo "publish=${PUBLISH}" >> "$GITHUB_OUTPUT"
+                  if [ "$PUBLISH" = "false" ]; then
+                      echo "Every package is already published at ${VERSION}; nothing to do."
+                  fi
+
             - name: Install dependencies
+              if: steps.version.outputs.publish == 'true'
               run: npm ci
 
             - name: Build packages
+              if: steps.version.outputs.publish == 'true'
               run: npm run build:packages
 
             - name: Typecheck
+              if: steps.version.outputs.publish == 'true'
               run: npm run typecheck
 
             - name: Test
+              if: steps.version.outputs.publish == 'true'
               run: npm run test
 
             - name: Publish packages (lockstep, with provenance)
+              if: steps.version.outputs.publish == 'true'
               run: node scripts/publish-packages.mjs --provenance

--- a/packages/retree-react/src/useRaw.perf.spec.tsx
+++ b/packages/retree-react/src/useRaw.perf.spec.tsx
@@ -34,13 +34,30 @@ function makeRows(rows: number, cells: number): WideRow[] {
     return result;
 }
 
-function time(label: string, fn: () => void): number {
-    const start = performance.now();
-    fn();
-    const ms = performance.now() - start;
+/**
+ * Best-of-N timing: mounts via `setup` several times and keeps the fastest
+ * run. Single-shot timings on shared CI runners are too noisy to gate on;
+ * the minimum is the closest observable to the true cost.
+ */
+function time(label: string, setup: () => () => void): number {
+    const RUNS = 5;
+    // Warmup run so first-render module/JIT costs don't bias whichever
+    // scenario is measured first.
+    setup()();
 
-    console.log(`${label}: ${ms.toFixed(1)} ms`);
-    return ms;
+    let best = Infinity;
+    for (let i = 0; i < RUNS; i++) {
+        const fn = setup();
+        const start = performance.now();
+        fn();
+        const ms = performance.now() - start;
+        if (ms < best) {
+            best = ms;
+        }
+    }
+
+    console.log(`${label}: ${best.toFixed(1)} ms (best of ${RUNS})`);
+    return best;
 }
 
 describe("useRaw perf probe", () => {
@@ -48,34 +65,38 @@ describe("useRaw perf probe", () => {
         const ROWS = 200;
         const CELLS = 40;
 
-        const nodeRoot = Retree.root({ rows: makeRows(ROWS, CELLS) });
-        function NodeTable() {
-            const rows = useNode(nodeRoot.rows);
-            let total = 0;
-            for (const row of rows) {
-                for (const cell of row.cells) {
-                    total += cell;
-                }
-            }
-            return <div>{total}</div>;
-        }
         const nodeMs = time("useNode wide table (200x40 reads)", () => {
-            render(<NodeTable />);
+            const nodeRoot = Retree.root({ rows: makeRows(ROWS, CELLS) });
+            function NodeTable() {
+                const rows = useNode(nodeRoot.rows);
+                let total = 0;
+                for (const row of rows) {
+                    for (const cell of row.cells) {
+                        total += cell;
+                    }
+                }
+                return <div>{total}</div>;
+            }
+            return () => {
+                render(<NodeTable />);
+            };
         });
 
-        const rawRoot = Retree.root({ rows: makeRows(ROWS, CELLS) });
-        function RawTable() {
-            const [rows] = useRaw(rawRoot.rows);
-            let total = 0;
-            for (const row of rows) {
-                for (const cell of row.cells) {
-                    total += cell;
-                }
-            }
-            return <div>{total}</div>;
-        }
         const rawMs = time("useRaw wide table (200x40 reads)", () => {
-            render(<RawTable />);
+            const rawRoot = Retree.root({ rows: makeRows(ROWS, CELLS) });
+            function RawTable() {
+                const [rows] = useRaw(rawRoot.rows);
+                let total = 0;
+                for (const row of rows) {
+                    for (const cell of row.cells) {
+                        total += cell;
+                    }
+                }
+                return <div>{total}</div>;
+            }
+            return () => {
+                render(<RawTable />);
+            };
         });
 
         // Loose gate: raw reads must not be slower than trapped reads.
@@ -85,37 +106,42 @@ describe("useRaw perf probe", () => {
     it("useRaw mount with toManaged per row vs useNode list", () => {
         const ROWS = 2000;
 
-        const nodeRoot = Retree.root({ rows: makeRows(ROWS, 1) });
-        function NodeList() {
-            const rows = useNode(nodeRoot.rows);
-            return <div>{rows.map((row) => row.id).join("")}</div>;
-        }
         const nodeMs = time("useNode list mount (2000 rows)", () => {
-            render(<NodeList />);
+            const nodeRoot = Retree.root({ rows: makeRows(ROWS, 1) });
+            function NodeList() {
+                const rows = useNode(nodeRoot.rows);
+                return <div>{rows.map((row) => row.id).join("")}</div>;
+            }
+            return () => {
+                render(<NodeList />);
+            };
         });
 
-        const rawRoot = Retree.root({ rows: makeRows(ROWS, 1) });
         let resolvedCount = 0;
-        function RawList() {
-            const [rows, toManaged] = useRaw(rawRoot.rows);
-            return (
-                <div>
-                    {rows
-                        .map((row) => {
-                            const source = toManaged(row);
-                            if (source !== undefined) {
-                                resolvedCount++;
-                            }
-                            return row.id;
-                        })
-                        .join("")}
-                </div>
-            );
-        }
         const rawMs = time(
             "useRaw list mount + toManaged all (2000 rows)",
             () => {
-                render(<RawList />);
+                const rawRoot = Retree.root({ rows: makeRows(ROWS, 1) });
+                function RawList() {
+                    const [rows, toManaged] = useRaw(rawRoot.rows);
+                    return (
+                        <div>
+                            {rows
+                                .map((row) => {
+                                    const source = toManaged(row);
+                                    if (source !== undefined) {
+                                        resolvedCount++;
+                                    }
+                                    return row.id;
+                                })
+                                .join("")}
+                        </div>
+                    );
+                }
+                resolvedCount = 0;
+                return () => {
+                    render(<RawList />);
+                };
             }
         );
 


### PR DESCRIPTION
## What

Two fixes, both prompted by a failing run on `main`.

### 1. Flaky `useRaw` perf test

`packages/retree-react/src/useRaw.perf.spec.tsx` gated on a single timed render of each scenario. Single-shot timings on shared CI runners are too noisy to gate on — a run measured `26.2ms` for the `toManaged`-per-row mount against a `23.5ms` budget (1.5× the `useNode` baseline) and failed.

The `time` helper now:
- takes a `setup` factory that builds a fresh Retree root + component and returns the render thunk, so each measured run is independent;
- does one warmup render so first-render module/JIT cost doesn't bias whichever scenario is measured first;
- takes the **best of 5** runs (the minimum is the closest observable to the true cost).

Locally the two scenarios now measure ~1.4ms vs ~1.5ms, comfortably inside the 1.5× gate.

### 2. Release workflow: skip no-op publishes

`.github/workflows/release.yml` now has an early step that reads the lockstep version from `packages/retree-core/package.json` and checks all seven `@retreejs/*` packages against npm. If every package is already published at that version, install/build/test/publish are all skipped (`if: steps.version.outputs.publish == 'true'`) and the run is a no-op. If any package is missing (including partial-publish recovery), it proceeds as before, and `publish-packages.mjs`'s existing idempotency still skips the already-published ones.

## Testing

- `npm run test` — 831 passed
- `npm run doctor` — clean (exit 0)
- Perf spec re-run 5×, stable